### PR TITLE
Updare wire:: to closer to Monero build

### DIFF
--- a/src/admin_main.cpp
+++ b/src/admin_main.cpp
@@ -31,6 +31,7 @@
 #include <boost/program_options/parsers.hpp>
 #include <boost/program_options/variables_map.hpp>
 #include <boost/range/adaptor/filtered.hpp>
+#include <boost/range/adaptor/transformed.hpp>
 #include <cassert>
 #include <cstring>
 #include <iostream>
@@ -54,6 +55,8 @@
 #include "wire/crypto.h"
 #include "wire/filters.h"
 #include "wire/json/write.h"
+#include "wire/wrapper/array.h"
+#include "wire/wrappers_impl.h"
 
 namespace
 {
@@ -79,7 +82,7 @@ namespace
     const auto transform = [] (lws::db::account src)
     { return admin_display<lws::db::account>{std::move(src)}; };
 
-    wire::array(dest, (source.value | boost::adaptors::filtered(filter)), transform);
+    wire_write::bytes(dest, wire::array(source.value | boost::adaptors::filtered(filter) | boost::adaptors::transformed(transform)));
   }
 
   template<typename F, typename... T>

--- a/src/db/storage.cpp
+++ b/src/db/storage.cpp
@@ -59,6 +59,8 @@
 #include "wire/filters.h"
 #include "wire/json.h"
 #include "wire/vector.h"
+#include "wire/wrapper/array.h"
+#include "wire/wrappers_impl.h"
 
 namespace lws
 {
@@ -746,7 +748,7 @@ namespace db
   {
     wire::object(dest,
       wire::field("scan_height", self.first),
-      wire::field("accounts", wire::as_array(std::move(self.second)))
+      wire::field("accounts", wire::array(std::move(self.second)))
     );
   }
 
@@ -839,10 +841,10 @@ namespace db
     const wire::as_array_filter<toggle_key_output> toggle_keys_filter{{show_keys}};
     wire::json_stream_writer json_stream{out};
     wire::object(json_stream,
-      wire::field(blocks.name, wire::as_array(reverse(*blocks_partial))),
+      wire::field(blocks.name, wire::array(reverse(*blocks_partial))),
       wire::field(accounts.name, wire::as_object(accounts_stream->make_range(), wire::enum_as_string, toggle_keys_filter)),
       wire::field(accounts_by_address.name, wire::as_object(transform(accounts_ba_stream->make_range(), address_as_key))),
-      wire::field(accounts_by_height.name, wire::as_array(accounts_bh_stream->make_range())),
+      wire::field(accounts_by_height.name, wire::array(accounts_bh_stream->make_range())),
       wire::field(outputs.name, wire::as_object(outputs_stream->make_range(), wire::as_integer, wire::as_array)),
       wire::field(spends.name, wire::as_object(spends_stream->make_range(), wire::as_integer, wire::as_array)),
       wire::field(images.name, wire::as_object(images_stream->make_range(), output_id_key{}, wire::as_array)),

--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -661,14 +661,19 @@ namespace lws
       using request = typename E::request;
       using response = typename E::response;
 
-      expect<request> req = wire::json::from_bytes<request>(std::move(root));
-      if (!req)
-        return req.error();
+      request req{};
+      std::error_code error = wire::json::from_bytes(std::move(root), req);
+      if (error)
+        return error;
 
-      expect<response> resp = E::handle(std::move(*req), std::move(disk), gclient);
+      expect<response> resp = E::handle(std::move(req), std::move(disk), gclient);
       if (!resp)
         return resp.error();
-      return wire::json::to_bytes<response>(*resp);
+
+      epee::byte_slice out{};
+      if ((error = wire::json::to_bytes(out, *resp)))
+        return error;
+      return {std::move(out)};
     }
 
     template<typename T>
@@ -693,9 +698,13 @@ namespace lws
     expect<epee::byte_slice> call_admin(std::string&& root, db::storage disk, const rpc::client&, const bool disable_auth)
     {
       using request = typename E::request;
-      expect<admin<request>> req = wire::json::from_bytes<admin<request>>(std::move(root));
-      if (!req)
-        return req.error();
+      
+      admin<request> req{};
+      {
+        const std::error_code error = wire::json::from_bytes(std::move(root), req);
+        if (error)
+          return error;
+      }
 
       if (!disable_auth)
       {
@@ -703,7 +712,7 @@ namespace lws
           return {error::account_not_found};
 
         db::account_address address{};
-        if (!crypto::secret_key_to_public_key(*(req->auth), address.view_public))
+        if (!crypto::secret_key_to_public_key(req.auth, address.view_public))
           return {error::crypto_failure};
 
         auto reader = disk.start_read();
@@ -719,8 +728,8 @@ namespace lws
       }
 
       wire::json_slice_writer dest{};
-      MONERO_CHECK(E{}(dest, std::move(disk), std::move(req->params)));
-      return dest.take_bytes();
+      MONERO_CHECK(E{}(dest, std::move(disk), req.params));
+      return epee::byte_slice{dest.take_sink()};
     }
 
     struct endpoint

--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -708,11 +708,11 @@ namespace lws
 
       if (!disable_auth)
       {
-        if (!req->auth)
+        if (!req.auth)
           return {error::account_not_found};
 
         db::account_address address{};
-        if (!crypto::secret_key_to_public_key(req.auth, address.view_public))
+        if (!crypto::secret_key_to_public_key(*(req.auth), address.view_public))
           return {error::crypto_failure};
 
         auto reader = disk.start_read();
@@ -728,7 +728,7 @@ namespace lws
       }
 
       wire::json_slice_writer dest{};
-      MONERO_CHECK(E{}(dest, std::move(disk), req.params));
+      MONERO_CHECK(E{}(dest, std::move(disk), std::move(req.params)));
       return epee::byte_slice{dest.take_sink()};
     }
 

--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -30,4 +30,4 @@ set(monero-lws-rpc_sources admin.cpp client.cpp daemon_pub.cpp daemon_zmq.cpp li
 set(monero-lws-rpc_headers admin.h client.h daemon_pub.h daemon_zmq.h fwd.h json.h light_wallet.h rates.h)
 
 add_library(monero-lws-rpc ${monero-lws-rpc_sources} ${monero-lws-rpc_headers})
-target_link_libraries(monero-lws-rpc monero::libraries monero-lws-wire-json)
+target_link_libraries(monero-lws-rpc monero::libraries monero-lws-wire-json monero-lws-wire-wrapper)

--- a/src/rpc/daemon_zmq.cpp
+++ b/src/rpc/daemon_zmq.cpp
@@ -32,6 +32,7 @@
 #include "rpc/message_data_structs.h" // monero/src
 #include "wire/crypto.h"
 #include "wire/json.h"
+#include "wire/wrapper/variant.h"
 #include "wire/vector.h"
 
 namespace
@@ -103,14 +104,13 @@ namespace cryptonote
   }
   static void read_bytes(wire::json_reader& source, tx_out& self)
   {
+    auto variant = wire::variant(std::ref(self.target));
     wire::object(source,
       WIRE_FIELD(amount),
-      wire::variant_field("transaction output variant", std::ref(self.target),
-        wire::option<txout_to_key>{"to_key"},
-        wire::option<txout_to_tagged_key>{"to_tagged_key"},
-        wire::option<txout_to_script>{"to_script"},
-        wire::option<txout_to_scripthash>{"to_scripthash"}
-      )
+      WIRE_OPTION("to_key", txout_to_key, variant),
+      WIRE_OPTION("to_tagged_key", txout_to_tagged_key, variant),
+      WIRE_OPTION("to_script", txout_to_script, variant),
+      WIRE_OPTION("to_scripthash", txout_to_scripthash, variant)
     );
   }
 
