### PR TITLE
Adding a Dockerfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,19 +88,36 @@ if (NOT MONERO_BUILD_DIR)
   message(FATAL_ERROR "The argument -DMONERO_BUILD_DIR must specify a location of an existing monero build")
 endif()
 
+if(STATIC)
+  if(MSVC)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .lib .dll.a .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  else()
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+  endif()
+endif()
+
 load_cache(${MONERO_BUILD_DIR} READ_WITH_PREFIX monero_
   Boost_THREAD_LIBRARY_RELEASE
   CMAKE_CXX_COMPILER
   EXTRA_LIBRARIES
+  LIBUDEV_LIBRARY
+  usb_LIBRARY
   HIDAPI_INCLUDE_DIR
+  HIDAPI_LIBRARY
   LMDB_INCLUDE
   monero_SOURCE_DIR
+  OPENSSL_INCLUDE_PATH
   OPENSSL_CRYPTO_LIBRARY
   OPENSSL_SSL_LIBRARY
   SODIUM_LIBRARY
   UNBOUND_LIBRARIES
   ZMQ_INCLUDE_PATH
   ZMQ_LIB
+  PGM_LIBRARY
+  NORM_LIBRARY
+  GSSAPI_LIBRARY
+  PROTOLIB_LIBRARY
+  SODIUM_LIBRARY
 )
 
 if (NOT (monero_monero_SOURCE_DIR MATCHES "${MONERO_SOURCE_DIR}(/src/cryptonote_protocol)"))
@@ -136,101 +153,34 @@ if (NOT (Boost_THREAD_LIBRARY STREQUAL monero_Boost_THREAD_LIBRARY_RELEASE))
   message(FATAL_ERROR "Boost libraries for monero build differs from this project")
 endif()
 
-# hidapi
-# https://github.com/moneroexamples/openmonero/blob/18370af8fa51a0e9d05dfe678dcd5bcb7fad30f7/cmake/FindHIDAPI.cmake#L26-L60
-find_library(HIDAPI_LIBRARY
-  NAMES hidapi hidapi-libusb)
 
