### PR TITLE
[Do not merge] Add support for subaddresses

### DIFF
--- a/src/db/data.cpp
+++ b/src/db/data.cpp
@@ -59,7 +59,7 @@ namespace db
     template<typename F, typename T>
     void map_account_address(F& format, T& self)
     {
-      wire::object(format, WIRE_FIELD(spend_public), WIRE_FIELD(view_public));
+      wire::object(format, WIRE_FIELD(spend_public), WIRE_FIELD(view_public), WIRE_FIELD(is_subaddress));
     }
   }
   WIRE_DEFINE_OBJECT(account_address, map_account_address);
@@ -220,6 +220,14 @@ namespace db
     return right.height == left.height ?
       std::memcmp(std::addressof(left.tx_hash), std::addressof(right.tx_hash), sizeof(left.tx_hash)) <= 0 :
       left.height < right.height;
+  }
+
+  crypto::secret_key get_secret_view_key(const lws::db::view_key key)
+  {
+    crypto::secret_key copy{};
+    static_assert(sizeof(copy) == sizeof(key), "bad memcpy");
+    std::memcpy(std::addressof(unwrap(copy)), std::addressof(key), sizeof(copy));
+    return copy;
   }
 } // db
 } // lws

--- a/src/db/data.h
+++ b/src/db/data.h
@@ -100,14 +100,17 @@ namespace db
 
   struct view_key : crypto::ec_scalar {};
   // wire::is_blob trait below
+  crypto::secret_key get_secret_view_key(const lws::db::view_key key);
 
   //! The public keys of a monero address
   struct account_address
   {
     crypto::public_key view_public; //!< Must be first for LMDB optimizations.
     crypto::public_key spend_public;
+    bool is_subaddress;
+    char reserved[7];
   };
-  static_assert(sizeof(account_address) == 64, "padding in account_address");
+  static_assert(sizeof(account_address) == 64 + 1 + 7, "padding in account_address");
   WIRE_DECLARE_OBJECT(account_address);
 
   struct account
@@ -122,7 +125,7 @@ namespace db
     account_flags flags;    //!< Additional account info bitmask.
     char reserved[3];
   };
-  static_assert(sizeof(account) == (4 * 2) + 64 + 32 + (8 * 2) + (4 * 2), "padding in account");
+  static_assert(sizeof(account) == (4 * 2) + 64 + 1 + 7 + 32 + (8 * 2) + (4 * 2), "padding in account");
   void write_bytes(wire::writer&, const account&, bool show_key = false);
 
   struct block_info
@@ -234,7 +237,7 @@ namespace db
     account_flags creation_flags; //!< Generated locally?
     char reserved[3];
   };
-  static_assert(sizeof(request_info) == 64 + 32 + 8 + (4 * 2), "padding in request_info");
+  static_assert(sizeof(request_info) == 64 + 1 + 7 + 32 + 8 + (4 * 2), "padding in request_info");
   void write_bytes(wire::writer& dest, const request_info& self, bool show_key = false);
 
   inline constexpr bool operator==(output_id left, output_id right) noexcept

--- a/src/db/storage.cpp
+++ b/src/db/storage.cpp
@@ -76,7 +76,7 @@ namespace db
       account_address address; //!< Must be first for LMDB optimizations
       account_lookup lookup;
     };
-    static_assert(sizeof(account_by_address) == 64 + 4 + 1 + 3, "padding in account_by_address");
+    static_assert(sizeof(account_by_address) == 64 + 1 + 7 + 4 + 1 + 3, "padding in account_by_address");
 
     constexpr const unsigned blocks_version = 0;
     constexpr const unsigned by_address_version = 0;
