### PR TITLE
Bump CXX version to C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ cmake_minimum_required(VERSION 3.1.0)
 project(monero-lws)
 
 enable_language(CXX)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(MONERO_LIBRARIES


### PR DESCRIPTION
This will be necessary to read headers from upstream Monero as changes are made.