@@ -132,13 +132,12 @@ namespace cryptonote
   }
   static void read_bytes(wire::json_reader& source, txin_v& self)
   {
+    auto variant = wire::variant(std::ref(self));
     wire::object(source,
-      wire::variant_field("transaction input variant", std::ref(self),
-        wire::option<txin_to_key>{"to_key"},
-        wire::option<txin_gen>{"gen"},
-        wire::option<txin_to_script>{"to_script"},
-        wire::option<txin_to_scripthash>{"to_scripthash"}
-      )
+      WIRE_OPTION("to_key", txin_to_key, variant),
+      WIRE_OPTION("gen", txin_gen, variant),
+      WIRE_OPTION("to_script", txin_to_script, variant),
+      WIRE_OPTION("to_scripthash", txin_to_scripthash, variant)
     );
   }
 

--- a/src/rpc/light_wallet.cpp
+++ b/src/rpc/light_wallet.cpp
@@ -28,6 +28,7 @@
 #include "light_wallet.h"
 
 #include <boost/range/adaptor/indexed.hpp>
+#include <boost/range/adaptor/transformed.hpp>
 #include <ctime>
 #include <limits>
 #include <stdexcept>
@@ -44,6 +45,8 @@
 #include "wire/json.h"
 #include "wire/traits.h"
 #include "wire/vector.h"
+#include "wire/wrapper/array.h"
+#include "wire/wrappers_impl.h"
 
 namespace
 {
@@ -261,7 +264,7 @@ namespace lws
       WIRE_FIELD_COPY(start_height),
       WIRE_FIELD_COPY(transaction_height),
       WIRE_FIELD_COPY(blockchain_height),
-      wire::field("transactions", wire::as_array(boost::adaptors::index(self.transactions)))
+      wire::field("transactions", wire::array(boost::adaptors::index(self.transactions)))
     );
   }
 
@@ -297,7 +300,7 @@ namespace lws
       WIRE_FIELD_COPY(per_byte_fee),
       WIRE_FIELD_COPY(fee_mask),
       WIRE_FIELD_COPY(amount),
-      wire::field("outputs", wire::as_array(std::cref(self.outputs), expand))
+      wire::field("outputs", wire::array(boost::adaptors::transform(self.outputs, expand)))
     );
   }
 

--- a/src/rpc/rates.cpp
+++ b/src/rpc/rates.cpp
@@ -72,7 +72,11 @@ namespace lws
 
     expect<lws::rates> crypto_compare_::operator()(std::string&& body) const
     {
-      return wire::json::from_bytes<lws::rates>(std::move(body));
+      lws::rates out{};
+      const std::error_code error = wire::json::from_bytes(std::move(body), out);
+      if (error)
+        return error;
+      return {std::move(out)};
     }
   } // rpc
 } // lws

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -158,9 +158,15 @@ namespace lws
       if (uri.empty())
         uri = "/";
 
+      epee::byte_slice bytes{};
       const std::string& url = event.value.second.url;
-      const epee::byte_slice bytes = wire::json::to_bytes(event);
+      const std::error_code json_error = wire::json::to_bytes(bytes, event);
       const net::http::http_response_info* info = nullptr;
+      if (json_error)
+      {
+        MERROR("Failed to generate webhook JSON: " << json_error.message());
+        return;
+      }
 
       MINFO("Sending webhook to " << url);
       if (!client.invoke(uri, "POST", std::string{bytes.begin(), bytes.end()}, timeout, std::addressof(info), params))

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -460,7 +460,12 @@ namespace lws
             MONERO_THROW(resp.error(), "Failed to retrieve blocks from daemon");
           }
 
-          auto fetched = MONERO_UNWRAP(wire::json::from_bytes<rpc::json<rpc::get_blocks_fast>::response>(std::move(*resp)));
+          rpc::json<rpc::get_blocks_fast>::response fetched{};
+          {
+            const std::error_code error = wire::json::from_bytes(std::move(*resp), fetched);
+            if (error)
+              throw std::system_error{error};
+          }
           if (fetched.result.blocks.empty())
             throw std::runtime_error{"Daemon unexpectedly returned zero blocks"};
 

--- a/src/wire/CMakeLists.txt
+++ b/src/wire/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, The Monero Project
+# Copyright (c) 2020-2023, The Monero Project
 #
 # All rights reserved.
 #
@@ -35,3 +35,4 @@ target_link_libraries(monero-lws-wire PRIVATE monero::libraries)
 
 add_subdirectory(json)
 add_subdirectory(msgpack)
+add_subdirectory(wrapper)

