### PR TITLE
Updating dockerfile to newer monerod release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Initial base from https://github.com/sethforprivacy/monero-lws/blob/588c7f1965d3afbda8a65dc870645650e063e897/Dockerfile
 
 # Set monerod version to install from github
-ARG MONERO_BRANCH=v0.18.0.0
-ARG MONERO_COMMIT_HASH=b6a029f222abada36c7bc6c65899a4ac969d7dee
+ARG MONERO_BRANCH=v0.18.2.1
+ARG MONERO_COMMIT_HASH=4f47fd26269764ff702e87242d8a75ce4f1bce67
 
 # Select ubuntu:20.04 for the build image base
 FROM ubuntu:20.04 as build


### PR DESCRIPTION
This updates the`dockerfile` on the `develop` branch to use the latest `monero` release. I have verified this still builds (on the `develop` branch). If there are no objections to this PR, I will update/cherry-pick to the `monero-lws` release branch and master branches.