### PR TITLE
per_kb_fee -> per_byte_fee

### DIFF
--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -537,15 +537,15 @@ namespace lws
         if (!resp)
           return resp.error();
 
-        if (resp->size_scale == 0 || 1024 < resp->size_scale || resp->fee_mask == 0)
+        if ((resp->size_scale != 1 && resp->size_scale != 1024) || resp->fee_mask == 0)
           return {lws::error::bad_daemon_response};
 
-        const std::uint64_t per_byte_fee =
-          resp->estimated_base_fee / resp->size_scale;
-        const std::uint64_t per_byte_fee_masked =
-          ((per_byte_fee + (resp->fee_mask - 1)) / resp->fee_mask) * resp->fee_mask;
+        const bool use_per_byte_fee = resp->size_scale == 1;
+        const std::uint64_t base_fee = resp->estimated_base_fee;
+        const std::uint64_t base_fee_masked =
+          ((base_fee + (resp->fee_mask - 1)) / resp->fee_mask) * resp->fee_mask;
 
-        return response{per_byte_fee_masked, resp->fee_mask, rpc::safe_uint64(received), std::move(unspent), std::move(req.creds.key)};
+        return response{base_fee_masked, resp->fee_mask, rpc::safe_uint64(received), std::move(unspent), std::move(req.creds.key), use_per_byte_fee};
       }
     };
 

--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -540,12 +540,12 @@ namespace lws
         if (resp->size_scale == 0 || 1024 < resp->size_scale || resp->fee_mask == 0)
           return {lws::error::bad_daemon_response};
 
-        const std::uint64_t per_kb_fee =
-          resp->estimated_base_fee * (1024 / resp->size_scale);
-        const std::uint64_t per_kb_fee_masked =
-          ((per_kb_fee + (resp->fee_mask - 1)) / resp->fee_mask) * resp->fee_mask;
+        const std::uint64_t per_byte_fee =
+          resp->estimated_base_fee / resp->size_scale;
+        const std::uint64_t per_byte_fee_masked =
+          ((per_byte_fee + (resp->fee_mask - 1)) / resp->fee_mask) * resp->fee_mask;
 
-        return response{per_kb_fee_masked, resp->fee_mask, rpc::safe_uint64(received), std::move(unspent), std::move(req.creds.key)};
+        return response{per_byte_fee_masked, resp->fee_mask, rpc::safe_uint64(received), std::move(unspent), std::move(req.creds.key)};
       }
     };
 

--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -537,12 +537,13 @@ namespace lws
         if (!resp)
           return resp.error();
 
-        if ((resp->size_scale != 1 && resp->size_scale != 1024) || resp->fee_mask == 0)
+        if (resp->size_scale == 0 || 1024 < resp->size_scale || resp->fee_mask == 0)
           return {lws::error::bad_daemon_response};
 
-        const bool use_per_byte_fee = resp->size_scale == 1;
+        const std::uint64_t per_byte_fee =
+          resp->estimated_base_fee / resp->size_scale;
 
-        return response{resp->estimated_base_fee, resp->fee_mask, rpc::safe_uint64(received), std::move(unspent), std::move(req.creds.key), use_per_byte_fee};
+        return response{per_byte_fee, resp->fee_mask, rpc::safe_uint64(received), std::move(unspent), std::move(req.creds.key)};
       }
     };
 

--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -541,11 +541,8 @@ namespace lws
           return {lws::error::bad_daemon_response};
 
         const bool use_per_byte_fee = resp->size_scale == 1;
-        const std::uint64_t base_fee = resp->estimated_base_fee;
-        const std::uint64_t base_fee_masked =
-          ((base_fee + (resp->fee_mask - 1)) / resp->fee_mask) * resp->fee_mask;
 
-        return response{base_fee_masked, resp->fee_mask, rpc::safe_uint64(received), std::move(unspent), std::move(req.creds.key), use_per_byte_fee};
+        return response{resp->estimated_base_fee, resp->fee_mask, rpc::safe_uint64(received), std::move(unspent), std::move(req.creds.key), use_per_byte_fee};
       }
     };
 