--- a/src/wire/crypto.h
+++ b/src/wire/crypto.h
@@ -47,6 +47,7 @@ namespace wire
 {
   WIRE_DECLARE_BLOB(crypto::ec_scalar);
   WIRE_DECLARE_BLOB(crypto::hash);
+  WIRE_DECLARE_BLOB(crypto::hash8);
   WIRE_DECLARE_BLOB(crypto::key_derivation);
   WIRE_DECLARE_BLOB(crypto::key_image);
   WIRE_DECLARE_BLOB(crypto::public_key);

--- a/src/wire/crypto.h
+++ b/src/wire/crypto.h
@@ -45,48 +45,12 @@ namespace crypto
 
 namespace wire
 {
-  template<>
-  struct is_blob<crypto::ec_scalar>
-    : std::true_type
-  {};
-
-  template<>
-  struct is_blob<crypto::hash8>
-    : std::true_type
-  {};
-
-  template<>
-  struct is_blob<crypto::hash>
-    : std::true_type
-  {};
-
-  template<>
-  struct is_blob<crypto::key_derivation>
-    : std::true_type
-  {};
-
-  template<>
-  struct is_blob<crypto::key_image>
-    : std::true_type
-  {};
-
-  template<>
-  struct is_blob<crypto::public_key>
-    : std::true_type
-  {};
-
-  template<>
-  struct is_blob<crypto::signature>
-    : std::true_type
-  {};
-
-  template<>
-  struct is_blob<rct::key>
-    : std::true_type
-  {};
-
-  template<>
-  struct is_blob<crypto::view_tag>
-    : std::true_type
-  {};
+  WIRE_DECLARE_BLOB(crypto::ec_scalar);
+  WIRE_DECLARE_BLOB(crypto::hash);
+  WIRE_DECLARE_BLOB(crypto::key_derivation);
+  WIRE_DECLARE_BLOB(crypto::key_image);
+  WIRE_DECLARE_BLOB(crypto::public_key);
+  WIRE_DECLARE_BLOB(crypto::signature);
+  WIRE_DECLARE_BLOB(crypto::view_tag);
+  WIRE_DECLARE_BLOB(rct::key);
 }

--- a/src/wire/field.h
+++ b/src/wire/field.h
@@ -55,24 +55,61 @@
 
 namespace wire
 {
-  template<typename T>
-  struct unwrap_reference
+  /*! Links `name` to a `value` and index `I` for object serialization.
+
+  `value_type` is `T` with optional `std::reference_wrapper` removed.
+  `value_type` needs a `read_bytes` function when parsing with a
+  `wire::reader` - see `read.h` for more info. `value_type` needs a
+  `write_bytes` function when parsing with a `wire::writer` - see `write.h`
+  for more info.
+
+  Any `value_type` where `is_optional_on_empty<value_type> == true`, will
+  automatically be converted to an optional field iff `value_type` has an
+  `empty()` method that returns `true`. The old output engine omitted fields
+  when an array was empty, and the standard input macro would ignore the
+  `false` return for the missing field. For compability reasons, the
+  input/output engine here matches that behavior. See `wrapper/array.h` to
+  enforce a required field even when the array is empty or specialize the
+  `is_optional_on_empty` trait. Only new fields should use this behavior.
+
+  Additional concept requirements for `value_type` when `Required == false`:
+    * must have an `operator*()` function.
+    * must have a conversion to bool function that returns true when
+      `operator*()` is safe to call (and implicitly when the associated field
+      should be written as opposed to skipped/omitted).
+  Additional concept requirements for `value_type` when `Required == false`
+  when reading:
+    * must have an `emplace()` method that ensures `operator*()` is safe to call.
+    * must have a `reset()` method to indicate a field was skipped/omitted.
+
+  If a standard type needs custom serialization, one "trick":
+  ```
+  struct custom_tag{};
+  void read_bytes(wire::reader&, boost::fusion::pair<custom_tag, std::string&>)
+  { ... }
+  void write_bytes(wire::writer&, boost::fusion::pair<custom_tag, const std::string&>)
+  { ... }
+
+  template<typename F, typename T>
+  void object_map(F& format, T& self)
   {
-    using type = T;
-  };
+    wire::object(format,
+      wire::field("foo", boost::fusion::make_pair<custom_tag>(std::ref(self.foo)))
+    );
+  }
+  ```
 
-  template<typename T>
-  struct unwrap_reference<std::reference_wrapper<T>>
-  {
-    using type = T;
-  };
-
-
-  //! Links `name` to a `value` for object serialization.
+  Basically each input/output format needs a unique type so that the compiler
+  knows how to "dispatch" the read/write calls. */
   template<typename T, bool Required, unsigned I = 0>
   struct field_
   {
-    using value_type = typename unwrap_reference<T>::type;
+    using value_type = unwrap_reference_t<T>;
+
+    //! \return True if field is forced optional when `get_value().empty()`.
+    static constexpr bool optional_on_empty() noexcept
+    { return is_optional_on_empty<value_type>::value; }
+
     static constexpr bool is_required() noexcept { return Required; }
     static constexpr std::size_t count() noexcept { return 1; }
     static constexpr unsigned id() noexcept { return I; }
@@ -84,17 +121,8 @@ namespace wire
     const char* name;
     T value;
 
-    //! \return `value` with `std::reference_wrapper` removed.
-    constexpr const value_type& get_value() const noexcept
-    {
-      return value;
-    }
-
-    //! \return `value` with `std::reference_wrapper` removed.
-    value_type& get_value() noexcept
-    {
-      return value;
-    }
+    constexpr const value_type& get_value() const noexcept { return value; }
+    value_type& get_value() noexcept { return value; }
   };
 
   //! Links `name` to `value`. Use `std::ref` if de-serializing.
@@ -109,76 +137,6 @@ namespace wire
   constexpr inline field_<T, false, I> optional_field(const char* name, T value)
   {
     return {name, std::move(value)};
-  }
-
-
-  //! Links `name` to a type `T` for variant serialization.
-  template<typename T>
-  struct option
-  {
-    static constexpr unsigned id() noexcept { return 0; }
-    const char* name;
-  };
-
-  //! \return Name associated with type `T` for variant `field`.
-  template<typename T, typename U>
-  constexpr const char* get_option_name(const U& field) noexcept
-  {
-    return static_cast< const option<T>& >(field).name;
-  }
-
-  //! Links each type in a variant to a string key.
-  template<typename T, bool Required, typename... U>
-  struct variant_field_ : option<U>...
-  {
-    using value_type = typename unwrap_reference<T>::type;
-    static constexpr bool is_required() noexcept { return Required; }
-    static constexpr std::size_t count() noexcept { return sizeof...(U); }
-
-    constexpr variant_field_(const char* name, T value, option<U>... opts)
-      : option<U>(std::move(opts))..., name(name), value(std::move(value))
-    {}
-
-    const char* name;
-    T value;
-
-    constexpr const value_type& get_value() const noexcept
-    {
-      return value;
-    }
-
-    value_type& get_value() noexcept
-    {
-      return value;
-    }
-
-    template<typename V>
-    struct wrap
-    {
-      using result_type = void;
-
-      variant_field_ self;
-      V visitor;
-
-      template<typename X>
-      void operator()(const X& value) const
-      {
-        visitor(get_option_name<X>(self), value);
-      }
-    };
-
-    template<typename V>
-    void visit(V visitor) const
-    {
-      apply_visitor(wrap<V>{*this, std::move(visitor)}, get_value());
-    }
-  };
-
-  //! Links variant `value` to a unique name per type in `opts`. Use `std::ref` for `value` if de-serializing.
-  template<typename T, typename... U>
-  constexpr inline variant_field_<T, true, U...> variant_field(const char* name, T value, option<U>... opts)
-  {
-    return {name, std::move(value), std::move(opts)...};
   }
 
 
@@ -260,22 +218,14 @@ namespace wire
   template<typename T, unsigned I>
   inline constexpr bool available(const field_<T, true, I>& elem) noexcept
   {
+    /* The old output engine always skipped fields when it was an empty array,
+       this follows that behavior. See comments for `field_`. */
     return elem.is_required() || (elem.optional_on_empty() && !wire::empty(elem.get_value()));
   }
   template<typename T, unsigned I>
   inline bool available(const field_<T, false, I>& elem)
   {
     return bool(elem.get_value());
-  }
-  template<typename T, typename... U>
-  inline constexpr bool available(const variant_field_<T, true, U...>&) noexcept
-  {
-    return true;
-  }
-  template<typename T, typename... U>
-  inline constexpr bool available(const variant_field_<T, false, U...>& elem)
-  {
-    return elem != nullptr;
   }
 }
 

--- a/src/wire/field.h
+++ b/src/wire/field.h
@@ -114,10 +114,6 @@ namespace wire
     static constexpr std::size_t count() noexcept { return 1; }
     static constexpr unsigned id() noexcept { return I; }
 
-    //! \return True if field is forced optional when `get_value().empty()`.
-    static constexpr bool optional_on_empty() noexcept
-    { return is_optional_on_empty<value_type>::value; }
-
     const char* name;
     T value;
 

--- a/src/wire/filters.h
+++ b/src/wire/filters.h
@@ -27,10 +27,12 @@
 
 #pragma once
 
+#include <boost/range/adaptor/transformed.hpp>
 #include <cassert>
 #include <type_traits>
 
 #include "lmdb/util.h"
+#include "wire/wrapper/array.h"
 
 // These functions are to be used with `wire::as_object(...)` key filtering
 

--- a/src/wire/filters.h
+++ b/src/wire/filters.h
@@ -27,12 +27,10 @@
 
 #pragma once
 
-#include <boost/range/adaptor/transformed.hpp>
 #include <cassert>
 #include <type_traits>
 
 #include "lmdb/util.h"
-#include "wire/wrapper/array.h"
 
 // These functions are to be used with `wire::as_object(...)` key filtering
 

--- a/src/wire/json/base.h
+++ b/src/wire/json/base.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, The Monero Project
+// Copyright (c) 2022-2023, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are
@@ -28,23 +28,31 @@
 #pragma once
 
 #include <string>
+#include <system_error>
 
-#include "byte_slice.h"
-#include "common/expect.h"
+#include "byte_stream.h"
 #include "wire/json/fwd.h"
+#include "wire/read.h"
+#include "wire/write.h"
 
 namespace wire
 {
   struct json
   {
     using input_type = json_reader;
-    using output_type = json_writer;
+    using output_type = json_slice_writer;
 
     template<typename T>
-    static expect<T> from_bytes(std::string&& source);
+    static std::error_code from_bytes(std::string&& source, T& dest)
+    {
+      return wire_read::from_bytes<input_type>(std::move(source), dest);
+    }
 
-    template<typename T>
-    static epee::byte_slice to_bytes(const T& source);
+    template<typename T, typename U>
+    static std::error_code to_bytes(T& dest, const U& source)
+    {
+      return wire_write::to_bytes<output_type>(dest, source);
+    }
   };
 }
 

--- a/src/wire/json/fwd.h
+++ b/src/wire/json/fwd.h
@@ -40,6 +40,7 @@ namespace wire
 {
   struct json;
   class json_reader;
+  class json_slice_writer;
   class json_writer;
 }
 

--- a/src/wire/json/read.h
+++ b/src/wire/json/read.h
@@ -107,28 +107,4 @@ namespace wire
         \return True if another value to read. */
     bool key(epee::span<const key_map> map, std::size_t&, std::size_t& index) override final;
   };
