### PR TITLE
Added webhook (tx-confirmation) support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,10 +28,10 @@
 
 include_directories(.)
 
+add_subdirectory(wire)
 add_subdirectory(db)
 add_subdirectory(rpc)
 add_subdirectory(util)
-add_subdirectory(wire)
 
 # For both the server and admin utility.
 set(monero-lws-common_sources config.cpp error.cpp)

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -59,6 +59,10 @@ namespace lws
         return "Response from monerod daemon was bad/unexpected";
       case error::bad_height:
         return "Invalid blockchain height";
+      case error::bad_url:
+        return "Invlaid URL";
+      case error::bad_webhook:
+        return "Invalid webhook request";
       case error::blockchain_reorg:
         return "A blockchain reorg has been detected";
       case error::configuration:

--- a/src/error.h
+++ b/src/error.h
@@ -43,6 +43,8 @@ namespace lws
     bad_client_tx,              //!< REST client submitted invalid transaction
     bad_daemon_response,        //!< RPC Response from daemon was invalid
     bad_height,                 //!< Invalid blockchain height
+    bad_url,                    //!< Invalid URL
+    bad_webhook,                //!< Invalid webhook request
     blockchain_reorg,           //!< Blockchain reorg after fetching/scanning block(s)
     configuration,              //!< Process configuration invalid
     crypto_failure,             //!< Cryptographic function failed

--- a/src/lmdb/msgpack_table.h
+++ b/src/lmdb/msgpack_table.h
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <utility>
+
+#include "common/expect.h" // monero/src
+#include "lmdb/error.h"    // monero/src
+#include "lmdb/table.h"    // monero/src
+#include "lmdb/util.h"     // monero/src
+#include "wire/msgpack.h"
+
+namespace lmdb
+{
+  //! Helper for grouping typical LMDB DBI options when key is fixed and value has msgpack component
+  template<typename K, typename V1, typename V2>
+  struct msgpack_table : table
+  {
+    using key_type = K;
+    using fixed_value_type = V1;
+    using msgpack_value_type = V2;
+    using value_type = std::pair<fixed_value_type, msgpack_value_type>;
+
+    constexpr explicit msgpack_table(const char* name, unsigned flags = 0, MDB_cmp_func value_cmp = nullptr) noexcept
+      : table{name, flags, &lmdb::less<lmdb::native_type<K>>, value_cmp}
+    {}
+
+    static expect<key_type> get_key(MDB_val key)
+    {
+      if (key.mv_size != sizeof(key_type))
+        return {lmdb::error(MDB_BAD_VALSIZE)};
+
+      key_type out;
+      std::memcpy(std::addressof(out), static_cast<char*>(key.mv_data), sizeof(out));
+      return out;
+    }
+
+    static epee::byte_slice make_value(const fixed_value_type& val1, const msgpack_value_type& val2)
+    {
+      epee::byte_stream initial;
+      initial.write({reinterpret_cast<const char*>(std::addressof(val1)), sizeof(val1)});
+      return wire_write::to_bytes(wire::msgpack_slice_writer{std::move(initial), true}, val2);
+    }
+
+    /*!
+        \tparam U must be same as `V`; used for sanity checking.
+        \tparam F is the type within `U` that is being extracted.
+        \tparam offset to `F` within `U`.
+
+        \note If using `F` and `offset` to retrieve a specific field, use
+            `MONERO_FIELD` macro in `src/lmdb/util.h` which calculates the
+            offset automatically.
+
+        \return Value of type `F` at `offset` within `value` which has
+            type `U`.
+    */
+    template<typename U, typename F = U, std::size_t offset = 0>
+    static expect<F> get_fixed_value(MDB_val value) noexcept
+    {
+      static_assert(std::is_same<U, V1>(), "bad MONERO_FIELD?");
+      static_assert(std::is_pod<F>(), "F must be POD");
+      static_assert(sizeof(F) + offset <= sizeof(U), "bad field type and/or offset");
+
+      if (value.mv_size < sizeof(U))
+        return {lmdb::error(MDB_BAD_VALSIZE)};
+
+      F out;
+      std::memcpy(std::addressof(out), static_cast<char*>(value.mv_data) + offset, sizeof(out));
+      return out;
+    }
+
+    static expect<value_type> get_value(MDB_val value) noexcept
+    {
+      if (value.mv_size < sizeof(fixed_value_type))
+        return {lmdb::error(MDB_BAD_VALSIZE)};
+      std::pair<fixed_value_type, msgpack_value_type> out;
+      std::memcpy(std::addressof(out.first), static_cast<const char*>(value.mv_data), sizeof(out.first));
+
+      auto msgpack_bytes = lmdb::to_byte_span(value);
+      msgpack_bytes.remove_prefix(sizeof(out.first));
+      auto msgpack = wire::msgpack::from_bytes<msgpack_value_type>(epee::byte_slice{{msgpack_bytes}});
+      if (!msgpack)
+        return msgpack.error();
+      out.second = std::move(*msgpack);
+
+      return out;
+    }
+    
+    //! Easier than doing another iterator .. for now :/
+    static expect<std::vector<std::pair<key_type, std::vector<value_type>>>> get_all(MDB_cursor& cur)
+    {
+      MDB_val key{};
+      MDB_val value{};
+      int err = mdb_cursor_get(&cur, &key, &value, MDB_FIRST);
+      std::vector<std::pair<key_type, std::vector<value_type>>> out;
+      for ( ; /* for every key */ ; )
+      {
+        if (err)
+        {
+          if (err != MDB_NOTFOUND)
+            return {lmdb::error(err)};
+          break;
+        }
+
+        expect<key_type> next_key = get_key(key);
+        if (!next_key)
+          return next_key.error();
+        out.emplace_back(std::move(*next_key), std::vector<value_type>{});
+
+        for ( ; /* for every value at key */ ; )
+        {
+          if (err)
+          {
+            if (err != MDB_NOTFOUND)
+              return {lmdb::error(err)};
+            break;
+          }
+          expect<value_type> next_value = get_value(value);
+          if (!next_value)
+            return next_value.error();
+          out.back().second.push_back(std::move(*next_value));
+          err = mdb_cursor_get(&cur, &key, &value, MDB_NEXT_DUP);
+        }
+
+        err = mdb_cursor_get(&cur, &key, &value, MDB_NEXT_NODUP);
+      } // every key
+      return out;
+    }
+  };
+} // lmdb