@@ -1196,13 +1196,10 @@ namespace db
   {
     expect<void> do_add_account(MDB_cursor& accounts_cur, MDB_cursor& accounts_ba_cur, MDB_cursor& accounts_bh_cur, account const& user) noexcept
     {
+      if (!user.address.is_subaddress)
       {
-        crypto::secret_key copy{};
+        crypto::secret_key copy = get_secret_view_key(user.key);
         crypto::public_key verify{};
-        static_assert(sizeof(copy) == sizeof(user.key), "bad memcpy");
-        std::memcpy(
-          std::addressof(unwrap(copy)), std::addressof(user.key), sizeof(copy)
-        );
 
         if (!crypto::secret_key_to_public_key(copy, verify))
           return {lws::error::bad_view_key};

--- a/src/db/storage.cpp
+++ b/src/db/storage.cpp
@@ -381,10 +381,9 @@ namespace db
 
     void migrate_0_1(MDB_txn& txn, tables_ const& tables)
     {
-      MINFO("Migrating from db version 0 to 1...");
-
       // All addresses in version 0 were primary addresses, but didn't have a bool `is_subaddress`.
       // This migration adds a falsey `is_subaddress` to every account_address stored in the db.
+      // If no addresses are stored, this wraps up quickly.
       struct account_address_v0
       {
         crypto::public_key view_public; //!< Must be first for LMDB optimizations.
@@ -544,6 +543,9 @@ namespace db
 
     void migrate(MDB_txn& txn, tables_ const& tables, const unsigned oldversion)
     {
+      if (oldversion == 0)
+        MINFO("Setting up database...");
+
       if (oldversion < 1)
         migrate_0_1(txn, tables);
     }

--- a/src/db/storage.h
+++ b/src/db/storage.h
@@ -45,6 +45,19 @@ namespace lws
 {
 namespace db
 {
+  struct tables_
+  {
+    MDB_dbi blocks;
+    MDB_dbi accounts;
+    MDB_dbi accounts_ba;
+    MDB_dbi accounts_bh;
+    MDB_dbi outputs;
+    MDB_dbi spends;
+    MDB_dbi images;
+    MDB_dbi requests;
+    MDB_dbi properties;
+  };
+
   namespace cursor
   {
     MONERO_CURSOR(accounts);

--- a/src/db/string.cpp
+++ b/src/db/string.cpp
@@ -41,7 +41,7 @@ namespace  db
       address.spend_public, address.view_public
     };
     return cryptonote::get_account_address_as_str(
-      lws::config::network, false, address_
+      lws::config::network, address.is_subaddress, address_
     );
   }
   expect<account_address>
@@ -51,11 +51,11 @@ namespace  db
 
     if (!cryptonote::get_account_address_from_str(info, lws::config::network, std::string{address}))
       return {lws::error::bad_address};
-    if (info.is_subaddress || info.has_payment_id)
+    if (info.has_payment_id)
       return {lws::error::bad_address};
 
     return account_address{
-      info.address.m_view_public_key, info.address.m_spend_public_key
+      info.address.m_view_public_key, info.address.m_spend_public_key, info.is_subaddress
     };
   }
 } // db


### PR DESCRIPTION
# PLEASE READ

Submitted a PR to the light wallet spec highlighting a different way of supporting subaddresses: https://github.com/monero-project/meta/pull/647

I anticipate closing this PR, and opening a new PR implementing the proposal accepted there.
__________

Update [1/3/21]: scanner picks up on outputs sent to subaddresses when there are 3+ outputs in a transaction involving subaddresses

## Overview

This PR adds support for subaddresses in `monero-lws`. All `monero-lws` server endpoints that take an address can instead take a subaddress with this PR. For example, to login with a testnet subaddress:

```
curl  -w "\n" -X POST http://127.0.0.1:8443/login -d '{"address": "BffjVfkhQiZZfc4mU9xHGZQHNfgvz1PG367Pwhed2yob1qXf96eMydYT8tTkev8RBsMQMyJChTdqae5JN1sFjknFRWBEqQh", "view_key": "f747f4a4838027c9af80e6364a941b60c538e67e9ea198b6ec452b74c276de06", "create_account": true, "generated_locally": false}'
```

I implemented a migration to add a falsey `is_subaddress` boolean to every address stored in the db, since all addresses already stored must be primary addresses. The migration runs the first time you run `monero-lws`, then doesn't run again. I took inspiration from [`monero/src/blockchain_db/lmdb/db_lmdb.cpp`](https://github.com/monero-project/monero/blob/319b831e65437f1c8e5ff4b4cb9be03f091f6fc6/src/blockchain_db/lmdb/db_lmdb.cpp#L1497) in how to structure the migration.

Also, drawing attention to 2 things in particular in this PR:

### 1. Potential subaddress leak

If you give someone your subaddress, they can use your subaddress to query the server to see if your subaddress is stored on the server, but cannot gain information beyond the fact that it is or is not stored. They would still need your view key to get more information beyond the fact that the subaddress is stored. The fact that it's stored is revealed to someone calling any of the endpoints and providing a subaddress with a different view key from the one already stored, which would return with a `"bad view key"` error iff already stored. This leak does not affect primary addresses.

I figure the added complexity to avoid this leak may not be worth the gain for `monero-lws`, since if you give someone your subaddress, and also give them the endpoint of your `monero-lws` server, you may already be comfortable with them knowing you're monitoring that subaddress on your own server already. I figure this would be a worse implication for MyMonero (and not monero-lws) since you probably don't want to tell someone who you give your subaddress to that you're using MyMonero by default (they would be able to find out if you're using MyMonero with just your subaddress), and therefore it's worth preventing in MyMonero's case if they start supporting subaddresses.

Without modifying the light wallet API, the simplest safe solution to prevent this I can think of (with no timing attack) would be to allow storage of all subaddress/view key pairs (i.e. allow duplicate subaddresses across different view keys). monero-lws admins could approve create/import requests by referencing the view key, rather than address (so an admin accepting a single view key could approve multiple create/import requests at once). There would be no uniqueness constraint on addresses this way, but rather on address/view key pairs. The plumbing to get this working would be a bit more work, but happy to do it if it's the desired solution.

### 2. Equality check on secret keys

The equality check on `crypto::secret_key` uses libsodium's constant time [crypto_verify_32](https://github.com/monero-project/monero/blob/319b831e65437f1c8e5ff4b4cb9be03f091f6fc6/src/crypto/generic-ops.h#L52). This is critical. If it didn't compare in constant time, and compared the `lws::db::view key` types with a naive byte comparison, it could leak the view key via a timing attack.