-
-
-  // Don't call `read` directly in this namespace, do it from `wire_read`.
-
-  template<typename T>
-  expect<T> json::from_bytes(std::string&& bytes)
-  {
-    json_reader source{std::move(bytes)};
-    return wire_read::to<T>(source);
-  }
-
-  // specialization prevents type "downgrading" to base type in cpp files
-
-  template<typename T>
-  inline void array(json_reader& source, T& dest)
-  {
-    wire_read::array(source, dest);
-  }
-
-  template<typename... T>
-  inline void object(json_reader& source, T... fields)
-  {
-    wire_read::object(source, wire_read::tracker<T>{std::move(fields)}...);
-  }
 } // wire

--- a/src/wire/json/write.cpp
+++ b/src/wire/json/write.cpp
@@ -54,10 +54,11 @@ namespace wire
     if (!formatter_.IsComplete())
       throw std::logic_error{"json_writer::take_json() failed with incomplete JSON tree"};
   }
-  epee::byte_slice json_writer::take_json()
+  epee::byte_stream json_writer::take_json()
   {
     check_complete();
-    epee::byte_slice out{std::move(bytes_)};
+    epee::byte_stream out{std::move(bytes_)};
+    bytes_.clear();
     formatter_.Reset(bytes_);
     return out;
   }

--- a/src/wire/msgpack/base.h
+++ b/src/wire/msgpack/base.h
@@ -36,13 +36,15 @@
 #include "byte_slice.h"
 #include "common/expect.h"
 #include "wire/msgpack/fwd.h"
+#include "wire/read.h"
+#include "wire/write.h"
 
 namespace wire
 {
   struct msgpack
   {
     using input_type = msgpack_reader;
-    using output_type = msgpack_writer;
+    using output_type = msgpack_slice_writer;
 
     //! Tags that do not require bitmask to identify
     enum class tag : std::uint8_t
@@ -162,12 +164,18 @@ namespace wire
     using object16 = type<std::uint16_t, tag::object16>;
     using object32 = type<std::uint32_t, tag::object32>;
     using object_types = std::tuple<object16, object32>;
-
+    
     template<typename T>
-    static expect<T> from_bytes(epee::byte_slice&& source);
+    static std::error_code from_bytes(epee::byte_slice&& source, T& dest)
+    {
+      return wire_read::from_bytes<input_type>(std::move(source), dest);
+    }
 
-    template<typename T>
-    static epee::byte_slice to_bytes(const T& source);
+    template<typename T, typename U>
+    static std::error_code to_bytes(T& dest, const U& source)
+    {
+      return wire_write::to_bytes<output_type>(dest, source);
+    }
   };
 }
 

--- a/src/wire/msgpack/fwd.h
+++ b/src/wire/msgpack/fwd.h
@@ -40,6 +40,7 @@ namespace wire
 {
   struct msgpack;
   class msgpack_reader;
+  class msgpack_slice_writer;
   class msgpack_writer;
 }
 

--- a/src/wire/msgpack/read.h
+++ b/src/wire/msgpack/read.h
@@ -137,28 +137,4 @@ namespace wire
         \return True if another value to read. */
     bool key(epee::span<const key_map> map, std::size_t&, std::size_t& index) override final;
   };
-
-
-  // Don't call `read` directly in this namespace, do it from `wire_read`.
-
-  template<typename T>
-  expect<T> msgpack::from_bytes(epee::byte_slice&& bytes)
-  {
-    msgpack_reader source{std::move(bytes)};
-    return wire_read::to<T>(source);
-  }
-
-  // specialization prevents type "downgrading" to base type in cpp files
-
-  template<typename T>
-  inline void array(msgpack_reader& source, T& dest)
-  {
-    wire_read::array(source, dest);
-  }
-
-  template<typename... T>
-  inline void object(msgpack_reader& source, T... fields)
-  {
-    wire_read::object(source, wire_read::tracker<T>{std::move(fields)}...);
-  }
 } // wire

--- a/src/wire/msgpack/write.cpp
+++ b/src/wire/msgpack/write.cpp
@@ -147,10 +147,10 @@ namespace wire
     if (expected_)
       throw std::logic_error{"msgpack_writer::take_msgpack() failed with incomplete tree"};
   }