--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -656,7 +656,7 @@ namespace lws
     };
 
     template<typename E>
-    expect<epee::byte_slice> call(std::string&& root, db::storage disk, const rpc::client& gclient)
+    expect<epee::byte_slice> call(std::string&& root, db::storage disk, const rpc::client& gclient, const bool)
     {
       using request = typename E::request;
       using response = typename E::response;
@@ -675,33 +675,35 @@ namespace lws
     struct admin
     {
       T params;
-      crypto::secret_key auth;
+      boost::optional<crypto::secret_key> auth;
     };
 
     template<typename T>
     void read_bytes(wire::json_reader& source, admin<T>& self)
     {
-      wire::object(
-        source, wire::field("auth", std::ref(unwrap(unwrap(self.auth)))), WIRE_FIELD(params)
-      );
+        wire::object(source, WIRE_OPTIONAL_FIELD(auth), WIRE_FIELD(params));
     }
     void read_bytes(wire::json_reader& source, admin<expect<void>>& self)
     {
-      // params optional
-      wire::object(source, wire::field("auth", std::ref(unwrap(unwrap(self.auth)))));
+        // params optional
+        wire::object(source, WIRE_OPTIONAL_FIELD(auth));
     }
 
     template<typename E>
-    expect<epee::byte_slice> call_admin(std::string&& root, db::storage disk, const rpc::client&)
+    expect<epee::byte_slice> call_admin(std::string&& root, db::storage disk, const rpc::client&, const bool disable_auth)
     {
       using request = typename E::request;
-      const expect<admin<request>> req = wire::json::from_bytes<admin<request>>(std::move(root));
+      expect<admin<request>> req = wire::json::from_bytes<admin<request>>(std::move(root));
       if (!req)
         return req.error();
 
+      if (!disable_auth)
       {
+        if (!req->auth)
+          return {error::account_not_found};
+
         db::account_address address{};
-        if (!crypto::secret_key_to_public_key(req->auth, address.view_public))
+        if (!crypto::secret_key_to_public_key(*(req->auth), address.view_public))
           return {error::crypto_failure};
 
         auto reader = disk.start_read();
@@ -717,14 +719,14 @@ namespace lws
       }
 
       wire::json_slice_writer dest{};
-      MONERO_CHECK(E{}(dest, std::move(disk), req->params));
+      MONERO_CHECK(E{}(dest, std::move(disk), std::move(req->params)));
       return dest.take_bytes();
     }
 
     struct endpoint
     {
       char const* const name;
-      expect<epee::byte_slice> (*const run)(std::string&&, db::storage, rpc::client const&);
+      expect<epee::byte_slice> (*const run)(std::string&&, db::storage, rpc::client const&, bool);
       const unsigned max_size;
     };
 
@@ -748,7 +750,11 @@ namespace lws
       {"/list_requests",         call_admin<rpc::list_requests_>,   100},
       {"/modify_account_status", call_admin<rpc::modify_account_>,  50 * 1024},
       {"/reject_requests",       call_admin<rpc::reject_requests_>, 50 * 1024},
-      {"/rescan",                call_admin<rpc::rescan_>,          50 * 1024}
+      {"/rescan",                call_admin<rpc::rescan_>,          50 * 1024},
+      {"/webhook_add",           call_admin<rpc::webhook_add_>,     50 * 1024},
+      {"/webhook_delete",        call_admin<rpc::webhook_delete_>,  50 * 1024},
+      {"/webhook_delete_uuid",   call_admin<rpc::webhook_del_uuid_>,50 * 1024},
+      {"/webhook_list",          call_admin<rpc::webhook_list_>,    100}
     };
 
     struct by_name_
@@ -781,13 +787,15 @@ namespace lws
     rpc::client client;
     boost::optional<std::string> prefix;
     boost::optional<std::string> admin_prefix;
+    bool disable_auth;
 
-    explicit internal(boost::asio::io_service& io_service, lws::db::storage disk, rpc::client client)
+    explicit internal(boost::asio::io_service& io_service, lws::db::storage disk, rpc::client client, const bool disable_auth)
       : lws::http_server_impl_base<rest_server::internal, context>(io_service)
       , disk(std::move(disk))
       , client(std::move(client))
       , prefix()
       , admin_prefix()
