### PR TITLE
Decoy selection algo off-by-1

### DIFF
--- a/src/util/gamma_picker.cpp
+++ b/src/util/gamma_picker.cpp
@@ -68,7 +68,8 @@ namespace lws
 
   bool gamma_picker::is_valid() const noexcept
   {
-    return CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE < rct_offsets.size() + 1;
+    static_assert(CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE > 0);
+    return CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE - 1 < rct_offsets.size();
   }
 
   std::uint64_t gamma_picker::spendable_upper_bound() const noexcept
@@ -91,6 +92,7 @@ namespace lws
 
     static_assert(std::is_empty<crypto::random_device>(), "random_device is no longer cheap to construct");
     static constexpr const crypto::random_device engine{};
+    static_assert(CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE > 0);
     const auto end = offsets().end() - CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE + 1;
     const uint64_t num_rct_outputs = spendable_upper_bound();
 

--- a/src/util/gamma_picker.cpp
+++ b/src/util/gamma_picker.cpp
@@ -68,14 +68,20 @@ namespace lws
 
   bool gamma_picker::is_valid() const noexcept
   {
-    return CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE < rct_offsets.size();
+    return CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE < rct_offsets.size() + 1;
   }
 
   std::uint64_t gamma_picker::spendable_upper_bound() const noexcept
   {
     if (!is_valid())
       return 0;
-    return *(rct_offsets.end() - CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE - 1);
+    return *(rct_offsets.end() - CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE);
+    /* Assume block indexes: [0, 1, ..., n-2, n-1]
+       where n is the number of blocks in the chain
+       A user can spend an output starting in block index n - CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE
+       The total number of spendable outputs is the cumulative count stored at that block
+       rct_offsets.end() points to index n
+       Therefore we need to return index rct_offets.end() - CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE */
   }
 
   std::uint64_t gamma_picker::operator()()
@@ -85,7 +91,7 @@ namespace lws
 
     static_assert(std::is_empty<crypto::random_device>(), "random_device is no longer cheap to construct");
     static constexpr const crypto::random_device engine{};
-    const auto end = offsets().end() - CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE;
+    const auto end = offsets().end() - CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE + 1;
     const uint64_t num_rct_outputs = spendable_upper_bound();
 
     for (unsigned tries = 0; tries < 100; ++tries)


### PR DESCRIPTION
[wallet2](https://github.com/monero-project/monero/blob/f307621678c24ee7ca158fde38080d787d678733/src/wallet/wallet2.cpp#L6454-L6455) + [consensus](https://github.com/monero-project/monero/blob/f307621678c24ee7ca158fde38080d787d678733/src/cryptonote_core/blockchain.cpp#L3531-L3536) allow a user to spend an output that's in a block 9 blocks prior to the final block in the chain, since the output is eligible to be included in the *next* block at that point (see discussion [here](https://github.com/monero-project/monero/pull/8794#issuecomment-1478116268)). The decoy selection algo should therefore apply the same criteria when selecting decoys.

The PR to change the decoy selection algo in the monero repo is still open here: https://github.com/monero-project/monero/pull/8794