-  epee::byte_slice msgpack_writer::take_msgpack()
+  epee::byte_stream msgpack_writer::take_msgpack()
   {
     check_complete();
-    epee::byte_slice out{std::move(bytes_)};
+    epee::byte_stream out{std::move(bytes_)};
     bytes_.clear();
     return out;
   }

--- a/src/wire/read.h
+++ b/src/wire/read.h
@@ -67,6 +67,9 @@ namespace wire
     //! \return Maximum read depth for both objects and arrays before erroring
     static constexpr std::size_t max_read_depth() noexcept { return 100; }
 
+    //! \return Assume delimited arrays in generic interface (some optimizations disabled)
+    static constexpr std::true_type delimited_arrays() noexcept { return {}; }
+
     reader() noexcept
       : depth_(0)
     {}
@@ -137,32 +140,25 @@ namespace wire
     void end_object() noexcept { decrement_depth(); }
   };
 
-  inline void read_bytes(reader& source, bool& dest)
-  {
-    dest = source.boolean();
-  }
+  template<typename R>
+  inline void read_bytes(R& source, bool& dest)
+  { dest = source.boolean(); }
 
-  inline void read_bytes(reader& source, double& dest)
-  {
-    dest = source.real();
-  }
+  template<typename R>
+  inline void read_bytes(R& source, double& dest)
+  { dest = source.real(); }
 
-  inline void read_bytes(reader& source, std::string& dest)
-  {
-    dest = source.string();
-  }
+  template<typename R>
+  inline void read_bytes(R& source, std::string& dest)
+  { dest = source.string(); }
 
   template<typename R>
   inline void read_bytes(R& source, std::vector<std::uint8_t>& dest)
-  {
-    dest = source.binary();
-  }
+  { dest = source.binary(); }
 
-  template<typename T>
-  inline enable_if<is_blob<T>::value> read_bytes(reader& source, T& dest)
-  {
-    source.binary(epee::as_mut_byte_span(dest));
-  }
+  template<typename R, typename T>
+  inline std::enable_if_t<is_blob<T>::value> read_bytes(R& source, T& dest)
+  { source.binary(epee::as_mut_byte_span(dest)); }
 
   namespace integer
   {
@@ -205,17 +201,17 @@ namespace wire
   }
 
   //! read all current and future signed integer types
-  template<typename T>
-  inline enable_if<std::is_signed<T>::value && std::is_integral<T>::value>
-  read_bytes(reader& source, T& dest)
+  template<typename R, typename T>
+  inline std::enable_if_t<std::is_signed<T>::value && std::is_integral<T>::value>
+  read_bytes(R& source, T& dest)
   {
     dest = integer::cast_signed<T>(source.integer());
   }
 
   //! read all current and future unsigned integer types
-  template<typename T>
-  inline enable_if<std::is_unsigned<T>::value && std::is_integral<T>::value>
-  read_bytes(reader& source, T& dest)
+  template<typename R, typename T>
+  inline std::enable_if_t<std::is_unsigned<T>::value && std::is_integral<T>::value>
+  read_bytes(R& source, T& dest)
   {
     dest = integer::cast_unsigned<T>(source.unsigned_integer());
   }
@@ -231,21 +227,27 @@ namespace wire_read
 
   [[noreturn]] void throw_exception(wire::error::schema code, const char* display, epee::span<char const* const> name_list);
 
+  template<typename R, typename T>
+  inline void bytes(R& source, T&& dest)
+  {
+    read_bytes(source, dest); // ADL (searches every associated namespace)
+  }
+
   //! \return `T` converted from `source` or error.
-  template<typename T, typename R>
-  inline expect<T> to(R& source)
+  template<typename R, typename T, typename U>
+  inline std::error_code from_bytes(T&& source, U& dest)
   {
     try
     {
-      T dest{};
-      read_bytes(source, dest);
-      source.check_complete();
-      return dest;
+      R in{std::forward<T>(source)};
+      bytes(in, dest);
+      in.check_complete();
     }
     catch (const wire::exception& e)
     {
       return e.code();
     }
+    return {};
   }
 
   template<typename R, typename T>
@@ -258,7 +260,7 @@ namespace wire_read
     std::size_t count = source.start_array();
 
     dest.clear();
-    dest.reserve(count);
+    wire::reserve(dest, count);
 
     bool more = count;
     while (more || !source.is_array_end(count))
@@ -272,31 +274,18 @@ namespace wire_read
     return source.end_array();
   }
 
-  // `unpack_variant_field` identifies which of the variant types was selected. starts with index-0
-
-  template<typename R, typename T>
-  inline void unpack_variant_field(std::size_t, R&, const T&)
-  {}
-
-  template<typename R, typename T, typename U, typename... X>
-  inline void unpack_variant_field(const std::size_t index, R& source, T& variant, const wire::option<U>& head, const wire::option<X>&... tail)
+  template<typename T, unsigned I>
+  inline void reset_field(wire::field_<T, true, I>& dest)
   {
-    if (index)
-      unpack_variant_field(index - 1, source, variant, tail...);
-    else
-    {
-      U dest{};
-      read_bytes(source, dest);
-      variant = std::move(dest);
-    }
+    // array fields are always optional, see `wire/field.h`
+    if (dest.optional_on_empty())
+      wire::clear(dest.get_value());
   }
 
-  // `unpack_field` expands `variant_field_`s or reads `field_`s directly
-
-  template<typename R, typename T, bool Required, typename... U>
-  inline void unpack_field(const std::size_t index, R& source, wire::variant_field_<T, Required, U...>& dest)
+  template<typename T, unsigned I>
+  inline void reset_field(wire::field_<T, false, I>& dest)
   {
-    unpack_variant_field(index, source, dest.get_value(), static_cast< const wire::option<U>& >(dest)...);
+    dest.get_value().reset();
   }
 
   template<typename T, bool Required, typename... U>
@@ -320,34 +309,15 @@ namespace wire_read
   template<typename R, typename T, unsigned I>
   inline void unpack_field(std::size_t, R& source, wire::field_<T, true, I>& dest)
   {
-    read_bytes(source, dest.get_value());
+    bytes(source, dest.get_value());
   }
 
   template<typename R, typename T, unsigned I>
   inline void unpack_field(std::size_t, R& source, wire::field_<T, false, I>& dest)
   {
-    dest.get_value().emplace();
-    read_bytes(source, *dest.get_value());
-  }
-
-  // `expand_field_map` writes a single `field_` name or all option names in a `variant_field_` to a table
-
-  template<std::size_t N>
-  inline void expand_field_map(std::size_t, wire::reader::key_map (&)[N])
-  {}
-
-  template<std::size_t N, typename T, typename... U>
-  inline void expand_field_map(std::size_t index, wire::reader::key_map (&map)[N], const T& head, const U&... tail)
-  {
-    map[index].name = head.name;
-    map[index].id = head.id();
-    expand_field_map(index + 1, map, tail...);
-  }
-
-  template<std::size_t N, typename T, bool Required, typename... U>
-  inline void expand_field_map(std::size_t index, wire::reader::key_map (&map)[N], const wire::variant_field_<T, Required, U...>& field)
-  {
-    expand_field_map(index, map, static_cast< const wire::option<U> & >(field)...);
+    if (!bool(dest.get_value()))
+      dest.get_value().emplace();
+    bytes(source, *dest.get_value());
   }
 
   //! Tracks read status of every object field instance.