+      , disable_auth(disable_auth)
     {
       assert(std::is_sorted(std::begin(endpoints), std::end(endpoints), by_name));
     }
@@ -853,7 +861,7 @@ namespace lws
       }
 
       // \TODO remove copy of json string here :/
-      auto body = handler->run(std::string{query.m_body}, disk.clone(), client);
+      auto body = handler->run(std::string{query.m_body}, disk.clone(), client, disable_auth);
       if (!body)
       {
         MINFO(body.error().message() << " from " << ctx.m_remote_address.str() << " on " << handler->name);
@@ -984,13 +992,13 @@ namespace lws
     bool any_ssl = false;
     for (const std::string& address : addresses)
     {
-      ports_.emplace_back(io_service_, disk.clone(), MONERO_UNWRAP(client.clone()));
+      ports_.emplace_back(io_service_, disk.clone(), MONERO_UNWRAP(client.clone()), config.disable_admin_auth);
       any_ssl |= init_port(ports_.back(), address, config, false);
     }
 
     for (const std::string& address : admin)
     {
-      ports_.emplace_back(io_service_, disk.clone(), MONERO_UNWRAP(client.clone()));
+      ports_.emplace_back(io_service_, disk.clone(), MONERO_UNWRAP(client.clone()), config.disable_admin_auth);
       any_ssl |= init_port(ports_.back(), address, config, true);
     }
 

--- a/src/rest_server.h
+++ b/src/rest_server.h
@@ -54,6 +54,7 @@ namespace lws
       std::vector<std::string> access_controls;
       std::size_t threads;
       bool allow_external;
+      bool disable_admin_auth;
     };
     
     explicit rest_server(epee::span<const std::string> addresses, std::vector<std::string> admin, db::storage disk, rpc::client client, configuration config);

--- a/src/rpc/admin.h
+++ b/src/rpc/admin.h
@@ -27,9 +27,11 @@
 
 #pragma once
 
+#include <boost/optional/optional.hpp>
 #include <string>
 #include <vector>
 #include "common/expect.h" // monero/src
+#include "crypto/crypto.h" // monero/src
 #include "db/data.h"
 #include "db/storage.h"
 #include "wire/fwd.h"
@@ -67,6 +69,29 @@ namespace rpc
     db::block_id height;
   };
   void read_bytes(wire::reader&, rescan_req&);
+
+  struct webhook_add_req
+  {
+    std::string url;
+    boost::optional<std::string> token;
+    boost::optional<db::account_address> address;
+    boost::optional<crypto::hash8> payment_id;
+    boost::optional<std::uint32_t> confirmations;
+    db::webhook_type type;
+  };
+  void read_bytes(wire::reader&, webhook_add_req&);
+
+  struct webhook_delete_req
+  {
+    std::vector<db::account_address> addresses;
+  };
+  void read_bytes(wire::reader&, webhook_delete_req&);
+
+  struct webhook_delete_uuid_req
+  {
+    std::vector<boost::uuids::uuid> event_ids;
+  };
+  void read_bytes(wire::reader&, webhook_delete_uuid_req&);
 
 
   struct accept_requests_
@@ -121,5 +146,36 @@ namespace rpc
     expect<void> operator()(wire::writer& dest, db::storage disk, const request& req) const;
   };
   constexpr const rescan_ rescan{};
+
+  struct webhook_add_
+  {
+    using request = webhook_add_req;
+    expect<void> operator()(wire::writer& dest, db::storage disk, request&& req) const;
+  };
+  constexpr const webhook_add_ webhook_add{};
+
+  struct webhook_delete_
+  {
+    using request = webhook_delete_req;
+    expect<void> operator()(wire::writer& dest, db::storage disk, const request& req) const;
+  };
+  constexpr const webhook_delete_ webhook_delete{};
+
+  struct webhook_del_uuid_
+  {
+    using request = webhook_delete_uuid_req;
+    expect<void> operator()(wire::writer& dest, db::storage disk, request req) const;
+  };
+  constexpr const webhook_del_uuid_ webhook_delete_uuid{};
+
+
+  struct webhook_list_
+  {
+    using request = expect<void>;
+    expect<void> operator()(wire::writer& dest, db::storage disk) const;
+    expect<void> operator()(wire::writer& dest, db::storage disk, const request&) const
+    { return (*this)(dest, std::move(disk)); }
+  };
+  constexpr const webhook_list_ webhook_list{};
 
 }} // lws // rpc

--- a/src/wire/crypto.h
+++ b/src/wire/crypto.h
@@ -30,13 +30,28 @@
 #include <type_traits>
 
 #include "crypto/crypto.h"   // monero/src
+#include "span.h"            // monero/contrib/include
 #include "ringct/rctTypes.h" // monero/src
 #include "wire/traits.h"