--- a/src/rpc/light_wallet.cpp
+++ b/src/rpc/light_wallet.cpp
@@ -294,7 +294,7 @@ namespace lws
       return expand_outputs{src, self.user_key};
     };
     wire::object(dest,
-      WIRE_FIELD_COPY(per_kb_fee),
+      WIRE_FIELD_COPY(per_byte_fee),
       WIRE_FIELD_COPY(fee_mask),
       WIRE_FIELD_COPY(amount),
       wire::field("outputs", wire::as_array(std::cref(self.outputs), expand))

--- a/src/rpc/light_wallet.cpp
+++ b/src/rpc/light_wallet.cpp
@@ -294,7 +294,7 @@ namespace lws
       return expand_outputs{src, self.user_key};
     };
     wire::object(dest,
-      wire::field(self.use_per_byte_fee ? "per_byte_fee" : "per_kb_fee", self.base_fee),
+      WIRE_FIELD_COPY(per_byte_fee),
       WIRE_FIELD_COPY(fee_mask),
       WIRE_FIELD_COPY(amount),
       wire::field("outputs", wire::as_array(std::cref(self.outputs), expand))

--- a/src/rpc/light_wallet.cpp
+++ b/src/rpc/light_wallet.cpp
@@ -294,7 +294,7 @@ namespace lws
       return expand_outputs{src, self.user_key};
     };
     wire::object(dest,
-      WIRE_FIELD_COPY(per_byte_fee),
+      wire::field(self.use_per_byte_fee ? "per_byte_fee" : "per_kb_fee", self.base_fee),
       WIRE_FIELD_COPY(fee_mask),
       WIRE_FIELD_COPY(amount),
       wire::field("outputs", wire::as_array(std::cref(self.outputs), expand))

--- a/src/rpc/light_wallet.h
+++ b/src/rpc/light_wallet.h
@@ -155,7 +155,7 @@ namespace rpc
   struct get_unspent_outs_response
   {
     get_unspent_outs_response() = delete;
-    std::uint64_t per_kb_fee;
+    std::uint64_t per_byte_fee;
     std::uint64_t fee_mask;
     safe_uint64 amount;
     std::vector<std::pair<db::output, std::vector<crypto::key_image>>> outputs;

--- a/src/rpc/light_wallet.h
+++ b/src/rpc/light_wallet.h
@@ -155,11 +155,12 @@ namespace rpc
   struct get_unspent_outs_response
   {
     get_unspent_outs_response() = delete;
-    std::uint64_t per_byte_fee;
+    std::uint64_t base_fee; // either per_byte_fee or per_kb_fee
     std::uint64_t fee_mask;
     safe_uint64 amount;
     std::vector<std::pair<db::output, std::vector<crypto::key_image>>> outputs;
     crypto::secret_key user_key;
+    bool use_per_byte_fee;
   };
   void write_bytes(wire::json_writer&, const get_unspent_outs_response&);
 

--- a/src/rpc/light_wallet.h
+++ b/src/rpc/light_wallet.h
@@ -155,12 +155,11 @@ namespace rpc
   struct get_unspent_outs_response
   {
     get_unspent_outs_response() = delete;
-    std::uint64_t base_fee; // either per_byte_fee or per_kb_fee
+    std::uint64_t per_byte_fee;
     std::uint64_t fee_mask;
     safe_uint64 amount;
     std::vector<std::pair<db::output, std::vector<crypto::key_image>>> outputs;
     crypto::secret_key user_key;
-    bool use_per_byte_fee;
   };
   void write_bytes(wire::json_writer&, const get_unspent_outs_response&);
 


### PR DESCRIPTION
Ok did the easy thing and converted `per_kb_fee` to `per_byte_fee`

One thing: upon deeper inspection, it *looks* like the server shouldn't be masking the fee. Maybe you see something I don't.. but if the client "re-masks" *after* factoring in weight (as MyMonero does [here](https://github.com/mymonero/mymonero-core-cpp/blob/a53e57f2a376b05bb0f4d851713321c749e5d8d9/src/monero_fee_utils.cpp#L233), here's [the caller](https://github.com/mymonero/mymonero-core-cpp/blob/a53e57f2a376b05bb0f4d851713321c749e5d8d9/src/monero_transfer_utils.cpp#L435)), the fee calculation is different than it would otherwise be. Since wallet2 [seems to only mask once after weight is factored in](https://github.com/monero-project/monero/blob/9aab19f349433687c7aaf2c1cbc5751e5912c0aa/src/wallet/wallet2.cpp#L336), and I figure the intention is to match wallet2, then makes sense to let the client do the masking so as to not lead to fingerprinting?

Running the numbers:

```.cpp
uint64_t calculate_fee_from_weight(uint64_t base_fee, uint64_t weight, uint64_t fee_multiplier, uint64_t fee_quantization_mask)
{
  // monero-lws expected calculated fee
  const std::uint64_t per_byte_fee_masked =
    ((base_fee + (fee_quantization_mask - 1)) / fee_quantization_mask) * fee_quantization_mask;
  uint64_t monero_lws_calculated_fee =  weight * per_byte_fee_masked * fee_multiplier;
  monero_lws_calculated_fee = (monero_lws_calculated_fee + fee_quantization_mask - 1) / fee_quantization_mask * fee_quantization_mask;

  // wallet2 calculated fee
  uint64_t fee = weight * base_fee * fee_multiplier;
  fee = (fee + fee_quantization_mask - 1) / fee_quantization_mask * fee_quantization_mask;

  printf("monero-lws fee: %lu \nwallet2 fee: %lu", monero_lws_calculated_fee, fee);
  return fee;
}
```

Outputs:

```
monero-lws fee: 344640000
wallet2 fee:   336650000
```