@@ -378,7 +348,8 @@ namespace wire_read
     std::size_t set_mapping(std::size_t index, wire::reader::key_map (&map)[N])
     {
       our_index_ = index;
-      expand_field_map(index, map, field_); // expands possible inner options
+      map[index].id = field_.id();
+      map[index].name = field_.name;
       return index + count();
     }
 
@@ -460,19 +431,14 @@ namespace wire_read
 
 namespace wire
 {
-  template<typename T>
-  inline void array(reader& source, T& dest)
-  {
-    wire_read::array(source, dest);
-  }
   template<typename R, typename T>
-  inline enable_if<is_array<T>::value> read_bytes(R& source, T& dest)
+  inline std::enable_if_t<is_array<T>::value> read_bytes(R& source, T& dest)
   {
     wire_read::array(source, dest);
   }
 
-  template<typename... T>
-  inline void object(reader& source, T... fields)
+  template<typename R, typename... T>
+  inline std::enable_if_t<std::is_base_of<reader, R>::value> object(R& source, T... fields)
   {
     wire_read::object(source, wire_read::tracker<T>{std::move(fields)}...);
   }

--- a/src/wire/read.h
+++ b/src/wire/read.h
@@ -288,24 +288,6 @@ namespace wire_read
     dest.get_value().reset();
   }
 