-find_path(HIDAPI_INCLUDE_DIR
-  NAMES hidapi.h
-  PATH_SUFFIXES
-  hidapi)
+set(LMDB_INCLUDE "${monero_LMDB_INCLUDE}")
+set(LMDB_LIB_PATH "monero::lmdb")
+set(ZMQ_LIB "${monero_ZMQ_LIB}")
 
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(HIDAPI
-  DEFAULT_MSG
-  HIDAPI_LIBRARY
-  HIDAPI_INCLUDE_DIR)
-
-if(HIDAPI_FOUND)
-  set(HIDAPI_LIBRARIES "${HIDAPI_LIBRARY}")
-  if((STATIC AND UNIX AND NOT APPLE) OR (DEPENDS AND CMAKE_SYSTEM_NAME STREQUAL "Linux"))
-    find_library(LIBUSB-1.0_LIBRARY usb-1.0)
-    find_library(LIBUDEV_LIBRARY udev)
-    if(LIBUSB-1.0_LIBRARY)
-      set(HIDAPI_LIBRARIES "${HIDAPI_LIBRARIES};${LIBUSB-1.0_LIBRARY}")
-      if(LIBUDEV_LIBRARY)
-        set(HIDAPI_LIBRARIES "${HIDAPI_LIBRARIES};${LIBUDEV_LIBRARY}")
-      else()
-        message(WARNING "libudev library not found, binaries may fail to link.")
-      endif()
-    else()
-      message(WARNING "libusb-1.0 library not found, binaries may fail to link.")
-    endif()
-  endif()
-
-  set(HIDAPI_INCLUDE_DIRS "${HIDAPI_INCLUDE_DIR}")
-endif()
-
-mark_as_advanced(HIDAPI_INCLUDE_DIR HIDAPI_LIBRARY)
-
-if (NOT (HIDAPI_INCLUDE_DIR STREQUAL monero_HIDAPI_INCLUDE_DIR))
-  message(STATUS "Found HIDAPI_INCLUDE_DIR: ${HIDAPI_INCLUDE_DIR}")
-  message(STATUS "Found monero_HIDAPI_INCLUDE_DIR: ${monero_HIDAPI_INCLUDE_DIR}")
-  message(FATAL_ERROR "hidapi libraries for monero build differs from this project")
-endif()
-
-# openssl
-if (STATIC)
-  set(OPENSSL_USE_STATIC_LIBS TRUE)
-endif()
-find_package(OpenSSL REQUIRED)
-
-if (NOT (OPENSSL_CRYPTO_LIBRARY STREQUAL monero_OPENSSL_CRYPTO_LIBRARY))
-  message(STATUS "Found OPENSSL_CRYPTO_LIBRARY: ${OPENSSL_CRYPTO_LIBRARY}")
-  message(STATUS "Found monero_OPENSSL_CRYPTO_LIBRARY: ${monero_OPENSSL_CRYPTO_LIBRARY}")
-  message(FATAL_ERROR "openssl libraries for monero build differs from this project")
-endif()
-
-# zmq
-# https://github.com/monero-project/monero/blob/9aab19f349433687c7aaf2c1cbc5751e5912c0aa/CMakeLists.txt#L1171-L1199
-if(STATIC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DZMQ_STATIC")
-endif()
-find_path(ZMQ_INCLUDE_PATH zmq.h)
-find_library(ZMQ_LIB zmq)
-find_library(PGM_LIBRARY pgm)
-find_library(NORM_LIBRARY norm)
-find_library(GSSAPI_LIBRARY gssapi_krb5)
-find_library(PROTOLIB_LIBRARY protolib)
-find_library(SODIUM_LIBRARY sodium)
-
-if(NOT ZMQ_INCLUDE_PATH)
-  message(FATAL_ERROR "Could not find required header zmq.h")
-endif()
 if(NOT ZMQ_LIB)
   message(FATAL_ERROR "Could not find required libzmq")
 endif()
-if(PGM_LIBRARY)
-  set(ZMQ_LIB "${ZMQ_LIB};${PGM_LIBRARY}")
+if(monero_PGM_LIBRARY)
+  set(ZMQ_LIB "${ZMQ_LIB};${monero_PGM_LIBRARY}")
 endif()
-if(NORM_LIBRARY)
-  set(ZMQ_LIB "${ZMQ_LIB};${NORM_LIBRARY}")
+if(monero_NORM_LIBRARY)
+  set(ZMQ_LIB "${ZMQ_LIB};${monero_NORM_LIBRARY}")
 endif()
-if(GSSAPI_LIBRARY)
-  set(ZMQ_LIB "${ZMQ_LIB};${GSSAPI_LIBRARY}")
+if(monero_GSSAPI_LIBRARY)
+  set(ZMQ_LIB "${ZMQ_LIB};${monero_GSSAPI_LIBRARY}")
 endif()
-if(PROTOLIB_LIBRARY)
-  set(ZMQ_LIB "${ZMQ_LIB};${PROTOLIB_LIBRARY}")
+if(monero_PROTOLIB_LIBRARY)
+  set(ZMQ_LIB "${ZMQ_LIB};${monero_PROTOLIB_LIBRARY}")
 endif()
-if(SODIUM_LIBRARY)
-  set(ZMQ_LIB "${ZMQ_LIB};${SODIUM_LIBRARY}")
+if(monero_SODIUM_LIBRARY)
+  set(ZMQ_LIB "${ZMQ_LIB};${monero_SODIUM_LIBRARY}")
 endif()
 
-if (NOT (ZMQ_INCLUDE_PATH STREQUAL monero_ZMQ_INCLUDE_PATH))
-  message(STATUS "Found ZMQ_INCLUDE_PATH: ${ZMQ_INCLUDE_PATH}")
-  message(STATUS "Found monero_ZMQ_INCLUDE_PATH: ${monero_ZMQ_INCLUDE_PATH}")
-  message(FATAL_ERROR "zmq libraries for monero build differs from this project")
+if(STATIC AND NOT IOS)
+  if(UNIX)
+    set(monero_OPENSSL_LIBRARIES "${monero_OPENSSL_LIBRARIES};${CMAKE_DL_LIBS};${CMAKE_THREAD_LIBS_INIT}")
+  endif()
 endif()
 
 foreach (LIB ${MONERO_LIBRARIES})
@@ -247,7 +197,6 @@ foreach (LIB ${MONERO_LIBRARIES})
     set_target_properties(${LIB_NAME} PROPERTIES IMPORTED_LOCATION ${LIB_PATH})
     list(APPEND IMPORTED_MONERO_LIBRARIES "${LIB_NAME}")
   endif()
-  
   unset(LIB_PATH CACHE)
 endforeach()
 
@@ -255,9 +204,8 @@ add_library(monero::libraries INTERFACE IMPORTED)
 set_property(TARGET monero::libraries PROPERTY
   INTERFACE_INCLUDE_DIRECTORIES
     ${Boost_INCLUDE_DIR}
-    ${HIDAPI_INCLUDE_DIRS}
-    ${OPENSSL_INCLUDE_DIR}
-    ${ZMQ_INCLUDE_PATH}
+    ${monero_HIDAPI_INCLUDE_DIRS}
+    ${monero_OPENSSL_INCLUDE_PATH}
     "${MONERO_BUILD_DIR}/generated_include"
     "${MONERO_SOURCE_DIR}/contrib/epee/include"
     "${MONERO_SOURCE_DIR}/external/easylogging++"
@@ -274,16 +222,16 @@ set_property(TARGET monero::libraries PROPERTY
     ${Boost_SERIALIZATION_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     ${Boost_THREAD_LIBRARY}
-    ${HIDAPI_LIBRARIES}
-    ${OPENSSL_LIBRARIES}
+    ${monero_HIDAPI_LIBRARY}
+    ${monero_usb_LIBRARY}
+    ${monero_LIBUDEV_LIBRARY}
+    ${ZMQ_LIB}
+    ${monero_OPENSSL_SSL_LIBRARY}
+    ${monero_OPENSSL_CRYPTO_LIBRARY}
     ${monero_SODIUM_LIBRARY}
     ${monero_UNBOUND_LIBRARIES}
     ${CMAKE_DL_LIBS}
 )
-
-set(LMDB_INCLUDE "${monero_LMDB_INCLUDE}")
-set(LMDB_LIB_PATH "monero::lmdb")
-
 
 #
 # Build monero-lws code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ load_cache(${MONERO_BUILD_DIR} READ_WITH_PREFIX monero_
   Boost_THREAD_LIBRARY_RELEASE
   CMAKE_CXX_COMPILER
   EXTRA_LIBRARIES
-  HIDAPI_LIBRARY
+  HIDAPI_INCLUDE_DIR
   LMDB_INCLUDE
   monero_SOURCE_DIR
   OPENSSL_CRYPTO_LIBRARY
@@ -115,10 +115,6 @@ if ("${monero_UNBOUND_LIBRARIES}" STREQUAL "UNBOUND_LIBRARIES-NOTFOUND")
   unset(monero_UNBOUND_LIBRARIES)
 endif()
 
-if ("${monero_HIDAPI_LIBRARY}" STREQUAL "HIDAPI_LIBRARY-NOTFOUND")
-  unset(monero_HIDAPI_LIBRARY)
-endif()
-
 #
 # Dependencies specific to monero-lws
 #
@@ -126,13 +122,115 @@ endif()
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
+# boost
 set(Boost_NO_BOOST_CMAKE ON)
+if(STATIC)
+  set(Boost_USE_STATIC_LIBS ON)
+  set(Boost_USE_STATIC_RUNTIME ON)
+endif()
 find_package(Boost 1.58 QUIET REQUIRED COMPONENTS chrono filesystem program_options regex serialization system thread)
 
 if (NOT (Boost_THREAD_LIBRARY STREQUAL monero_Boost_THREAD_LIBRARY_RELEASE))
   message(STATUS "Found Boost_THREAD_LIBRARY: ${Boost_THREAD_LIBRARY}")
   message(STATUS "Found monero_Boost_THREAD_LIBRARY_RELEASE: ${monero_Boost_THREAD_LIBRARY_RELEASE}")
   message(FATAL_ERROR "Boost libraries for monero build differs from this project")
+endif()
+
+# hidapi
+# https://github.com/moneroexamples/openmonero/blob/18370af8fa51a0e9d05dfe678dcd5bcb7fad30f7/cmake/FindHIDAPI.cmake#L26-L60
+find_library(HIDAPI_LIBRARY
+  NAMES hidapi hidapi-libusb)
+
+find_path(HIDAPI_INCLUDE_DIR
+  NAMES hidapi.h
+  PATH_SUFFIXES
+  hidapi)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(HIDAPI
+  DEFAULT_MSG
+  HIDAPI_LIBRARY
+  HIDAPI_INCLUDE_DIR)
+
+if(HIDAPI_FOUND)
+  set(HIDAPI_LIBRARIES "${HIDAPI_LIBRARY}")
+  if((STATIC AND UNIX AND NOT APPLE) OR (DEPENDS AND CMAKE_SYSTEM_NAME STREQUAL "Linux"))
+    find_library(LIBUSB-1.0_LIBRARY usb-1.0)
+    find_library(LIBUDEV_LIBRARY udev)
+    if(LIBUSB-1.0_LIBRARY)
+      set(HIDAPI_LIBRARIES "${HIDAPI_LIBRARIES};${LIBUSB-1.0_LIBRARY}")
+      if(LIBUDEV_LIBRARY)
+        set(HIDAPI_LIBRARIES "${HIDAPI_LIBRARIES};${LIBUDEV_LIBRARY}")
+      else()
+        message(WARNING "libudev library not found, binaries may fail to link.")
+      endif()
+    else()
+      message(WARNING "libusb-1.0 library not found, binaries may fail to link.")
+    endif()
+  endif()
+
+  set(HIDAPI_INCLUDE_DIRS "${HIDAPI_INCLUDE_DIR}")
+endif()
+
+mark_as_advanced(HIDAPI_INCLUDE_DIR HIDAPI_LIBRARY)
+
+if (NOT (HIDAPI_INCLUDE_DIR STREQUAL monero_HIDAPI_INCLUDE_DIR))
+  message(STATUS "Found HIDAPI_INCLUDE_DIR: ${HIDAPI_INCLUDE_DIR}")
+  message(STATUS "Found monero_HIDAPI_INCLUDE_DIR: ${monero_HIDAPI_INCLUDE_DIR}")
+  message(FATAL_ERROR "hidapi libraries for monero build differs from this project")
+endif()
+
+# openssl
+if (STATIC)
+  set(OPENSSL_USE_STATIC_LIBS TRUE)
+endif()
+find_package(OpenSSL REQUIRED)
+
+if (NOT (OPENSSL_CRYPTO_LIBRARY STREQUAL monero_OPENSSL_CRYPTO_LIBRARY))
+  message(STATUS "Found OPENSSL_CRYPTO_LIBRARY: ${OPENSSL_CRYPTO_LIBRARY}")
+  message(STATUS "Found monero_OPENSSL_CRYPTO_LIBRARY: ${monero_OPENSSL_CRYPTO_LIBRARY}")
+  message(FATAL_ERROR "openssl libraries for monero build differs from this project")
+endif()
+
+# zmq
+# https://github.com/monero-project/monero/blob/9aab19f349433687c7aaf2c1cbc5751e5912c0aa/CMakeLists.txt#L1171-L1199
+if(STATIC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DZMQ_STATIC")
+endif()
+find_path(ZMQ_INCLUDE_PATH zmq.h)
+find_library(ZMQ_LIB zmq)
+find_library(PGM_LIBRARY pgm)
+find_library(NORM_LIBRARY norm)
+find_library(GSSAPI_LIBRARY gssapi_krb5)
+find_library(PROTOLIB_LIBRARY protolib)
+find_library(SODIUM_LIBRARY sodium)
+
+if(NOT ZMQ_INCLUDE_PATH)
+  message(FATAL_ERROR "Could not find required header zmq.h")
+endif()
+if(NOT ZMQ_LIB)
+  message(FATAL_ERROR "Could not find required libzmq")
+endif()
+if(PGM_LIBRARY)
+  set(ZMQ_LIB "${ZMQ_LIB};${PGM_LIBRARY}")
+endif()
+if(NORM_LIBRARY)
+  set(ZMQ_LIB "${ZMQ_LIB};${NORM_LIBRARY}")
+endif()
+if(GSSAPI_LIBRARY)
+  set(ZMQ_LIB "${ZMQ_LIB};${GSSAPI_LIBRARY}")
+endif()
+if(PROTOLIB_LIBRARY)
+  set(ZMQ_LIB "${ZMQ_LIB};${PROTOLIB_LIBRARY}")
+endif()
+if(SODIUM_LIBRARY)
+  set(ZMQ_LIB "${ZMQ_LIB};${SODIUM_LIBRARY}")
+endif()
+
+if (NOT (ZMQ_INCLUDE_PATH STREQUAL monero_ZMQ_INCLUDE_PATH))
+  message(STATUS "Found ZMQ_INCLUDE_PATH: ${ZMQ_INCLUDE_PATH}")
+  message(STATUS "Found monero_ZMQ_INCLUDE_PATH: ${monero_ZMQ_INCLUDE_PATH}")
+  message(FATAL_ERROR "zmq libraries for monero build differs from this project")
 endif()
 
 foreach (LIB ${MONERO_LIBRARIES})
@@ -157,6 +255,9 @@ add_library(monero::libraries INTERFACE IMPORTED)
 set_property(TARGET monero::libraries PROPERTY
   INTERFACE_INCLUDE_DIRECTORIES
     ${Boost_INCLUDE_DIR}
+    ${HIDAPI_INCLUDE_DIRS}
+    ${OPENSSL_INCLUDE_DIR}
+    ${ZMQ_INCLUDE_PATH}
     "${MONERO_BUILD_DIR}/generated_include"
     "${MONERO_SOURCE_DIR}/contrib/epee/include"
     "${MONERO_SOURCE_DIR}/external/easylogging++"
@@ -173,9 +274,8 @@ set_property(TARGET monero::libraries PROPERTY
     ${Boost_SERIALIZATION_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     ${Boost_THREAD_LIBRARY}
-    ${monero_HIDAPI_LIBRARY}
-    ${monero_OPENSSL_CRYPTO_LIBRARY}
-    ${monero_OPENSSL_SSL_LIBRARY}
+    ${HIDAPI_LIBRARIES}
+    ${OPENSSL_LIBRARIES}
     ${monero_SODIUM_LIBRARY}
     ${monero_UNBOUND_LIBRARIES}
     ${CMAKE_DL_LIBS}
@@ -183,8 +283,6 @@ set_property(TARGET monero::libraries PROPERTY
 
 set(LMDB_INCLUDE "${monero_LMDB_INCLUDE}")
 set(LMDB_LIB_PATH "monero::lmdb")
-set(ZMQ_LIB "${monero_ZMQ_LIB}")
-set(ZMQ_INCLUDE_PATH "${monero_ZMQ_INCLUDE_PATH}")
 
 
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,11 +96,6 @@ RUN apt-get install --no-install-recommends -y \
     ca-certificates \
     curl \
     jq \
-    libgssapi-krb5-2 \
-    libhidapi-dev \
-    libnorm-dev \
-    libpgm-dev \
-    libzmq3-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:20.04 as monero-lws-build
+
+# Set monerod and monero-lws versions to install from github
+ARG MONERO_BRANCH=v0.17.3.0
+ARG MONERO_COMMIT_HASH=ab18fea3500841fc312630d49ed6840b3aedb34d
+
+ARG MONERO_LWS_BRANCH=release-v0.1_0.17
+ARG MONERO_LWS_COMMIT_HASH=9d8a7e558aace21782217f69c3f083069538f38a
+
+# install dependencies
+RUN set -o errexit -o nounset \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get upgrade -y -q \
+    && apt-get install -y -q git build-essential cmake pkg-config libssl-dev libzmq3-dev libunbound-dev libsodium-dev libunwind8-dev \
+    liblzma-dev libreadline6-dev libldns-dev libexpat1-dev libpgm-dev qttools5-dev-tools libhidapi-dev libusb-1.0-0-dev \
+    libprotobuf-dev protobuf-compiler libudev-dev libboost-all-dev ccache doxygen graphviz \
+    && apt-get autoclean
+
+# install monerod
+RUN git clone --recursive --depth 1 -b ${MONERO_BRANCH} https://github.com/monero-project/monero.git \
+    && cd monero \
+    && test `git rev-parse HEAD` = ${MONERO_COMMIT_HASH} || exit 1 \
+    && make -j$(nproc) release
+
+# install monero-lws
+RUN git clone --recursive --depth 1 -b ${MONERO_LWS_BRANCH} https://github.com/vtnerd/monero-lws.git \
+    && cd monero-lws \
+    && test `git rev-parse HEAD` = ${MONERO_LWS_COMMIT_HASH} || exit 1 \
+    && mkdir build && cd build \
+    && cmake -DMONERO_SOURCE_DIR=/monero -DMONERO_BUILD_DIR=/monero/build/Linux/_no_branch_/release .. \
+    && make -j$(nproc)
+
+# expose REST server port
+EXPOSE 8443
+
+# expose commands `monero-lws-daemon` and `monero-lws-admin` via PATH
+ENV PATH "$PATH:/monero-lws/build/src"
+
+ENTRYPOINT ["monero-lws-daemon"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Initial base from https://github.com/sethforprivacy/monero-lws/blob/588c7f1965d3afbda8a65dc870645650e063e897/Dockerfile
 
 # Set monerod version to install from github
-ARG MONERO_BRANCH=v0.17.3.0
-ARG MONERO_COMMIT_HASH=ab18fea3500841fc312630d49ed6840b3aedb34d
+ARG MONERO_BRANCH=v0.17.3.2
+ARG MONERO_COMMIT_HASH=424e4de16b98506170db7b0d7d87a79ccf541744
 
 # Select ubuntu:20.04 for the build image base
 FROM ubuntu:20.04 as build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,121 @@
-FROM ubuntu:20.04 as monero-lws-build
+# Initial base from https://github.com/sethforprivacy/monero-lws/blob/588c7f1965d3afbda8a65dc870645650e063e897/Dockerfile
 
-# Set monerod and monero-lws versions to install from github
+# Set monerod version to install from github
 ARG MONERO_BRANCH=v0.17.3.0
 ARG MONERO_COMMIT_HASH=ab18fea3500841fc312630d49ed6840b3aedb34d
 
-ARG MONERO_LWS_BRANCH=release-v0.1_0.17
-ARG MONERO_LWS_COMMIT_HASH=9d8a7e558aace21782217f69c3f083069538f38a
+# Select ubuntu:20.04 for the build image base
+FROM ubuntu:20.04 as build
 
-# install dependencies
-RUN set -o errexit -o nounset \
-    && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get update \
-    && apt-get upgrade -y -q \
-    && apt-get install -y -q git build-essential cmake pkg-config libssl-dev libzmq3-dev libunbound-dev libsodium-dev libunwind8-dev \
-    liblzma-dev libreadline6-dev libldns-dev libexpat1-dev libpgm-dev qttools5-dev-tools libhidapi-dev libusb-1.0-0-dev \
-    libprotobuf-dev protobuf-compiler libudev-dev libboost-all-dev ccache doxygen graphviz \
-    && apt-get autoclean
+# Install all dependencies for a static build
+# Added DEBIAN_FRONTEND=noninteractive to workaround tzdata prompt on installation
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get upgrade --no-install-recommends -y
 
-# install monerod
-RUN git clone --recursive --depth 1 -b ${MONERO_BRANCH} https://github.com/monero-project/monero.git \
-    && cd monero \
+RUN apt-get install --no-install-recommends -y \
+    build-essential \
+    ca-certificates \
+    ccache \
+    cmake \
+    doxygen \
+    git \
+    graphviz \
+    libboost-all-dev \
+    libexpat1-dev \
+    libhidapi-dev \
+    libldns-dev \
+    liblzma-dev \
+    libpgm-dev \
+    libprotobuf-dev \
+    libreadline6-dev \
+    libsodium-dev \
+    libssl-dev \
+    libudev-dev \
+    libunbound-dev \
+    libunwind8-dev \
+    libusb-1.0-0-dev \
+    libzmq3-dev \
+    pkg-config \
+    protobuf-compiler \
+    qttools5-dev-tools \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set necessary args and environment variables for building Monero
+ARG MONERO_BRANCH
+ARG MONERO_COMMIT_HASH
+ARG NPROC
+ENV CFLAGS='-fPIC'
+ENV CXXFLAGS='-fPIC -DELPP_FEATURE_CRASH_LOG'
+ENV USE_SINGLE_BUILDDIR 1
+ENV BOOST_DEBUG         1
+
+# Switch to Monero source directory
+WORKDIR /monero
+
+# Git pull Monero source at specified tag/branch and compile monerod binary
+RUN git clone --recursive --branch ${MONERO_BRANCH} \
+    https://github.com/monero-project/monero . \
     && test `git rev-parse HEAD` = ${MONERO_COMMIT_HASH} || exit 1 \
-    && make -j$(nproc) release
+    && git submodule init && git submodule update \
+    && mkdir -p build/release && cd build/release \
+    # Create make build files manually for release-static-linux-x86_64
+    && cmake -D STATIC=ON -D ARCH="x86-64" -D BUILD_64=ON -D CMAKE_BUILD_TYPE=release -D BUILD_TAG="linux-x64" ../.. \
+    # Build only monerod binary using number of available threads
+    && cd /monero && nice -n 19 ionice -c2 -n7 make -j${NPROC:-$(nproc)} -C build/release daemon
 
-# install monero-lws
-RUN git clone --recursive --depth 1 -b ${MONERO_LWS_BRANCH} https://github.com/vtnerd/monero-lws.git \
-    && cd monero-lws \
-    && test `git rev-parse HEAD` = ${MONERO_LWS_COMMIT_HASH} || exit 1 \
-    && mkdir build && cd build \
-    && cmake -DMONERO_SOURCE_DIR=/monero -DMONERO_BUILD_DIR=/monero/build/Linux/_no_branch_/release .. \
-    && make -j$(nproc)
+# TODO: remove the need to manually make this static liblmdb_lib.a
+RUN cd /monero/build/release/src/lmdb && make && cd /monero
 
-# expose REST server port
+# Switch to monero-lws source directory
+WORKDIR /monero-lws
+
+COPY . .
+
+ARG NPROC
+RUN set -ex \
+    && git submodule init && git submodule update \
+    && rm -rf build && mkdir build && cd build \
+    && cmake -D STATIC=ON -D MONERO_SOURCE_DIR=/monero -D MONERO_BUILD_DIR=/monero/build/release .. \
+    && make -j${NPROC:-$(nproc)}
+
+# Begin final image build
+# Select Ubuntu 20.04LTS for the image base
+FROM ubuntu:20.04
+
+# Added DEBIAN_FRONTEND=noninteractive to workaround tzdata prompt on installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Upgrade base image
+RUN apt-get update \
+    && apt-get upgrade --no-install-recommends -y
+
+# Install necessary dependencies
+RUN apt-get install --no-install-recommends -y \
+    ca-certificates \
+    curl \
+    jq \
+    libgssapi-krb5-2 \
+    libhidapi-dev \
+    libnorm-dev \
+    libpgm-dev \
+    libzmq3-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add user and setup directories for monero-lws
+RUN useradd -ms /bin/bash monero-lws \
+    && mkdir -p /home/monero-lws/.bitmonero/light_wallet_server \
+    && chown -R monero-lws:monero-lws /home/monero-lws/.bitmonero
+USER monero-lws
+
+# Switch to home directory and install newly built monero-lws binary
+WORKDIR /home/monero-lws
+COPY --chown=monero-lws:monero-lws --from=build /monero-lws/build/src/* /usr/local/bin/
+
+# Expose REST server port
 EXPOSE 8443
 
-# expose commands `monero-lws-daemon` and `monero-lws-admin` via PATH
-ENV PATH "$PATH:/monero-lws/build/src"
-
-ENTRYPOINT ["monero-lws-daemon"]
+ENTRYPOINT ["monero-lws-daemon", "--db-path=/home/monero-lws/.bitmonero/light_wallet_server"]
+CMD ["--daemon=tcp://monerod:18082", "--sub=tcp://monerod:18083", "--log-level=4"]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,8 +53,8 @@ target_link_libraries(monero-lws-daemon
     monero-lws-util
     monero-lws-wire-json
     ${Boost_CHRONO_LIBRARY}
-    ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
+    ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_THREAD_LIBRARY}
     ${CMAKE_THREAD_LIBS_INIT}
     ${EXTRA_LIBRARIES}


### PR DESCRIPTION
Requested on [the reddit](https://www.reddit.com/r/Monero/comments/sll4bi/monero_meet_20220205_fees_monerolws_and_network/hvw1zzw/)

### Instructions

If you're already running `monerod` on the same machine you'd like to host `monero-lws`, you can use this Dockerfile to spin up a `monero-lws` docker container by running the following commands on Linux:

```
docker build -t monero-lws .

# starts monero-lws-daemon
docker run --network="host" --restart unless-stopped --name="monero-lws" -v bitmonero-lws:/home/monero-lws/.bitmonero/light_wallet_server monero-lws --log-level=4

# run admin commands as described here: https://github.com/vtnerd/monero-lws/blob/develop/docs/administration.md
docker exec monero-lws monero-lws-admin --db-path="home/monero-lws/.bitmonero/light_wallet_server" --help
docker exec monero-lws monero-lws-admin --db-path="home/monero-lws/.bitmonero/light_wallet_server" debug_database | json_pp
```

On Linux, `--network="host"` will expose the host machine's network to the Docker container. This is what allows the Docker container to retrieve data from the running `monerod` instance on the machine. More on this [here](https://docs.docker.com/network/network-tutorial-host/).

On [Windows](https://docs.docker.com/desktop/windows/networking/#use-cases-and-workarounds) and [Mac](https://docs.docker.com/desktop/mac/networking/#use-cases-and-workarounds), the `docker run` command I believe should be this instead (untested):

```
docker run --restart unless-stopped --name="monero-lws" -v bitmonero-lws:/home/monero-lws/.bitmonero/light_wallet_server monero-lws --log-level=4 --daemon="tcp://host.docker.internal:18082"
```

There should be a way to write [a consistent docker run command](https://stackoverflow.com/a/43541732) for all platforms as of Docker v20.10, but couldn't get it working so moving on. Certain there's room for cleanup in these commands by docker afficionados.