### PR TITLE
Detect missing HIDAPI in Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,11 @@ if ("${monero_UNBOUND_LIBRARIES}" STREQUAL "UNBOUND_LIBRARIES-NOTFOUND")
   unset(monero_UNBOUND_LIBRARIES)
 endif()
 
+if ("${monero_HIDAPI_LIBRARY}" STREQUAL "HIDAPI_LIBRARY-NOTFOUND")
+  unset(monero_HIDAPI_INCLUDE_DIR)
+  unset(monero_HIDAPI_LIBRARY)
+endif()
+
 #
 # Dependencies specific to monero-lws
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get install --no-install-recommends -y \
     graphviz \
     libboost-all-dev \
     libexpat1-dev \
-    libhidapi-dev \
     libldns-dev \
     liblzma-dev \
     libpgm-dev \


### PR DESCRIPTION
`HIDAPI` is not needed to build upstream `monerod`. This detects the missing library, and omits it from the include and linking stages. The `Dockerfile` was also updated to omit the installation of `HIDAPI` since its not needed.

I manually verified that this still works when `HIDAPI` is present.