-  template<typename T, bool Required, typename... U>
-  inline void reset_field(wire::variant_field_<T, Required, U...>& dest)
-  {}
-
-  template<typename T, unsigned I>
-  inline void reset_field(wire::field_<T, true, I>& dest)
-  {
-    // array fields are always optional, see `wire/field.h`
-    if (dest.optional_on_empty())
-      wire::clear(dest.get_value());
-  }
-
-  template<typename T, unsigned I>
-  inline void reset_field(wire::field_<T, false, I>& dest)
-  {
-    dest.get_value().reset();
-  }
-
   template<typename R, typename T, unsigned I>
   inline void unpack_field(std::size_t, R& source, wire::field_<T, true, I>& dest)
   {

--- a/src/wire/wrapper/CMakeLists.txt
+++ b/src/wire/wrapper/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Copyright (c) 2020, The Monero Project
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of
+#    conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list
+#    of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be
+#    used to endorse or promote products derived from this software without specific
+#    prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+# THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+set(monero-lws-wire_sources variant.cpp)
+set(monero-lws-wire_headers variant.h)
+
+add_library(monero-lws-wire-wrapper ${monero-lws-wire_sources} ${monero-lws-wire_headers})
+target_include_directories(monero-lws-wire-wrapper PUBLIC "${LMDB_INCLUDE}")
+target_link_libraries(monero-lws-wire-wrapper PRIVATE monero::libraries)
+

--- a/src/wire/wrapper/array.h
+++ b/src/wire/wrapper/array.h
@@ -1,0 +1,158 @@
+// Copyright (c) 2021, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <cstdint>
+#include <utility>
+
+//#include "wire/field.h"
+#include "wire/traits.h"
+
+/*! An array field with read constraint. See `array_` for more info. All (empty)
+  arrays were "optional" (omitted) historically in epee, so this matches prior
+  behavior. */
+#define WIRE_FIELD_ARRAY(name, read_constraint)         \
+  ::wire::optional_field( #name , ::wire::array< read_constraint >(std::ref( self . name )))
+
+namespace wire
+{
+  /*! A wrapper that ensures `T` is written as an array, with `C` constraints
+    when reading (`max_element_count` or `min_element_size`). `C` can be `void`
+    if write-only.
+    This wrapper meets the requirements for an optional field; `wire::field`
+    and `wire::optional_field` determine whether an empty array must be
+    encoded on the wire. Historically, empty arrays were always omitted on
+    the wire (a defacto optional field).
+    The `is_array` trait can also be used, but is default treated as an optional
+    field. The trait `is_optional_on_empty` traits can be specialized to disable
+    the optional on empty behavior. See `wire/traits.h` for more ifnormation
+    on the `is_optional_on_empty` trait.
+    `container_type` is `T` with optional `std::reference_wrapper` removed.
+    `container_type` concept requirements:
+      * `typedef` `value_type` that specifies inner type.
+      * must have `size()` method that returns number of elements.
+    Additional concept requirements for `container_type` when reading:
+      * must have `clear()` method that removes all elements (`size() == 0`).
+      * must have either: (1) `end()` and `emplace_hint(iterator, value_type&&)`
+        or (2) `emplace_back()` and `back()`:
+        * `end()` method that returns one-past the last element.
+        * `emplace_hint(iterator, value_type&&)` method that move constructs a new
+           element.
+        * `emplace_back()` method that default initializes new element
+        * `back()` method that retrieves last element by reference.
+    Additional concept requirements for `container_type` when writing:
+      * must work with foreach loop (`std::begin` and `std::end`).
+      * must work with `boost::size` (from the `boost::range` library). */
+  template<typename T, typename C = void>
+  struct array_
+  {
+    using constraint = C;
+    using container_type = unwrap_reference_t<T>;
+    using value_type = typename container_type::value_type;
+
+    // See nested `array_` overload below
+    using inner_array = std::reference_wrapper<value_type>;
+    using inner_array_const = std::reference_wrapper<const value_type>;
+
+    T container;
+
+    constexpr const container_type& get_container() const noexcept { return container; }
+    container_type& get_container() noexcept { return container; }
+
+    //! Read directly into the non-nested array
+    container_type& get_read_object() noexcept { return get_container(); }
+
+
+    // concept requirements for optional fields
+
+    explicit operator bool() const noexcept { return !get_container().empty(); }
+    array_& emplace() noexcept { return *this; }
+
+    array_& operator*() noexcept { return *this; }
+    const array_& operator*() const noexcept { return *this; }
+
+    void reset() { get_container().clear(); }
+  };
+
+  //! Nested array case
+  template<typename T, typename C, typename D>
+  struct array_<array_<T, C>, D>
+  {
+    // compute `container_type` and `value_type` recursively
+    using constraint = D;
+    using container_type = typename array_<T, C>::container_type;
+    using value_type = typename container_type::value_type;
+
+    // Re-compute `array_` for inner values
+    using inner_array = array_<typename array_<T, C>::inner_array, C>;
+    using inner_array_const = array_<typename array_<T, C>::inner_array_const, C>;
+
+    array_<T, C> nested;
+
+    const container_type& get_container() const noexcept { return nested.get_container(); }
+    container_type& get_container() noexcept { return nested.get_container(); }
+
+    //! Read through this proxy to track nested array
+    array_& get_read_object() noexcept { return *this; }
+
+
+    // concept requirements for optional fields
+
+    explicit operator bool() const noexcept { return !empty(); }
+    array_& emplace() noexcept { return *this; }
+
+    array_& operator*() noexcept { return *this; }
+    const array_& operator*() const noexcept { return *this; }
+
+    void reset() { clear(); }
+
+
+    /* For reading nested arrays. writing nested arrays is handled in
+       `wrappers_impl.h` with range transform. */
+
+    void clear() { get_container().clear(); }
+    bool empty() const noexcept { return get_container().empty(); }
+    std::size_t size() const noexcept { return get_container().size(); }
+
+    void emplace_back() { get_container().emplace_back(); }
+
+    //! \return A proxy object for tracking inner-array constraints
+    inner_array back() noexcept { return {std::ref(get_container().back())}; }
+  };
+
+  //! Treat `value` as an array when reading/writing, and constrain reading with `C`.
+  template<typename C = void, typename T = void>
+  inline constexpr array_<T, C> array(T value)
+  {
+    return {std::move(value)};
+  }
+
+  /* Do not register with `is_optional_on_empty` trait, this allows selection
+     on whether an array is mandatory on wire. */
+
+} // wire

--- a/src/wire/wrapper/variant.h
+++ b/src/wire/wrapper/variant.h
@@ -1,0 +1,207 @@
+// Copyright (c) 2022, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <boost/variant/get.hpp>
+#include <boost/variant/variant_fwd.hpp>
+#include <functional>
+#include <utility>
+
+#include "wire/error.h"
+#include "wire/fwd.h"
+#include "wire/field.h"
+#include "wire/read.h"
+#include "wire/write.h"
+
+#define WIRE_OPTION(name, type, cpp_name)                               \
+  wire::optional_field(name, wire::option<type>(std::ref(cpp_name)))
+
+namespace wire
+{
+  [[noreturn]] void throw_variant_exception(error::schema type, const char* variant_name);
+
+  /*! Wrapper for any C++ variant type that tracks if a `read_bytes` call has
+    completed on wrapped `value`. This wrapper is not needed if the variant is
+    being used for writes only - see `wire::option_` below for more information.
+
+    `variant_type` is `T` with optional `std::reference_wrapper` removed. See
+    `option_` for concept requirements of `variant_type`.
+
+    Example usage:
+    ```
+    template<typename F, typename T>
+    void type_map(F& format, T& self)
+    {
+      auto variant = wire::variant(std::ref(self.field3));
+      wire::object(format,
+        ...
+        WIRE_OPTION("type1", type1, variant),
+        WIRE_OPTION("type2", type2, variant)
+      );
+    }
+    ``` */
+  template<typename T>
+  struct variant_
+  {
+    using variant_type = unwrap_reference_t<T>;
+
+    //! \throw wire::exception with `type` and mangled C++ name of `variant_type`.
+    [[noreturn]] static void throw_exception(const error::schema type)
+    { throw_variant_exception(type, typeid(variant_type).name()); }
+
+    constexpr variant_(T&& value)
+      : value(std::move(value)), read(false)
+    {}
+
+    T value;
+    bool read;
+
+    constexpr const variant_type& get_variant() const noexcept { return value; }
+    variant_type& get_variant() noexcept { return value; }
+
+    //! Makes `variant_` compatible with `emplace()` in `option_`.
+    template<typename U>
+    variant_& operator=(U&& rhs)
+    {
+      get_variant() = std::forward<U>(rhs);
+      return *this;
+    }
+  };
+
+  template<typename T>
+  inline constexpr variant_<T> variant(T value)
+  { return {std::move(value)}; }
+
+  namespace adapt
+  {
+    template<typename T>
+    inline void throw_if_not_read(const T&)
+    { throw_variant_exception(error::schema::missing_key, typeid(T).name()); }
+
+    template<typename T>
+    inline void throw_if_not_read(const variant_<T>& value)
+    {
+      if (!value.read)
+        value.throw_exception(error::schema::missing_key);
+    }
+
+
+    // other variant overloads can be added here as needed
+
+    template<typename U, typename... T>
+    inline const U* get_if(const boost::variant<T...>& value)
+    { return boost::get<U>(std::addressof(value)); }
+
+    template<typename U, typename T>
+    inline const U* get_if(const variant_<T>& value)
+    { return adapt::get_if<U>(value.get_variant()); }
+  }
+
+  /*! Wrapper that makes a variant compatible with `wire::optional_field`.
+    Currently `wire::variant_` and `boost::variant` are valid variant types
+    for writing, and only `wire::variant_` is valid for reading.
+
+   `variant_type` is `T` with optional `std::reference_wrapper` removed.
+   `variant_type` concept requirements:
+     * must have two overloads for `get<U>` function in `adapt` namespace - one
+       `const` and one non-`const` that returns `const U&` and `U&` respectively
+       iff `variant_type` is storing type `U`. Otherwise, the function should
+       throw an exception.
+     * must have overload for `get_if<U>` function in `adapt` namespace that
+       returns `const U*` when `variant_type` is storing type `U`. Otherwise, the
+       function should return `nullptr`.
+     * must have a member function `operator=(U&&)` that changes the stored type
+       to `U` (`get<U>` and `get_if<U>` will return `U` after `operator=`
+       completion).
+
+   The `wire::variant(std::ref(self.field3))` step in the example above can be
+   omitted if only writing is needed. The `boost::variant` value should be
+   given directly to `wire::option<U>(...)` or `WIRE_OPTION` macro - only one
+   type is active so `wire::optional_field` will omit all other types/fields. */
+  template<typename T, typename U>
+  struct option_
+  {
+    using variant_type = unwrap_reference_t<T>;
+    using option_type = U;
+
+    T value;
+
+    constexpr const variant_type& get_variant() const noexcept { return value; }
+    variant_type& get_variant() noexcept { return value; }
+
+    //! \return `true` iff `U` is active type in variant.
+    bool is_active() const { return adapt::get_if<U>(get_variant()) != nullptr; }
+
+
+    // concept requirements for optional fields
+
+    explicit operator bool() const { return is_active(); }
+    void emplace() { get_variant() = U{}; }
+
+    const option_& operator*() const { return *this; }
+    option_& operator*() { return *this; }
+
+    //! \throw wire::exception iff no variant type was read.
+    void reset() { adapt::throw_if_not_read(get_variant()); }
+  };
+
+  template<typename U, typename T>
+  inline constexpr option_<T, U> option(T value)
+  { return {std::move(value)}; }
+
+  namespace adapt
+  {
+    // other variant overloads can be added here as needed
+
+    template<typename U, typename... T>
+    inline U& get(boost::variant<T...>& value)
+    { return boost::get<U>(value); }
+
+    template<typename U, typename... T>
+    inline const U& get(const boost::variant<T...>& value)
+    { return boost::get<U>(value); }
+
+    template<typename U, typename T>
+    inline const U& get(const variant_<T>& value)
+    { return adapt::get<U>(value.get_variant()); }
+  }
+
+  //! \throw wire::exception if `dest.get_variant()` has already been used in `read_bytes`.
+  template<typename R, typename T, typename U>
+  inline void read_bytes(R& source, option_<std::reference_wrapper<variant_<T>>, U> dest)
+  {
+    if (dest.get_variant().read)
+      dest.get_variant().throw_exception(error::schema::invalid_key);
+    wire_read::bytes(source, adapt::get<U>(dest.get_variant().get_variant()));
+    dest.get_variant().read = true;
+  }
+
+  template<typename W, typename T, typename U>
+  inline void write_bytes(W& dest, const option_<T, U>& source)
+  { wire_write::bytes(dest, adapt::get<U>(source.get_variant())); }
+}

--- a/src/wire/wrappers_impl.h
+++ b/src/wire/wrappers_impl.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, The Monero Project
+// Copyright (c) 2022, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are
@@ -25,63 +25,38 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "daemon_pub.h"
+#pragma once
 
-#include "wire/crypto.h"
+#include <boost/range/adaptor/transformed.hpp>
 #include "wire/error.h"
-#include "wire/field.h"
-#include "wire/traits.h"
-#include "wire/json/read.h"
-
-namespace
-{
-  struct dummy_chain_array
-  {
-    using value_type = crypto::hash;
-
-    std::uint64_t count;
-    std::reference_wrapper<crypto::hash> id;
-
-    void clear() noexcept {}
-    void reserve(std::size_t) noexcept {}
-
-    crypto::hash& back() noexcept { return id; }
-    void emplace_back() { ++count; }
-  };
-}
+#include "wire/read.h"
+#include "wire/write.h"
+#include "wire/wrapper/array.h"
 
 namespace wire
 {
-  template<>
-  struct is_array<dummy_chain_array>
-    : std::true_type
-  {};
-}
+  //
+  // free functions for `array_` wrapper
+  //
 
-namespace lws
-{
-namespace rpc
-{
-  static void read_bytes(wire::json_reader& src, minimal_chain_pub& self)
+  template<typename R, typename T, typename C>
+  inline void read_bytes(R& source, array_<T, C> wrapper)
   {
-    dummy_chain_array chain{0, std::ref(self.top_block_id)};
-    wire::object(src,
-      wire::field("first_height", std::ref(self.top_block_height)),
-      wire::field("ids", std::ref(chain))
-    );
-
-    self.top_block_height += chain.count - 1;
-    if (chain.count == 0)
-      WIRE_DLOG_THROW(wire::error::schema::binary, "expected at least one block hash");
+    // see constraints directly above `array_` definition
+    static_assert(std::is_same<R, void>::value, "array_ must have a read constraint for memory purposes");
+    wire_read::array(source, wrapper.get_read_object());
   }
 
-  expect<minimal_chain_pub> minimal_chain_pub::from_json(std::string&& source)
+  template<typename W, typename T, typename C>
+  inline void write_bytes(W& dest, const array_<T, C>& wrapper)
   {
-    minimal_chain_pub out{};
-    std::error_code err = wire::json::from_bytes(std::move(source), out);
-    if (err)
-      return err;
-    return {std::move(out)};
+    wire_write::array(dest, wrapper.get_container());
   }
-}
-}
+  template<typename W, typename T, typename C, typename D>
+  inline void write_bytes(W& dest, const array_<array_<T, C>, D>& wrapper)
+  {
+    using inner_type = typename array_<array_<T, C>, D>::inner_array_const;
+    const auto wrap = [](const auto& val) -> inner_type { return {std::ref(val)}; };
+    wire_write::array(dest, boost::adaptors::transform(wrapper.get_container(), wrap));
+  }
+} // wire

--- a/tests/unit/wire/read.write.test.cpp
+++ b/tests/unit/wire/read.write.test.cpp
@@ -146,23 +146,23 @@ namespace
       verify_initial(lest_env, base);
 
       {
-        const expect<epee::byte_slice> bytes = T::to_bytes(base);
-        EXPECT(bytes);
+        epee::byte_slice bytes{};
+        EXPECT(!T::to_bytes(bytes, base));
 
-        const expect<complex> derived = T::template from_bytes<complex>(U{std::string{bytes->begin(), bytes->end()}});
-        EXPECT(derived);
-        verify_initial(lest_env, *derived);
+        complex derived{};
+        EXPECT(!T::template from_bytes<complex>(U{std::string{bytes.begin(), bytes.end()}}, derived));
+        verify_initial(lest_env, derived);
       }
 
       fill(base);
 
       {
-        const expect<epee::byte_slice> bytes = T::to_bytes(base);
-        EXPECT(bytes);
+        epee::byte_slice bytes{};
+        EXPECT(!T::to_bytes(bytes, base));
 
-        const expect<complex> derived = T::template from_bytes<complex>(U{std::string{bytes->begin(), bytes->end()}});
-        EXPECT(derived);
-        verify_filled(lest_env, *derived);
+        complex derived{};
+        EXPECT(!T::template from_bytes<complex>(U{std::string{bytes.begin(), bytes.end()}}, derived));
+        verify_filled(lest_env, derived);
       }
     }
   }
