### PR TITLE
Fixed integer conversion in wire::

### DIFF
--- a/src/wire/read.cpp
+++ b/src/wire/read.cpp
@@ -35,9 +35,12 @@ void wire::reader::increment_depth()
     WIRE_DLOG_THROW_(error::schema::maximum_depth);
 }
 
-[[noreturn]] void wire::integer::throw_exception(std::intmax_t source, std::intmax_t min)
+[[noreturn]] void wire::integer::throw_exception(std::intmax_t source, std::intmax_t min, std::uintmax_t max)
 {
-  WIRE_DLOG_THROW(error::schema::larger_integer, source << " given when " << min << " is minimum permitted");
+  if (source < 0)
+    WIRE_DLOG_THROW(error::schema::larger_integer, source << " given when " << min << " is minimum permitted");
+  else
+    throw_exception(std::uintmax_t(source), max);
 }
 [[noreturn]] void wire::integer::throw_exception(std::uintmax_t source, std::uintmax_t max)
 {


### PR DESCRIPTION
@jeffro256 found a bug in the integer conversion code for wire. The code was hand-rolled and therefore suspect. The intent was to reduce the ASM noise per integer type, so that inlining was more likely.

I have switched to `boost::conversion::try_lexical_convert` which produces ASM compaction comparable to what this incorrect version had.

I'm not aware of any security issues, although technically this is UB here. The biggest fallout is that incorrect integer values will not be properly reported, but each value requires further checking typically anyway.

If someone approves this, I will just cherry-pick onto `master` and the current release branch.