### PR TITLE
Fixed two bugs in wire:

### DIFF
--- a/src/wire/json/write.cpp
+++ b/src/wire/json/write.cpp
@@ -73,6 +73,12 @@ namespace wire
     return buf;
   }
 
+  void json_writer::boolean(const bool source)
+  {
+    formatter_.Bool(source);
+    check_flush();
+  }
+
   void json_writer::integer(const int source)
   {
     formatter_.Int(source);

--- a/src/wire/json/write.h
+++ b/src/wire/json/write.h
@@ -85,6 +85,8 @@ namespace wire
     //! \return Null-terminated buffer containing uint as decimal ascii
     static std::array<char, uint_to_string_size> to_string(std::uintmax_t) noexcept;
 
+    void boolean(bool) override final;
+
     void integer(int) override final;
     void integer(std::intmax_t) override final;
 

--- a/src/wire/read.cpp
+++ b/src/wire/read.cpp
@@ -35,9 +35,12 @@ void wire::reader::increment_depth()
     WIRE_DLOG_THROW_(error::schema::maximum_depth);
 }
 
-[[noreturn]] void wire::integer::throw_exception(std::intmax_t source, std::intmax_t min)
+[[noreturn]] void wire::integer::throw_exception(std::intmax_t source, std::intmax_t min, std::uintmax_t max)
 {
-  WIRE_DLOG_THROW(error::schema::larger_integer, source << " given when " << min << " is minimum permitted");
+  if (source < 0)
+    WIRE_DLOG_THROW(error::schema::larger_integer, source << " given when " << min << " is minimum permitted");
+  else
+    throw_exception(std::uintmax_t(source), max);
 }
 [[noreturn]] void wire::integer::throw_exception(std::uintmax_t source, std::uintmax_t max)
 {

--- a/src/wire/write.h
+++ b/src/wire/write.h
@@ -47,6 +47,8 @@ namespace wire
 
     virtual ~writer() noexcept;
 
+    virtual void boolean(bool) = 0;
+
     virtual void integer(int) = 0;
     virtual void integer(std::intmax_t) = 0;
 
@@ -77,6 +79,11 @@ namespace wire
   };
 
   // leave in header, compiler can de-virtualize when final type is given
+
+  inline void write_bytes(writer& dest, const bool source)
+  {
+    dest.boolean(source);
+  }
 
   inline void write_bytes(writer& dest, const int source)
   {


### PR DESCRIPTION
  * Integer conversion checks in src/wire/read.h
  * Missing "boolean" function in wire::writer and derived types


This is the same as #53 but without the unit tests and onto the 0.2 release branch. Trying to strip the review to its core components to make it easier.