+
+namespace crypto
+{
+  template<typename R>
+  void read_bytes(R& source, crypto::secret_key& self)
+  {
+    source.binary(epee::as_mut_byte_span(unwrap(unwrap(self))));
+  }
+}
 
 namespace wire
 {
   template<>
   struct is_blob<crypto::ec_scalar>
+    : std::true_type
+  {};
+
+  template<>
+  struct is_blob<crypto::hash8>
     : std::true_type
   {};
 

--- a/src/wire/msgpack/base.h
+++ b/src/wire/msgpack/base.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <cstdint>
+#include <limits>
 #include <string>
 #include <tuple>
 

--- a/src/wire/msgpack/write.h
+++ b/src/wire/msgpack/write.h
@@ -86,8 +86,12 @@ namespace wire
     }
 
   protected:
+    msgpack_writer(epee::byte_stream&& initial, bool integer_keys, bool needs_flush)
+      : writer(), bytes_(std::move(initial)), expected_(1), integer_keys_(integer_keys), needs_flush_(needs_flush)
+    {}
+
     msgpack_writer(bool integer_keys, bool needs_flush)
-      : writer(), bytes_(), expected_(1), integer_keys_(integer_keys), needs_flush_(needs_flush)
+      : msgpack_writer(epee::byte_stream{}, integer_keys, needs_flush)
     {}
 
     //! \throw std::logic_error if tree was not completed
@@ -153,6 +157,10 @@ namespace wire
   //! Buffers entire JSON message in memory
   struct msgpack_slice_writer final : msgpack_writer
   {
+    msgpack_slice_writer(epee::byte_stream&& initial, bool integer_keys = false)
+      : msgpack_writer(std::move(initial), integer_keys, false)
+    {}
+
     explicit msgpack_slice_writer(bool integer_keys = false)
       : msgpack_writer(integer_keys, false)
     {}

--- a/src/wire/uuid.h
+++ b/src/wire/uuid.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, The Monero Project
+// Copyright (c) 2020, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are
@@ -24,36 +24,16 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 #pragma once
 
-#include <atomic>
-#include <boost/optional/optional.hpp>
-#include <cstdint>
-#include <string>
+#include <boost/uuid/uuid.hpp>
+#include <type_traits>
 
-#include "db/storage.h"
-#include "rpc/client.h"
-
-namespace lws
+namespace wire
 {
-  //! Scans all active `db::account`s. Detects if another process changes active list.
-  class scanner
-  {
-    static std::atomic<bool> running;
-
-    scanner() = delete;
-
-  public:
-    //! Use `client` to sync blockchain data, and \return client if successful.
-    static expect<rpc::client> sync(db::storage disk, rpc::client client);
-
-    //! Poll daemon until `stop()` is called, using `thread_count` threads.
-    static void run(db::storage disk, rpc::context ctx, std::size_t thread_count, boost::string_ref webhook_ssl_verification);
-
-    //! \return True if `stop()` has never been called.
-    static bool is_running() noexcept { return running; }
-
-    //! Stops all scanner instances globally.
-    static void stop() noexcept { running = false; }
-  };
-} // lws
+  template<>
+  struct is_blob<boost::uuids::uuid>
+    : std::true_type
+  {};
+}

