### PR TITLE
Add support for admin REST server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ load_cache(${MONERO_BUILD_DIR} READ_WITH_PREFIX monero_
   HIDAPI_LIBRARY
   LMDB_INCLUDE
   monero_SOURCE_DIR
-  OPENSSL_INCLUDE_PATH
+  OPENSSL_INCLUDE_DIR
   OPENSSL_CRYPTO_LIBRARY
   OPENSSL_SSL_LIBRARY
   SODIUM_LIBRARY
@@ -217,7 +217,7 @@ set_property(TARGET monero::libraries PROPERTY
   INTERFACE_INCLUDE_DIRECTORIES
     ${Boost_INCLUDE_DIR}
     ${monero_HIDAPI_INCLUDE_DIRS}
-    ${monero_OPENSSL_INCLUDE_PATH}
+    ${monero_OPENSSL_INCLUDE_DIR}
     "${MONERO_BUILD_DIR}/generated_include"
     "${MONERO_SOURCE_DIR}/contrib/epee/include"
     "${MONERO_SOURCE_DIR}/external/easylogging++"

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -1,27 +1,90 @@
-# Using monero-lws-admin
-
-The `monero-lws-admin` executable is used to administer the database used by
-`monero-lws-daemon`. Any number of `monero-lws-admin` instances can run
+# monero-lws Administration
+The `monero-lws-admin` executable or `--admin-rest-server` option in the
+`monero-lws-daemon` executable can be used to administer the database
+used by `monero-lws-daemon`. Any number of `monero-lws-admin` instances can run
 concurrently with a single `monero-lws-daemon` instance on the same database.
 Administration is necessary to authorize new accounts and rescan requests
 submitted from the REST API. The admin executable can also be used to list
 the contents of the LMDB file for debugging purposes.
 
-# Basics
+# monero-lws-admin
 
 The `monero-lws-admin` utility is structured around command-line arguments with
 JSON responses printed to `stdout`. Each administration command takes arguments
-by position - the design makes it potentially compatible with a JSON or MsgPack
-array (as used in JSON-RPC, etc). Every available administration command and
-required+optional arguments are listed when the `--help` flag is given to the
-executable.
+by position. Every available administration command and required+optional
+arguments are listed when the `--help` flag is given to the executable.
 
 The [`jq`](https://stedolan.github.io/jq/) utility is recommended if using
 `monero-lws-admin` in a shell environment. The `jq` program can be used for
 indenting the output to make it more readable, and can be used to
 search+filter the JSON output from the command.
 
+# Admin REST API
+The `monero-lws-daemon` can be started with 1+ `--admin-rest-server` parameters
+that specify a listening location for admin REST clients. By default, there is
+no admin REST server and no available admin accounts.
+
+An admin REST server can be merged with a regular REST server if path prefixes
+are specified, such as
+`--rest-server https://0.0.0.0:8443/basic --admin-rest-server https://0.0.0.0:8443/admin`.
+This will start a server listening on one port, 8443, and requires clients to
+specify `/basic/command` or `/admin/admin_command` when making a
+request.
+
+An admin account account can be created via `monero-lws-admin create_admin`
+_only_ (this command is not available via REST for security purposes). The
+`key` value returned in the `create_admin` JSON object becomes the `auth`
+parameter in the admin REST API. A new admin account is put into the
+`hidden` state - the account is _not_ scanned for transactions and is _not_
+available to the normal REST API, but is available to the admin REST API.
+
+Running `monero-lws-admin list_admin` will display all current admin
+accounts, and their current state ("active", "inactive", or "hidden"). If
+an admin account needs to be revoked, use the `modify_account` command
+to put the account into the "inactive" state. Deleting accounts is not
+currently supported.
+
+Every admin REST request must be a `POST` that contains a JSON object with
+an `auth` field and an optional `params` field:
+
+```json
+{
+  "auth":"...",
+  "params":{...}
+ }
+```
+where the `params` object is specified below.
+
+## Commands
+A subset of admin commands are available via admin REST API - the remainder
+are initially omitted for security purposes. The commands available via REST
+are:
+  * **accept_requests**: `{"type": "import"|"create", "addresses":[...]}`
+  * **add_account**: `{"address": ..., "key": ...}`
+  * **list_accounts**: `{}`
+  * **list_requests**: `{}`
+  * **modify_account_status**: `{"status": "active"|"hidden"|"inactive", "addresses":[...]}`
+  * **reject_requests**: `{"type": "import"|"create", "addresses":[...]}`
+  * **rescan**: `{"height":..., "addresses":[...]}`
+
+where the listed object must be the `params` field above.
+
 # Examples
+
+## Admin REST API
+
+```json
+{
+  "auth":"6d732245002a9499b3842c0a7f9fc6b2d657c77bd612dbefa4f7f9357d08530a",
+  "params":{
+    "status": "inactive",
+    "addresses": ["9sAejnQ9EBR1111111111111111111111111111111111AdYmVTw2Tv6L9KYkHjJ2wd737ov8ZL5QU7CJ4zV6basGP9fyno"]
+  }
+ }
+```
+will put the listed address into the "inactive" state.
+
+## monero-lws-admin
 
 **List every active Monero address on a newline:**
   ```bash

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,6 +68,7 @@ target_link_libraries(monero-lws-admin
     monero::libraries
     monero-lws-common
     monero-lws-db
+    monero-lws-rpc
     monero-lws-wire-json
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     Threads::Threads

--- a/src/admin_main.cpp
+++ b/src/admin_main.cpp
@@ -30,6 +30,7 @@
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/parsers.hpp>
 #include <boost/program_options/variables_map.hpp>
+#include <boost/range/adaptor/filtered.hpp>
 #include <cassert>
 #include <cstring>
 #include <iostream>
@@ -47,63 +48,45 @@
 #include "db/string.h"
 #include "options.h"
 #include "misc_log_ex.h"  // monero/contrib/epee/include
+#include "rpc/admin.h"
 #include "span.h"         // monero/contrib/epee/include
 #include "string_tools.h" // monero/contrib/epee/include
+#include "wire/crypto.h"
 #include "wire/filters.h"
 #include "wire/json/write.h"
 
 namespace
 {
-  // Do not output "full" debug data provided by `db::data.h` header; truncate output
+  // wrapper for custom output for admin accounts
   template<typename T>
-  struct truncated
+  struct admin_display
   {
     T value;
   };
 
-  void write_bytes(wire::json_writer& dest, const truncated<lws::db::account>& self)
+  void write_bytes(wire::json_writer& dest, const admin_display<lws::db::account>& source)
   {
     wire::object(dest,
-      wire::field("address", lws::db::address_string(self.value.address)),
-      wire::field("scan_height", self.value.scan_height),
-      wire::field("access_time", self.value.access)
-    );
-  };
-
-  void write_bytes(wire::json_writer& dest, const truncated<lws::db::request_info>& self)
-  {
-    wire::object(dest,
-      wire::field("address", lws::db::address_string(self.value.address)),
-      wire::field("start_height", self.value.start_height)
+      wire::field("address", lws::db::address_string(source.value.address)),
+      wire::field("key", std::cref(source.value.key))
     );
   }
 
-  template<typename V>
-  void write_bytes(wire::json_writer& dest, const truncated<boost::iterator_range<lmdb::value_iterator<V>>> self)
+  void write_bytes(wire::json_writer& dest, admin_display<boost::iterator_range<lmdb::value_iterator<lws::db::account>>> source)
   {
-    const auto truncate = [] (V src) { return truncated<V>{std::move(src)}; };
-    wire::array(dest, std::move(self.value), truncate);
+    const auto filter = [](const lws::db::account& src)
+    { return bool(src.flags & lws::db::account_flags::admin_account); };
+    const auto transform = [] (lws::db::account src)
+    { return admin_display<lws::db::account>{std::move(src)}; };
+
+    wire::array(dest, (source.value | boost::adaptors::filtered(filter)), transform);
   }
 
-  template<typename K, typename V>
-  void stream_json_object(std::ostream& dest, boost::iterator_range<lmdb::key_iterator<K, V>> self)
+  template<typename F, typename... T>
+  void run_command(F f, std::ostream& dest, T&&... args)
   {
-    using value_range = boost::iterator_range<lmdb::value_iterator<V>>;
-    const auto truncate = [] (value_range src) -> truncated<value_range>
-    {
-     return {std::move(src)};
-    };
-
-    wire::json_stream_writer json{dest};
-    wire::dynamic_object(json, std::move(self), wire::enum_as_string, truncate);
-    json.finish();
-  }
-
-  void write_json_addresses(std::ostream& dest, epee::span<const lws::db::account_address> self)
-  {
-    // writes an array of monero base58 address strings
     wire::json_stream_writer stream{dest};
-    wire::object(stream, wire::field("updated", wire::as_array(self, lws::db::address_string)));
+    MONERO_UNWRAP(f(stream, std::forward<T>(args)...));
     stream.finish();
   }
 
@@ -151,6 +134,7 @@ namespace
     arguments.remove_prefix(1);
 
     std::vector<lws::db::account_address> addresses{};
+    addresses.reserve(arguments.size());
     for (std::string const& address : arguments)
       addresses.push_back(lws::db::address_string(address).value());
     return addresses;
@@ -161,15 +145,11 @@ namespace
     if (prog.arguments.size() < 2)
       throw std::runtime_error{"accept_requests requires 2 or more arguments"};
 
-    const lws::db::request req =
-      MONERO_UNWRAP(lws::db::request_from_string(prog.arguments[0]));
-    std::vector<lws::db::account_address> addresses =
-      get_addresses(epee::to_span(prog.arguments));
-
-    const std::vector<lws::db::account_address> updated =
-      prog.disk.accept_requests(req, epee::to_span(addresses)).value();
-
-    write_json_addresses(out, epee::to_span(updated));
+    lws::rpc::address_requests req{
+      get_addresses(epee::to_span(prog.arguments)),
+      MONERO_UNWRAP(lws::db::request_from_string(prog.arguments[0]))
+    };
+    run_command(lws::rpc::accept_requests, out, std::move(prog.disk), std::move(req));
   }
 
   void add_account(program prog, std::ostream& out)
@@ -177,13 +157,31 @@ namespace
     if (prog.arguments.size() != 2)
       throw std::runtime_error{"add_account needs exactly two arguments"};
 
-    const lws::db::account_address address[1] = {
-      lws::db::address_string(prog.arguments[0]).value()
+    lws::rpc::add_account_req req{
+      lws::db::address_string(prog.arguments[0]).value(),
+      get_key(prog.arguments[1])
     };
-    const crypto::secret_key key{get_key(prog.arguments[1])};
+    run_command(lws::rpc::add_account, out, std::move(prog.disk), std::move(req));
+  }
 
-    MONERO_UNWRAP(prog.disk.add_account(address[0], key));
-    write_json_addresses(out, address);
+  void create_admin(program prog, std::ostream& out)
+  {
+    if (!prog.arguments.empty())
+      throw std::runtime_error{"create_admin takes zero arguments"};
+
+    admin_display<lws::db::account> account{};
+    {
+      crypto::secret_key auth{};
+      crypto::generate_keys(account.value.address.view_public, auth);
+      MONERO_UNWRAP(prog.disk.add_account(account.value.address, auth, lws::db::account_flags::admin_account));
+
+      static_assert(sizeof(auth) == sizeof(account.value.key), "bad memcpy");
+      std::memcpy(std::addressof(account.value.key), std::addressof(auth), sizeof(auth));
+    }
+
+    wire::json_stream_writer json{out};
+    write_bytes(json, account);
+    json.finish();
   }
 
   void debug_database(program prog, std::ostream& out)
@@ -199,20 +197,31 @@ namespace
   {
     if (!prog.arguments.empty())
       throw std::runtime_error{"list_accounts takes zero arguments"};
+    run_command(lws::rpc::list_accounts, out, std::move(prog.disk));
+  }
 
-    auto reader = prog.disk.start_read().value();
-    auto stream = reader.get_accounts().value();
-    stream_json_object(out, stream.make_range());
+  void list_admin(program prog, std::ostream& out)
+  {
+    if (!prog.arguments.empty())
+      throw std::runtime_error{"list_admin takes zero arguments"};
+
+    using value_range = boost::iterator_range<lmdb::value_iterator<lws::db::account>>;
+    const auto transform = [] (value_range user)
+    { return admin_display<value_range>{std::move(user)}; };
+
+    auto reader = MONERO_UNWRAP(prog.disk.start_read());
+    wire::json_stream_writer json{out};
+    wire::dynamic_object(
+      json, reader.get_accounts().value().make_range(), wire::enum_as_string, transform
+    );
+    json.finish();
   }
 
   void list_requests(program prog, std::ostream& out)
   {
     if (!prog.arguments.empty())
       throw std::runtime_error{"list_requests takes zero arguments"};
-
-    auto reader = prog.disk.start_read().value();
-    auto stream = reader.get_requests().value();
-    stream_json_object(out, stream.make_range());
+    run_command(lws::rpc::list_requests, out, std::move(prog.disk));
   }
 
   void modify_account(program prog, std::ostream& out)
@@ -220,15 +229,11 @@ namespace
     if (prog.arguments.size() < 2)
       throw std::runtime_error{"modify_account_status requires 2 or more arguments"};
 
-    const lws::db::account_status status =
-      lws::db::account_status_from_string(prog.arguments[0]).value();
-    std::vector<lws::db::account_address> addresses =
-      get_addresses(epee::to_span(prog.arguments));
-
-    const std::vector<lws::db::account_address> updated =
-      prog.disk.change_status(status, epee::to_span(addresses)).value();
-
-    write_json_addresses(out, epee::to_span(updated));
+    lws::rpc::modify_account_req req{
+      get_addresses(epee::to_span(prog.arguments)),
+      lws::db::account_status_from_string(prog.arguments[0]).value()
+    };
+    run_command(lws::rpc::modify_account, out, std::move(prog.disk), std::move(req));
   }
 
   void reject_requests(program prog, std::ostream& out)
@@ -236,12 +241,11 @@ namespace
     if (prog.arguments.size() < 2)
       MONERO_THROW(common_error::kInvalidArgument, "reject_requests requires 2 or more arguments");
 
-    const lws::db::request req =
-      lws::db::request_from_string(prog.arguments[0]).value();
-    std::vector<lws::db::account_address> addresses =
-      get_addresses(epee::to_span(prog.arguments));
-
-    MONERO_UNWRAP(prog.disk.reject_requests(req, epee::to_span(addresses)));
+    lws::rpc::address_requests req{
+      get_addresses(epee::to_span(prog.arguments)),
+      lws::db::request_from_string(prog.arguments[0]).value()
+    };
+    run_command(lws::rpc::reject_requests, out, std::move(prog.disk), std::move(req));
   }
 
   void rescan(program prog, std::ostream& out)
@@ -249,14 +253,11 @@ namespace
     if (prog.arguments.size() < 2)
       throw std::runtime_error{"rescan requires 2 or more arguments"};
 
-    const auto height = lws::db::block_id(std::stoull(prog.arguments[0]));
-    const std::vector<lws::db::account_address> addresses =
-      get_addresses(epee::to_span(prog.arguments));
-
-    const std::vector<lws::db::account_address> updated =
-      prog.disk.rescan(height, epee::to_span(addresses)).value();
-
-    write_json_addresses(out, epee::to_span(updated));
+    lws::rpc::rescan_req req{
+      get_addresses(epee::to_span(prog.arguments)),
+      lws::db::block_id(std::stoull(prog.arguments[0]))
+    };
+    run_command(lws::rpc::rescan, out, std::move(prog.disk), std::move(req));
   }
 
   void rollback(program prog, std::ostream& out)
@@ -277,14 +278,16 @@ namespace
     char const* const name;
     void (*const handler)(program, std::ostream&);
     char const* const parameters;
-    };
+  };
 
   static constexpr const command commands[] =
   {
     {"accept_requests",       &accept_requests, "<\"create\"|\"import\"> <base58 address> [base 58 address]..."},
     {"add_account",           &add_account,     "<base58 address> <view key hex>"},
+    {"create_admin",          &create_admin,    ""},
     {"debug_database",        &debug_database,  ""},
     {"list_accounts",         &list_accounts,   ""},
+    {"list_admin",            &list_admin,      ""},
     {"list_requests",         &list_requests,   ""},
     {"modify_account_status", &modify_account,  "<\"active\"|\"inactive\"|\"hidden\"> <base58 address> [base 58 address]..."},
     {"reject_requests",       &reject_requests, "<\"create\"|\"import\"> <base58 address> [base 58 address]..."},

--- a/src/db/data.h
+++ b/src/db/data.h
@@ -81,7 +81,7 @@ namespace db
   enum account_flags : std::uint8_t
   {
     default_account = 0,
-    admin_account   = 1,          //!< Not currently used, for future extensions
+    admin_account   = 1,          //!< Indicates `key` can be used for admin requests
     account_generated_locally = 2 //!< Flag sent by client on initial login request
   };
 

--- a/src/db/storage.h
+++ b/src/db/storage.h
@@ -194,7 +194,7 @@ namespace db
 
 
     //! Add an account, for immediate inclusion in the active list.
-    expect<void> add_account(account_address const& address, crypto::secret_key const& key) noexcept;
+    expect<void> add_account(account_address const& address, crypto::secret_key const& key, account_flags flags = account_flags::default_account) noexcept;
 
     //! Reset `addresses` to `height` for scanning.
     expect<std::vector<account_address>>

--- a/src/rest_server.h
+++ b/src/rest_server.h
@@ -56,7 +56,7 @@ namespace lws
       bool allow_external;
     };
     
-    explicit rest_server(epee::span<const std::string> addresses, db::storage disk, rpc::client client, configuration config);
+    explicit rest_server(epee::span<const std::string> addresses, std::vector<std::string> admin, db::storage disk, rpc::client client, configuration config);
     
     rest_server(rest_server&&) = delete;
     rest_server(rest_server const&) = delete;

--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -26,8 +26,8 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set(monero-lws-rpc_sources client.cpp daemon_pub.cpp daemon_zmq.cpp light_wallet.cpp rates.cpp)
-set(monero-lws-rpc_headers client.h daemon_pub.h daemon_zmq.h fwd.h json.h light_wallet.h rates.h)
+set(monero-lws-rpc_sources admin.cpp client.cpp daemon_pub.cpp daemon_zmq.cpp light_wallet.cpp rates.cpp)
+set(monero-lws-rpc_headers admin.h client.h daemon_pub.h daemon_zmq.h fwd.h json.h light_wallet.h rates.h)
 
 add_library(monero-lws-rpc ${monero-lws-rpc_sources} ${monero-lws-rpc_headers})
 target_link_libraries(monero-lws-rpc monero::libraries monero-lws-wire-json)

--- a/src/rpc/admin.cpp
+++ b/src/rpc/admin.cpp
@@ -1,0 +1,198 @@
+// Copyright (c) 2023, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "admin.h"
+
+#include <boost/range/iterator_range.hpp>
+#include <functional>
+#include <utility>
+#include "db/string.h"
+#include "error.h"
+#include "span.h" // monero/contrib/epee/include
+#include "wire.h"
+#include "wire/crypto.h"
+#include "wire/error.h"
+#include "wire/json/write.h"
+#include "wire/traits.h"
+#include "wire/vector.h"
+
+namespace
+{
+  // Do not output "full" debug data provided by `db::data.h` header; truncate output
+  template<typename T>
+  struct truncated
+  {
+    T value;
+  };
+
+  lws::db::account_address wire_unwrap(const boost::string_ref source)
+  {
+    const expect<lws::db::account_address> address = lws::db::address_string(source);
+    if (!address)
+      WIRE_DLOG_THROW(wire::error::schema::string, "Bad string to address conversion: " << address.error().message());
+    return *address;
+  }
+
+  using base58_address = truncated<lws::db::account_address&>;
+  void read_bytes(wire::reader& source, base58_address& dest)
+  {
+    dest.value = wire_unwrap(source.string());
+  }
+
+  void write_bytes(wire::writer& dest, const truncated<lws::db::account>& self)
+  {
+    wire::object(dest,
+      wire::field("address", lws::db::address_string(self.value.address)),
+      wire::field("scan_height", self.value.scan_height),
+      wire::field("access_time", self.value.access)
+    );
+  }
+
+  void write_bytes(wire::writer& dest, const truncated<lws::db::request_info>& self)
+  {
+    wire::object(dest,
+      wire::field("address", lws::db::address_string(self.value.address)),
+      wire::field("start_height", self.value.start_height)
+    );
+  }
+
+  template<typename V>
+  void write_bytes(wire::json_writer& dest, const truncated<boost::iterator_range<lmdb::value_iterator<V>>> self)
+  {
+    const auto truncate = [] (V src) { return truncated<V>{std::move(src)}; };
+    wire::array(dest, std::move(self.value), truncate);
+  }
+
+  template<typename K, typename V, typename C>
+  expect<void> stream_object(wire::json_writer& dest, expect<lmdb::key_stream<K, V, C>> self)
+  {
+    using value_range = boost::iterator_range<lmdb::value_iterator<V>>;
+    const auto truncate = [] (value_range src) -> truncated<value_range>
+    {
+      return {std::move(src)};
+    };
+
+    if (!self)
+      return self.error();
+
+    wire::dynamic_object(dest, self->make_range(), wire::enum_as_string, truncate);
+    return success();
+  }
+
+  template<typename T, typename U>
+  void read_addresses(wire::reader& source, T& self, U field)
+  {
+    std::vector<std::string> addresses;
+    wire::object(source, wire::field("addresses", std::ref(addresses)), std::move(field));
+
+    self.addresses.reserve(addresses.size());
+    for (const auto& elem : addresses)
+      self.addresses.emplace_back(wire_unwrap(elem));
+  }
+
+  void write_addresses(wire::writer& dest, epee::span<const lws::db::account_address> self)
+  {
+    // writes an array of monero base58 address strings
+    wire::object(dest, wire::field("updated", wire::as_array(self, lws::db::address_string)));
+  }
+
+  expect<void> write_addresses(wire::writer& dest, const expect<std::vector<lws::db::account_address>>& self)
+  {
+    if (!self)
+      return self.error();
+    write_addresses(dest, epee::to_span(*self));
+    return success();
+  }
+} // anonymous
+
+namespace lws { namespace rpc
+{
+  void read_bytes(wire::reader& source, add_account_req& self)
+  {
+    wire::object(source,
+      wire::field("address", base58_address{self.address}),
+      wire::field("key", std::ref(unwrap(unwrap(self.key))))
+    );
+  }
+
+  void read_bytes(wire::reader& source, address_requests& self)
+  {
+    read_addresses(source, self, WIRE_FIELD(type));
+  }
+  void read_bytes(wire::reader& source, modify_account_req& self)
+  {
+    read_addresses(source, self, WIRE_FIELD(status));
+  }
+  void read_bytes(wire::reader& source, rescan_req& self)
+  {
+    read_addresses(source, self, WIRE_FIELD(height));
+  }
+
+  expect<void> accept_requests_::operator()(wire::writer& dest, db::storage disk, const request& req) const
+  {
+    return write_addresses(dest, disk.accept_requests(req.type, epee::to_span(req.addresses)));
+  }
+
+  expect<void> add_account_::operator()(wire::writer& out, db::storage disk, const request& req) const
+  {
+    using span = epee::span<const lws::db::account_address>;
+    MONERO_CHECK(disk.add_account(req.address, req.key));
+    write_addresses(out, span{std::addressof(req.address), 1});
+    return success();
+  }
+
+  expect<void> list_accounts_::operator()(wire::json_writer& dest, db::storage disk) const
+  {
+    auto reader = disk.start_read();
+    if (!reader)
+      return reader.error();
+    return stream_object(dest, reader->get_accounts());
+  }
+
+  expect<void> list_requests_::operator()(wire::json_writer& dest, db::storage disk) const
+  {
+    auto reader = disk.start_read();
+    if (!reader)
+      return reader.error();
+    return stream_object(dest, reader->get_requests());
+  }
+
+  expect<void> modify_account_::operator()(wire::writer& dest, db::storage disk, const request& req) const
+  {
+    return write_addresses(dest, disk.change_status(req.status, epee::to_span(req.addresses)));
+  }
+
+  expect<void> reject_requests_::operator()(wire::writer& dest, db::storage disk, const request& req) const
+  {
+    return write_addresses(dest, disk.reject_requests(req.type, epee::to_span(req.addresses)));
+  }
+
+  expect<void> rescan_::operator()(wire::writer& dest, db::storage disk, const request& req) const
+  {
+    return write_addresses(dest, disk.rescan(req.height, epee::to_span(req.addresses)));
+  }
+}} // lws // rpc

--- a/src/rpc/admin.h
+++ b/src/rpc/admin.h
@@ -1,0 +1,125 @@
+// Copyright (c) 2023, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include "common/expect.h" // monero/src
+#include "db/data.h"
+#include "db/storage.h"
+#include "wire/fwd.h"
+#include "wire/json/fwd.h"
+
+namespace lws
+{
+namespace rpc
+{
+  struct add_account_req
+  {
+    db::account_address address;
+    crypto::secret_key key;
+  };
+  void read_bytes(wire::reader&, add_account_req&);
+
+  //! Request object for `accept_requests` and `reject_requests` endpoints.
+  struct address_requests
+  {
+    std::vector<db::account_address> addresses;
+    db::request type;
+  };
+  void read_bytes(wire::reader&, address_requests&);
+
+  struct modify_account_req
+  {
+    std::vector<db::account_address> addresses;
+    db::account_status status;
+  };
+  void read_bytes(wire::reader&, modify_account_req&);
+
+  struct rescan_req
+  {
+    std::vector<db::account_address> addresses;
+    db::block_id height;
+  };
+  void read_bytes(wire::reader&, rescan_req&);
+
+
+  struct accept_requests_
+  {
+    using request = address_requests;
+    expect<void> operator()(wire::writer& dest, db::storage disk, const request& req) const;
+  };
+  constexpr const accept_requests_ accept_requests{};
+
+  struct add_account_
+  {
+    using request = add_account_req;
+    expect<void> operator()(wire::writer& dest, db::storage disk, const request& req) const;
+  };
+  constexpr const add_account_ add_account{};
+
+  struct list_accounts_
+  {
+    using request = expect<void>;
+    expect<void> operator()(wire::json_writer& dest, db::storage disk) const;
+    expect<void> operator()(wire::json_writer& dest, db::storage disk, const request&) const
+    { return (*this)(dest, std::move(disk)); }
+  };
+  constexpr const list_accounts_ list_accounts{};
+
+  struct list_requests_
+  {
+    using request = expect<void>;
+    expect<void> operator()(wire::json_writer& dest, db::storage disk) const;
+    expect<void> operator()(wire::json_writer& dest, db::storage disk, const request&) const
+    { return (*this)(dest, std::move(disk)); }
+  };
+  constexpr const list_requests_ list_requests{};
+
+  struct modify_account_
+  {
+    using request = modify_account_req;
+    expect<void> operator()(wire::writer& dest, db::storage disk, const request& req) const;
+  };
+  constexpr const modify_account_ modify_account{};
+
+  struct reject_requests_
+  {
+    using request = address_requests;
+    expect<void> operator()(wire::writer& dest, db::storage disk, const request& req) const;
+  };
+  constexpr const reject_requests_ reject_requests{};
+
+  struct rescan_
+  {
+    using request = rescan_req;
+    expect<void> operator()(wire::writer& dest, db::storage disk, const request& req) const;
+  };
+  constexpr const rescan_ rescan{};
+
+}} // lws // rpc


### PR DESCRIPTION
This makes some of the commands currently only available in `monero-lws-admin` via REST. Some of the commands are intentionally omitted for security purposes. The admin REST commands can be accessed via a separate port or separate namespace/prefix on the same port.