@@ -184,12 +184,15 @@ namespace
   template<typename T, typename U>
   expect<small> round_trip(lest::env& lest_env, std::int64_t value)
   {
-    expect<small> out = small{0};
+    small out{0};
     SETUP("Testing round-trip with " + std::to_string(value))
     {
-      const expect<epee::byte_slice> bytes = T::template to_bytes(big{value});
-      EXPECT(bytes);
-      out = T::template from_bytes<small>(U{std::string{bytes->begin(), bytes->end()}});
+      epee::byte_slice bytes{};
+      EXPECT(!T::template to_bytes(bytes, big{value}));
+      const std::error_code error =
+        T::template from_bytes(U{std::string{bytes.begin(), bytes.end()}}, out);
+      if (error)
+        return error;
     }
     return out;
   }
@@ -236,12 +239,12 @@ namespace
     verify_initial(lest_env, base);
     fill(base);
 
-    const expect<epee::byte_slice> bytes = T::to_bytes(base);
-    EXPECT(bytes);
+    epee::byte_slice bytes{};
+    EXPECT(!T::to_bytes(bytes, base));
 
-    const expect<simple> derived = T::template from_bytes<simple>(U{std::string{bytes->begin(), bytes->end()}});
-    EXPECT(derived);
-    EXPECT(derived->choice);
+    simple derived{};
+    EXPECT(!T::template from_bytes<simple>(U{std::string{bytes.begin(), bytes.end()}}, derived));
+    EXPECT(derived.choice);
   }
 }
 


### PR DESCRIPTION
There is an ongoing effort by me to bring the `::wire::` framework to the monero repo. There have been changes made to that diff, and some of the changes are now here (if `::wire::` gets merged in the monero repo we will use that version instead).