--- a/src/wire/write.h
+++ b/src/wire/write.h
@@ -170,15 +170,19 @@ namespace wire_write
   template<typename W, typename T, unsigned I>
   inline bool field(W& dest, const wire::field_<T, true, I> elem)
   {
-    dest.key(I, elem.name);
-    write_bytes(dest, elem.get_value());
+    // Arrays always optional, see `wire/field.h`
+    if (wire::available(elem))
+    {
+      dest.key(I, elem.name);
+      write_bytes(dest, elem.get_value());
+    }
     return true;
   }
 
   template<typename W, typename T, unsigned I>
   inline bool field(W& dest, const wire::field_<T, false, I> elem)
   {
-    if (bool(elem.get_value()))
+    if (wire::available(elem))
     {
       dest.key(I, elem.name);
       write_bytes(dest, *elem.get_value());

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -30,8 +30,18 @@ add_library(monero-lws-unit-framework framework.test.cpp)
 target_include_directories(monero-lws-unit-framework PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_SOURCE_DIR}/src")
 target_link_libraries(monero-lws-unit-framework)
 
+add_subdirectory(db)
+add_subdirectory(rpc)
 add_subdirectory(wire)
 
 add_executable(monero-lws-unit main.cpp)
-target_link_libraries(monero-lws-unit monero-lws-unit-framework monero-lws-unit-wire monero-lws-unit-wire-json monero-lws-unit-wire-msgpack)
+target_link_libraries(
+  monero-lws-unit
+  monero-lws-unit-db
+  monero-lws-unit-framework
+  monero-lws-unit-rpc
+  monero-lws-unit-wire
+  monero-lws-unit-wire-json
+  monero-lws-unit-wire-msgpack
+)
 add_test(NAME monero-lws-unit COMMAND monero-lws-unit -v)

--- a/tests/unit/db/CMakeLists.txt
+++ b/tests/unit/db/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020, The Monero Project
+# Copyright (c) 2022-2023, The Monero Project
 #
 # All rights reserved.
 #
@@ -26,9 +26,13 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set(monero-lws-db_sources account.cpp data.cpp storage.cpp string.cpp)
-set(monero-lws-db_headers account.h data.h fwd.h storage.h string.h)
-
-add_library(monero-lws-db ${monero-lws-db_sources} ${monero-lws-db_headers})
-target_include_directories(monero-lws-db PUBLIC "${LMDB_INCLUDE}")
-target_link_libraries(monero-lws-db monero::libraries monero-lws-common monero-lws-wire-msgpack ${LMDB_LIB_PATH})
+add_library(monero-lws-unit-db OBJECT storage.test.cpp webhook.test.cpp)
+target_link_libraries(
+  monero-lws-unit-db
+  monero-lws-unit-framework
+  monero-lws-common
+  monero-lws-db
+  monero::libraries
+  ${Boost_PROGRAM_OPTIONS_LIBRARY}
+)
+#add_test(monero-lws-unit)

--- a/tests/unit/db/storage.test.h
+++ b/tests/unit/db/storage.test.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, The Monero Project
+// Copyright (c) 2023, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are
@@ -24,36 +24,23 @@
 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 #pragma once
 
-#include <atomic>
-#include <boost/optional/optional.hpp>
-#include <cstdint>
-#include <string>
-
+#include <boost/filesystem/path.hpp>
+#include "crypto/crypto.h" // monero/src/
+#include "db/account.h"
+#include "db/data.h"
 #include "db/storage.h"
-#include "rpc/client.h"
 
-namespace lws
+namespace lws { namespace db { namespace test
 {
-  //! Scans all active `db::account`s. Detects if another process changes active list.
-  class scanner
+  struct cleanup_db
   {
-    static std::atomic<bool> running;
-
-    scanner() = delete;
-
-  public:
-    //! Use `client` to sync blockchain data, and \return client if successful.
-    static expect<rpc::client> sync(db::storage disk, rpc::client client);
-
-    //! Poll daemon until `stop()` is called, using `thread_count` threads.
-    static void run(db::storage disk, rpc::context ctx, std::size_t thread_count, boost::string_ref webhook_ssl_verification);
-
-    //! \return True if `stop()` has never been called.
-    static bool is_running() noexcept { return running; }
-
-    //! Stops all scanner instances globally.
-    static void stop() noexcept { running = false; }
+    ~cleanup_db();
   };
-} // lws
+
+  lws::db::storage get_fresh_db();
+  lws::db::account make_db_account(const lws::db::account_address& pubs, const crypto::secret_key& key);
+  lws::account make_account(const lws::db::account_address& pubs, const crypto::secret_key& key);
+}}} // lws // db // test

--- a/tests/unit/db/webhook.test.cpp
+++ b/tests/unit/db/webhook.test.cpp
@@ -1,0 +1,210 @@
+// Copyright (c) 2023, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "framework.test.h"
+
+#include <boost/uuid/random_generator.hpp>
+#include <cstdint>
+#include "crypto/crypto.h" // monero/src
+#include "db/data.h"
+#include "db/storage.h"
+#include "db/storage.test.h"
+
+namespace
+{
+  bool add_out(lws::account& account, const lws::db::block_id last_id, const std::uint64_t payment_id)
+  {
+    crypto::hash8 real_id{};
+    std::memcpy(std::addressof(real_id), std::addressof(payment_id), sizeof(real_id));
+    return account.add_out(
+      lws::db::output{
+        lws::db::transaction_link{
+          lws::db::block_id(lmdb::to_native(last_id) + 1),
+          crypto::rand<crypto::hash>()
+        },
+        lws::db::output::spend_meta_{
+          lws::db::output_id{0, 100},
+          std::uint64_t(1000),
+          std::uint32_t(16),
+          std::uint32_t(1),
+          crypto::rand<crypto::public_key>()
+        },
+        std::uint64_t(10000000),
+        std::uint64_t(0),
+        crypto::rand<crypto::hash>(),
+        crypto::rand<crypto::public_key>(),
+        crypto::rand<rct::key>(),
+        {{}, {}, {}, {}, {}, {}, {}},
+        lws::db::extra_and_length(0),
+        lws::db::output::payment_id_{real_id}
+      }
+    );
+  }
+}
+
+LWS_CASE("db::storage::*_webhook")
+{
+  lws::db::account_address account{};
+  crypto::secret_key view{};
+  crypto::generate_keys(account.spend_public, view);
+  crypto::generate_keys(account.view_public, view);
+
+  SETUP("One Account and one Webhook Database")
+  {
+    lws::db::test::cleanup_db on_scope_exit{};
+    lws::db::storage db = lws::db::test::get_fresh_db();
+    const lws::db::block_info last_block =
+      MONERO_UNWRAP(MONERO_UNWRAP(db.start_read()).get_last_block());
+    MONERO_UNWRAP(db.add_account(account, view));
+
+    const boost::uuids::uuid id = boost::uuids::random_generator{}();
+    {
+      lws::db::webhook_value value{
+        lws::db::webhook_dupsort{500, id},
+        lws::db::webhook_data{"http://the_url", "the_token", 3}
+      };
+      MONERO_UNWRAP(
+        db.add_webhook(lws::db::webhook_type::tx_confirmation, account, std::move(value))
+      );
+    }
+
+    SECTION("storage::get_webhooks()")
+    {
+      lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
+      const auto result = MONERO_UNWRAP(reader.get_webhooks());
+      EXPECT(result.size() == 1);
+      EXPECT(result[0].first.user == lws::db::account_id(1));
+      EXPECT(result[0].first.type == lws::db::webhook_type::tx_confirmation);
+      EXPECT(result[0].second.size() == 1);
+      EXPECT(result[0].second[0].first.payment_id == 500);
+      EXPECT(result[0].second[0].first.event_id == id);
+      EXPECT(result[0].second[0].second.url == "http://the_url");
+      EXPECT(result[0].second[0].second.token == "the_token");
+      EXPECT(result[0].second[0].second.confirmations == 3);
+    }
+
+    SECTION("storage::clear_webhooks(addresses)")
+    {
+      EXPECT(MONERO_UNWRAP(MONERO_UNWRAP(db.start_read()).get_webhooks()).size() == 1);
+      MONERO_UNWRAP(db.clear_webhooks({std::addressof(account), 1}));
+
+      lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
+      const auto result = MONERO_UNWRAP(reader.get_webhooks());
+      EXPECT(result.empty());
+    }
+
+    SECTION("storage::clear_webhooks(uuid)")
+    {
+      EXPECT(MONERO_UNWRAP(MONERO_UNWRAP(db.start_read()).get_webhooks()).size() == 1);
+      MONERO_UNWRAP(db.clear_webhooks({id}));
+
+      lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
+      const auto result = MONERO_UNWRAP(reader.get_webhooks());
+      EXPECT(result.empty());
+    }
+
+    SECTION("storage::update(...) one at a time")
+    {
+      lws::account full_account = lws::db::test::make_account(account, view);
+      full_account.updated(last_block.id);
+      EXPECT(add_out(full_account, last_block.id, 500));
+
+      const std::vector<lws::db::output> outs = full_account.outputs();
+      EXPECT(outs.size() == 1);
+
+      lws::db::block_info head = last_block;
+      for (unsigned i = 0; i < 1; ++i)
+      {
+        crypto::hash chain[2] = {head.hash, crypto::rand<crypto::hash>()};
+
+        auto updated = db.update(head.id, chain, {std::addressof(full_account), 1});
+        EXPECT(!updated.has_error());
+        EXPECT(updated->first == 1);
+        if (i < 3)
+        {
+          EXPECT(updated->second.size() == 1);
+          EXPECT(updated->second[0].key.user == lws::db::account_id(1));
+          EXPECT(updated->second[0].key.type == lws::db::webhook_type::tx_confirmation);
+          EXPECT(updated->second[0].value.first.payment_id == 500);
+          EXPECT(updated->second[0].value.first.event_id == id);
+          EXPECT(updated->second[0].value.second.url == "http://the_url");
+          EXPECT(updated->second[0].value.second.token == "the_token");
+          EXPECT(updated->second[0].value.second.confirmations == i + 1);
+
+          EXPECT(updated->second[0].tx_info.link == outs[0].link);
+          EXPECT(updated->second[0].tx_info.spend_meta.id == outs[0].spend_meta.id);
+          EXPECT(updated->second[0].tx_info.pub == outs[0].pub);
+          EXPECT(updated->second[0].tx_info.payment_id.short_ == outs[0].payment_id.short_);
+        }
+        else
+          EXPECT(updated->second.empty());
+
+        full_account.updated(head.id);
+        head = {lws::db::block_id(lmdb::to_native(head.id) + 1), chain[1]};
+      }
+    }
+
+    SECTION("storage::update(...) all at once")
+    {
+      const crypto::hash chain[5] = {
+        last_block.hash,
+        crypto::rand<crypto::hash>(),
+        crypto::rand<crypto::hash>(),
+        crypto::rand<crypto::hash>(),
+        crypto::rand<crypto::hash>()
+      };
+
+      lws::account full_account = lws::db::test::make_account(account, view);
+      full_account.updated(last_block.id);
+      EXPECT(add_out(full_account, last_block.id, 500));
+
+      const std::vector<lws::db::output> outs = full_account.outputs();
+      EXPECT(outs.size() == 1);
+
+      const auto updated = db.update(last_block.id, chain, {std::addressof(full_account), 1});
+      EXPECT(!updated.has_error());
+      EXPECT(updated->first == 1);
+      EXPECT(updated->second.size() == 3);
+
+      for (unsigned i = 0; i < 3; ++i)
+      {
+        EXPECT(updated->second[i].key.user == lws::db::account_id(1));
+        EXPECT(updated->second[i].key.type == lws::db::webhook_type::tx_confirmation);
+        EXPECT(updated->second[i].value.first.payment_id == 500);
+        EXPECT(updated->second[i].value.first.event_id == id);
+        EXPECT(updated->second[i].value.second.url == "http://the_url");
+        EXPECT(updated->second[i].value.second.token == "the_token");
+        EXPECT(updated->second[i].value.second.confirmations == i + 1);
+
+        EXPECT(updated->second[i].tx_info.link == outs[0].link);
+        EXPECT(updated->second[i].tx_info.spend_meta.id == outs[0].spend_meta.id);
+        EXPECT(updated->second[i].tx_info.pub == outs[0].pub);
+        EXPECT(updated->second[i].tx_info.payment_id.short_ == outs[0].payment_id.short_);
+      }
+    }
+  }
+}

--- a/tests/unit/rpc/CMakeLists.txt
+++ b/tests/unit/rpc/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020, The Monero Project
+# Copyright (c) 2022-2023, The Monero Project
 #
 # All rights reserved.
 #
@@ -26,9 +26,15 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set(monero-lws-db_sources account.cpp data.cpp storage.cpp string.cpp)
-set(monero-lws-db_headers account.h data.h fwd.h storage.h string.h)
-
-add_library(monero-lws-db ${monero-lws-db_sources} ${monero-lws-db_headers})
-target_include_directories(monero-lws-db PUBLIC "${LMDB_INCLUDE}")
-target_link_libraries(monero-lws-db monero::libraries monero-lws-common monero-lws-wire-msgpack ${LMDB_LIB_PATH})
+add_library(monero-lws-unit-rpc OBJECT admin.test.cpp)
+target_link_libraries(
+  monero-lws-unit-rpc
+  monero-lws-unit-db
+  monero-lws-unit-framework
+  monero-lws-common
+  monero-lws-db
+  monero-lws-rpc
+  monero-lws-wire-json
+  monero::libraries
+)
+#add_test(monero-lws-unit)

--- a/tests/unit/rpc/admin.test.cpp
+++ b/tests/unit/rpc/admin.test.cpp
@@ -1,0 +1,167 @@
+// Copyright (c) 2023, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "framework.test.h"
+
+#include <boost/range/algorithm/equal.hpp>
+#include "db/storage.test.h"
+#include "db/string.h"
+#include "error.h"
+#include "hex.h" // monero/contrib/epee/include
+#include "rpc/admin.h"
+#include "wire/json.h"
+
+namespace
+{
+  constexpr const char address_str[] =
+    u8"42ui2zRV3KBKgHPnQHDZu7WFc397XmhEjL9e6UnSpyHiKh4vydo7atvaQDSDKYPoCb51GQZc7hZZvDrJM7JCyuYqHHbshVn";
+  constexpr const char view_str[] =
+    u8"9ec001644f8d79ecb368083e48e7efb5a48b3563c9a78ba497874fd58285330d";
+
+  template<typename T>
+  expect<epee::byte_slice> call_endpoint(lws::db::storage disk, std::string json)
+  {
+    using request_type = typename T::request;
+    expect<request_type> req = wire::json::from_bytes<request_type>(std::move(json));
+    if (!req)
+      return req.error();
+    wire::json_slice_writer out{};
+    MONERO_CHECK(T{}(out, std::move(disk), std::move(*req)));
+    return out.take_bytes();
+  }
+}
+
+LWS_CASE("rpc::admin")
+{
+  lws::db::account_address account = MONERO_UNWRAP(lws::db::address_string(address_str));
+  crypto::secret_key view{};
+  EXPECT(epee::from_hex::to_buffer(epee::as_mut_byte_span(unwrap(unwrap(view))), view_str));
+
+  SETUP("One Account One Webhook Database")
+  {
+    lws::db::test::cleanup_db on_scope_exit{};
+    lws::db::storage db = lws::db::test::get_fresh_db();
+    const lws::db::block_info last_block =
+      MONERO_UNWRAP(MONERO_UNWRAP(db.start_read()).get_last_block());
+    MONERO_UNWRAP(db.add_account(account, view));
+
+    boost::uuids::uuid id{};
+    epee::byte_slice id_str{};
+    expect<epee::byte_slice> result{lws::error::configuration};
+    {
+      std::string add_json_str{};
+      add_json_str.append(u8"{\"url\":\"http://the_url\", \"token\":\"the_token\",");
+      add_json_str.append(u8"\"address\":\"").append(address_str).append(u8"\",");
+      add_json_str.append(u8"\"payment_id\":\"deadbeefdeadbeef\",");
+      add_json_str.append(u8"\"type\":\"tx-confirmation\",\"confirmations\":3}");
+      result = call_endpoint<lws::rpc::webhook_add_>(db.clone(), std::move(add_json_str));
+      EXPECT(!result.has_error());
+    }
+
+    {
+      static constexpr const char begin[] =
+        u8"{\"payment_id\":\"deadbeefdeadbeef\",\"event_id\":\"";
+      epee::byte_slice begin_ = result->take_slice(sizeof(begin) - 1);
+      EXPECT(boost::range::equal(std::string{begin}, begin_));
+    }
+    {
+      id_str = result->take_slice(32);
+      const boost::string_ref id_hex{
+        reinterpret_cast<const char*>(id_str.data()), id_str.size()
+      };
+      EXPECT(epee::from_hex::to_buffer(epee::as_mut_byte_span(id), id_hex));
+    }
+
+    SECTION("webhook_add")
+    {
+      static constexpr const char end[] =
+        u8"\",\"token\":\"the_token\",\"confirmations\":3,\"url\":\"http://the_url\"}";
+      EXPECT(boost::range::equal(std::string{end}, *result));
+      EXPECT(MONERO_UNWRAP(MONERO_UNWRAP(db.start_read()).get_webhooks()).size() == 1);
+    }
+
+    SECTION("webhook_delete_uuid")
+    {
+      EXPECT(MONERO_UNWRAP(MONERO_UNWRAP(db.start_read()).get_webhooks()).size() == 1);
+      std::string delete_json_str{};
+      delete_json_str.append(u8"{\"addresses\":[\"");
+      delete_json_str.append(address_str);
+      delete_json_str.append(u8"\"]}");
+
+      expect<epee::byte_slice> result2 =
+        call_endpoint<lws::rpc::webhook_delete_>(db.clone(), std::move(delete_json_str));
+      EXPECT(!result2.has_error());
+      EXPECT(boost::range::equal(std::string{u8"{}"}, *result2));
+      EXPECT(MONERO_UNWRAP(MONERO_UNWRAP(db.start_read()).get_webhooks()).empty());
+    }
+
+    SECTION("webhook_delete_uuid")
+    {
+      EXPECT(MONERO_UNWRAP(MONERO_UNWRAP(db.start_read()).get_webhooks()).size() == 1);
+      std::string delete_json_str{};
+      delete_json_str.append(u8"{\"event_ids\":[\"");
+      delete_json_str.append(reinterpret_cast<const char*>(id_str.data()), id_str.size());
+      delete_json_str.append(u8"\"]}");
+
+      expect<epee::byte_slice> result2 =
+        call_endpoint<lws::rpc::webhook_del_uuid_>(db.clone(), std::move(delete_json_str));
+      EXPECT(!result2.has_error());
+      EXPECT(boost::range::equal(std::string{u8"{}"}, *result2));
+      EXPECT(MONERO_UNWRAP(MONERO_UNWRAP(db.start_read()).get_webhooks()).empty());
+    }
+
+    SECTION("webhook_list")
+    {
+      wire::json_slice_writer out{};
+      EXPECT(lws::rpc::webhook_list(out, db.clone()));
+      expect<epee::byte_slice> bytes = out.take_bytes();
+      EXPECT(!bytes.has_error());
+
+      {
+        static constexpr const char begin[] =
+          u8"{\"webhooks\":[{\"key\":{\"user\":1,\"type\":\"tx-confirmation\"}"
+            ",\"value\":[{\"payment_id\":\"deadbeefdeadbeef\",\"event_id\":\"";
+        epee::byte_slice begin_ = bytes->take_slice(sizeof(begin) - 1);
+        EXPECT(boost::range::equal(std::string{begin}, begin_));
+      }
+      {
+        boost::uuids::uuid id_{};
+        epee::byte_slice id_str_ = bytes->take_slice(32);
+        const boost::string_ref id_hex{
+          reinterpret_cast<const char*>(id_str_.data()), id_str_.size()
+        };
+        EXPECT(epee::from_hex::to_buffer(epee::as_mut_byte_span(id_), id_hex));
+        EXPECT(id_ == id);
+      }
+      {
+        static constexpr const char end[] =
+          u8"\",\"token\":\"the_token\",\"confirmations\":3,\"url\":\"http://the_url\"}]}]}";
+        EXPECT(boost::range::equal(std::string{end}, *bytes));
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a "still-in-progress" PR/patch to add webhook support to `monero-lws-daemon`. I would like to add some unit testing before officially merging this PR. There's also some trivial stuff I noticed - wrong copyright dates for instance. This branch should be considered "beta" - the expectation is that is should be near usable in a production environment.

This PR currently supports "`tx-confirmation`" only - a Monero address + (optional) payment_id is sent via REST, along with a provided URL. The URL is then invoked 1+ times when an output for that address+payment_id pair is found on the blockchain. The number of URL invokes is determine in the original API call - the user specifies the number of confirmations needed (defaults to 1).

Please respond to this PR if you need help using this new feature. I **will** perform force pushes on this branch to keep the history lean and mean so be warned about that.

A quick example (which is from the documentation):

#### Initial user invoke
```json
{
  "auth": "f50922f5fcd186eaa4bd7070b8072b66fea4fd736f06bd82df702e2314187d09",
  "params": {
    "type": "tx-confirmation",
    "url": "http://127.0.0.1:7000",
    "payment_id": "df034c176eca3296",
    "token": "1234",
    "address": "9uTcr6T9GURRt7UADQc2rhjg5oMYBDyoQ5jgx8nAvVvs757WwDkc2vHLPJhwZfCnfVdnWNvuuKzJe8eMVTKwadYzBrYRG5j"
  }
}
```

### Initial Response
```json
{
  "payment_id": "df034c176eca3296",
  "event_id": "fa10a4db485145f1a24dc09c19a79d43",
  "token": "1234",
  "confirmations": 1,
  "url": "http://127.0.0.1:7000"
}
```

### Triggered Response (to specified URL)
```json
{
  "event": "tx-confirmation",
  "payment_id": "df034c176eca3296",
  "token": "1234",
  "confirmations": 1,
  "id": "fa10a4db485145f1a24dc09c19a79d43",
  "tx_info": {
    "id": {
      "high": 0,
      "low": 5550229
    },
    "block": 2192100,
    "index": 0,
    "amount": 4949570000,
    "timestamp": 1678324181,
    "tx_hash": "901f9a2a919b6312131537ff6117d56ce2c0dc1f1341b845d7667299e1ef892f",
    "tx_prefix_hash": "89685cb7acb836fde30fae8be5d8b884e92706df086960d0508e146979ef80dc",
    "tx_public": "54c153792e47c1da8ceb3979560c424c1928b7b4a089c1c8b3ce99c563e1d240",
    "rct_mask": "f3449407dc3721299b5309c0c336a17daeebce55165ddd447ba28bbd1f46c201",
    "payment_id": "df034c176eca3296",
    "unlock_time": 0,
    "mixin_count": 15,
    "coinbase": false
  }
}
```
