### PR TITLE
Add support for view tags (+ epee misc util re-located)

### DIFF
--- a/src/rpc/daemon_zmq.cpp
+++ b/src/rpc/daemon_zmq.cpp
@@ -93,6 +93,10 @@ namespace cryptonote
   {
     wire::object(source, WIRE_FIELD(hash));
   }
+  static void read_bytes(wire::json_reader& source, txout_to_tagged_key& self)
+  {
+    wire::object(source, WIRE_FIELD(key), WIRE_FIELD(view_tag));
+  }
   static void read_bytes(wire::json_reader& source, txout_to_key& self)
   {
     wire::object(source, WIRE_FIELD(key));
@@ -103,6 +107,7 @@ namespace cryptonote
       WIRE_FIELD(amount),
       wire::variant_field("transaction output variant", std::ref(self.target),
         wire::option<txout_to_key>{"to_key"},
+        wire::option<txout_to_tagged_key>{"to_tagged_key"},
         wire::option<txout_to_script>{"to_script"},
         wire::option<txout_to_scripthash>{"to_scripthash"}
       )

--- a/src/rpc/light_wallet.cpp
+++ b/src/rpc/light_wallet.cpp
@@ -35,7 +35,7 @@
 
 #include "db/string.h"
 #include "error.h"
-#include "misc_os_dependent.h" // monero/contrib/epee/include
+#include "time_helper.h"       // monero/contrib/epee/include
 #include "ringct/rctOps.h"     // monero/src
 #include "span.h"              // monero/contrib/epee/include
 #include "util/random_outputs.h"

--- a/src/wire/crypto.h
+++ b/src/wire/crypto.h
@@ -69,4 +69,9 @@ namespace wire
   struct is_blob<rct::key>
     : std::true_type
   {};
+
+  template<>
+  struct is_blob<crypto::view_tag>
+    : std::true_type
+  {};
 }


### PR DESCRIPTION
Edit:

Worth highlighting, this code won't be able to identify bp+ outputs at the fork height with Monero's current master branch because I assumed that [this PR will be merged](https://github.com/monero-project/monero/pull/8277)

([here](https://github.com/j-berman/monero-lws/commit/f0be525daeb2d272d54684bdde877d62f7a4e6e3) is the code that *would* work with master that I assume will not be needed)