### PR TITLE
Add zero-confirmation support to webhooks (only)

### DIFF
--- a/src/db/data.cpp
+++ b/src/db/data.cpp
@@ -34,6 +34,7 @@
 #include "wire/json/write.h"
 #include "wire/msgpack.h"
 #include "wire/uuid.h"
+#include "wire/wrapper/defaulted.h"
 
 namespace lws
 {
@@ -126,9 +127,11 @@ namespace db
     const auto payment_id = payment_bytes.empty() ?
       nullptr : std::addressof(payment_bytes);
 
+    // defaulted will omit "id" and "block" when the output is in the
+    // txpool with no valid values.
     wire::object(dest,
-      wire::field<0>("id", std::cref(self.spend_meta.id)),
-      wire::field<1>("block", self.link.height),
+      wire::optional_field<0>("id", wire::defaulted(std::cref(self.spend_meta.id), output_id::txpool())),
+      wire::optional_field<1>("block", wire::defaulted(self.link.height, block_id::txpool)),
       wire::field<2>("index", self.spend_meta.index),
       wire::field<3>("amount", self.spend_meta.amount),
       wire::field<4>("timestamp", self.timestamp),

--- a/src/db/data.h
+++ b/src/db/data.h
@@ -30,6 +30,7 @@
 #include <cassert>
 #include <cstdint>
 #include <iosfwd>
+#include <limits>
 #include <string>
 #include <utility>
 
@@ -63,12 +64,19 @@ namespace db
   WIRE_AS_INTEGER(account_time);
 
   //! References a block height
-  enum class block_id : std::uint64_t {};
+  enum class block_id : std::uint64_t
+  {
+    txpool = std::uint64_t(-1) //! Represents not-yet-a-block
+  };
   WIRE_AS_INTEGER(block_id);
 
   //! References a global output number, as determined by the public chain
   struct output_id
   {
+    //! \return Special ID for outputs not yet in a block.
+    static constexpr output_id txpool() noexcept
+    { return {0, std::numeric_limits<std::uint64_t>::max()}; }
+
     std::uint64_t high; //!< Amount on public chain; rct outputs are `0`
     std::uint64_t low;  //!< Offset within `amount` on the public chain
   };

--- a/src/db/storage.cpp
+++ b/src/db/storage.cpp
@@ -662,6 +662,42 @@ namespace db
     return requests.get_value<request_info>(value);
   }
 
+  expect<std::vector<webhook_value>>
+  storage_reader::find_webhook(webhook_key const& key, crypto::hash8 const& payment_id, cursor::webhooks cur)
+  {
+    MONERO_PRECOND(txn != nullptr);
+    assert(db != nullptr);
+    MONERO_CHECK(check_cursor(*txn, db->tables.webhooks, cur));
+
+    webhook_dupsort dup{};
+
+    static_assert(sizeof(dup.payment_id) == sizeof(payment_id), "bad memcpy");
+    std::memcpy(std::addressof(dup.payment_id), std::addressof(payment_id), sizeof(payment_id));
+
+    MDB_val lkey = lmdb::to_val(key);
+    MDB_val lvalue = lmdb::to_val(dup);
+
+    std::vector<webhook_value> result{};
+    int err = mdb_cursor_get(cur.get(), &lkey, &lvalue, MDB_GET_BOTH_RANGE);
+    for (;;)
+    {
+      if (err)
+      {
+        if (err == MDB_NOTFOUND)
+          break;
+        return {lmdb::error(err)};
+      }
+
+      if (webhooks.get_fixed_value<MONERO_FIELD(webhook_dupsort, payment_id)>(lvalue) != dup.payment_id)
+        break;
+
+      result.push_back(MONERO_UNWRAP(webhooks.get_value(lvalue)));
+      err = mdb_cursor_get(cur.get(), &lkey, &lvalue, MDB_NEXT_DUP);
+    }
+
+    return result;
+  }
+
   expect<std::vector<std::pair<webhook_key, std::vector<webhook_value>>>>
   storage_reader::get_webhooks(cursor::webhooks cur)
   {

--- a/src/db/storage.h
+++ b/src/db/storage.h
@@ -133,6 +133,10 @@ namespace db
     expect<request_info>
       get_request(request type, account_address const& address, cursor::requests cur = nullptr) noexcept;
 
+    //! \return All webhook values associated with user `key` and `payment_id`.
+    expect<std::vector<webhook_value>>
+      find_webhook(webhook_key const& key, crypto::hash8 const& payment_id, cursor::webhooks cur = nullptr);
+
     //! \return All webhooks in the DB
     expect<std::vector<std::pair<webhook_key, std::vector<webhook_value>>>>
       get_webhooks(cursor::webhooks cur = nullptr);

--- a/src/rpc/client.h
+++ b/src/rpc/client.h
@@ -75,6 +75,12 @@ namespace rpc
     expect<void> get_response(cryptonote::rpc::Message& response, std::chrono::seconds timeout, source_location loc);
 
   public:
+
+    enum class topic : std::uint8_t
+    {
+      block = 0, txpool
+    };
+
     //! A client with no connection (all send/receive functions fail).
     explicit client() noexcept
       : ctx(), daemon(), daemon_sub(), signal_sub()
@@ -110,7 +116,7 @@ namespace rpc
     expect<void> watch_scan_signals() noexcept;
 
     //! Wait for new block announce or internal timeout.
-    expect<minimal_chain_pub> wait_for_block();
+    expect<std::vector<std::pair<topic, std::string>>> wait_for_block();
 
     //! \return A JSON message for RPC request `M`.
     template<typename M>

--- a/src/rpc/daemon_pub.cpp
+++ b/src/rpc/daemon_pub.cpp
@@ -27,6 +27,8 @@
 
 #include "daemon_pub.h"
 
+#include "cryptonote_basic/cryptonote_basic.h" // monero/src
+#include "rpc/daemon_zmq.h"
 #include "wire/crypto.h"
 #include "wire/error.h"
 #include "wire/field.h"
@@ -82,6 +84,16 @@ namespace rpc
     if (err)
       return err;
     return {std::move(out)};
+  }
+
+  static void read_bytes(wire::json_reader& source, full_txpool_pub& self)
+  {
+    wire_read::array(source, self.txes);
+  }
+
+  expect<full_txpool_pub> full_txpool_pub::from_json(std::string&& source)
+  {
+    return wire::json::from_bytes<full_txpool_pub>(std::move(source));
   }
 }
 }

--- a/src/rpc/daemon_pub.cpp
+++ b/src/rpc/daemon_pub.cpp
@@ -99,15 +99,5 @@ namespace rpc
       return err;
     return {std::move(out)};
   }
-
-  static void read_bytes(wire::json_reader& source, full_txpool_pub& self)
-  {
-    wire_read::array(source, self.txes);
-  }
-
-  expect<full_txpool_pub> full_txpool_pub::from_json(std::string&& source)
-  {
-    return wire::json::from_bytes<full_txpool_pub>(std::move(source));
-  }
 }
 }

--- a/src/rpc/daemon_pub.cpp
+++ b/src/rpc/daemon_pub.cpp
@@ -95,5 +95,15 @@ namespace rpc
   {
     return wire::json::from_bytes<full_txpool_pub>(std::move(source));
   }
+
+  static void read_bytes(wire::json_reader& source, full_txpool_pub& self)
+  {
+    wire_read::array(source, self.txes);
+  }
+
+  expect<full_txpool_pub> full_txpool_pub::from_json(std::string&& source)
+  {
+    return wire::json::from_bytes<full_txpool_pub>(std::move(source));
+  }
 }
 }

--- a/src/rpc/daemon_pub.cpp
+++ b/src/rpc/daemon_pub.cpp
@@ -93,7 +93,11 @@ namespace rpc
 
   expect<full_txpool_pub> full_txpool_pub::from_json(std::string&& source)
   {
-    return wire::json::from_bytes<full_txpool_pub>(std::move(source));
+    full_txpool_pub out{};
+    std::error_code err = wire::json::from_bytes(std::move(source), out);
+    if (err)
+      return err;
+    return {std::move(out)};
   }
 
   static void read_bytes(wire::json_reader& source, full_txpool_pub& self)

--- a/src/rpc/daemon_pub.h
+++ b/src/rpc/daemon_pub.h
@@ -34,6 +34,7 @@
 #include "crypto/hash.h"   // monero/src
 #include "wire/json/fwd.h"
 
+namespace cryptonote { class transaction; }
 namespace lws
 {
 namespace rpc
@@ -45,6 +46,13 @@ namespace rpc
     crypto::hash top_block_id;
 
     static expect<minimal_chain_pub> from_json(std::string&&);
+  };
+
+  struct full_txpool_pub
+  {
+    std::vector<cryptonote::transaction> txes;
+
+    static expect<full_txpool_pub> from_json(std::string&&);
   };
 }
 }

--- a/src/rpc/daemon_zmq.cpp
+++ b/src/rpc/daemon_zmq.cpp
@@ -42,6 +42,7 @@ namespace
   constexpr const std::size_t default_inputs = 2;
   constexpr const std::size_t default_outputs = 4;
   constexpr const std::size_t default_txextra_size = 2048;
+  constexpr const std::size_t default_txpool_size = 32;
 }
 
 namespace rct
@@ -177,6 +178,11 @@ namespace cryptonote
       self.transactions.reserve(default_transaction_count);
       wire::object(source, WIRE_FIELD(block), WIRE_FIELD(transactions));
     }
+
+    static void read_bytes(wire::json_reader& source, tx_in_pool& self)
+    {
+      wire::object(source, WIRE_FIELD(tx), WIRE_FIELD(tx_hash));
+    }
   } // rpc
 } // cryptonote
 
@@ -187,3 +193,8 @@ void lws::rpc::read_bytes(wire::json_reader& source, get_blocks_fast_response& s
   wire::object(source, WIRE_FIELD(blocks), WIRE_FIELD(output_indices), WIRE_FIELD(start_height), WIRE_FIELD(current_height));
 }
 
+void lws::rpc::read_bytes(wire::json_reader& source, get_transaction_pool_response& self)
+{
+  self.transactions.reserve(default_txpool_size);
+  wire::object(source, WIRE_FIELD(transactions));
+}

--- a/src/rpc/daemon_zmq.cpp
+++ b/src/rpc/daemon_zmq.cpp
@@ -141,7 +141,7 @@ namespace cryptonote
     );
   }
 
-  static void read_bytes(wire::json_reader& source, transaction& self)
+  void read_bytes(wire::json_reader& source, transaction& self)
   {
     self.vin.reserve(default_inputs);
     self.vout.reserve(default_outputs);

--- a/src/rpc/daemon_zmq.h
+++ b/src/rpc/daemon_zmq.h
@@ -40,6 +40,9 @@ namespace crypto
 
 namespace cryptonote
 {
+  class transaction;
+  void read_bytes(wire::json_reader& source, transaction& self);
+
   namespace rpc
   {
     struct block_with_transactions;

--- a/src/rpc/daemon_zmq.h
+++ b/src/rpc/daemon_zmq.h
@@ -46,6 +46,7 @@ namespace cryptonote
   namespace rpc
   {
     struct block_with_transactions;
+    struct tx_in_pool;
   }
 }
 
@@ -74,5 +75,21 @@ namespace rpc
     using response = get_blocks_fast_response;
   };
   void read_bytes(wire::json_reader&, get_blocks_fast_response&);
+
+  struct get_transaction_pool_request
+  {
+    get_transaction_pool_request() = delete;
+  };
+  struct get_transaction_pool_response
+  {
+    get_transaction_pool_response() = delete;
+    std::vector<cryptonote::rpc::tx_in_pool> transactions;
+  };
+  struct get_transaction_pool
+  {
+    using request = get_transaction_pool_request;
+    using response = get_transaction_pool_response;
+  };
+  void read_bytes(wire::json_reader&, get_transaction_pool_response&);
 } // rpc
 } // lws

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -517,9 +517,9 @@ namespace lws
     void scan_transactions(std::string&& txpool_msg, epee::span<lws::account> users, db::storage const& disk, rpc::client& client, const net::ssl_verification_t verify_mode)
     {
       // uint64::max is for txpool
-      static const std::vector<std::uint64_t> fake_outs{
+      static const std::vector<std::uint64_t> fake_outs(
         256, std::numeric_limits<std::uint64_t>::max()
-      };
+      );
 
       const auto parsed = rpc::full_txpool_pub::from_json(std::move(txpool_msg));
       if (!parsed)

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -314,7 +314,10 @@ namespace lws
             return false;
           }
 
-          auto txpool = MONERO_UNWRAP(wire::json::from_bytes<rpc::json<rpc::get_transaction_pool>::response>(std::move(*resp)));
+          rpc::json<rpc::get_transaction_pool>::response txpool{};
+          const std::error_code err = wire::json::from_bytes(std::move(*resp), txpool);
+          if (err)
+            MONERO_THROW(err, "Invalid json-rpc");
           for (auto& tx : txpool.result.transactions)
             txpool_.emplace(get_transaction_prefix_hash(tx.tx), tx.tx_hash);
         }

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -533,10 +533,7 @@ namespace lws
 
       send_webhook sender{disk, client, verify_mode};
       for (const auto& tx : parsed->txes)
-      {
-        const crypto::hash hash = cryptonote::get_transaction_hash(tx);
-        scan_transaction_base(users, db::block_id::txpool, time, hash, tx, fake_outs, null_spend{}, sender);
-      }
+        scan_transaction_base(users, db::block_id::txpool, time, crypto::hash{}, tx, fake_outs, null_spend{}, sender);
     }
 
     void update_rates(rpc::context& ctx)

--- a/src/wire/wrapper/defaulted.h
+++ b/src/wire/wrapper/defaulted.h
@@ -1,0 +1,78 @@
+// Copyright (c) 2021-2023, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <functional>
+#include <utility>
+
+#include "wire/field.h"
+#include "wire/traits.h"
+
+//! An optional field that is omitted when a default value is used
+#define WIRE_FIELD_DEFAULTED(name, default_)                            \
+  ::wire::optional_field( #name , ::wire::defaulted(std::ref( self . name ), default_ ))
+
+namespace wire
+{
+  /*! A wrapper that tells `wire::writer`s to skip field generation when default
+    value, and tells `wire::reader`s to use default value when field not present. */
+  template<typename T, typename U>
+  struct defaulted_
+  {
+    using value_type = typename unwrap_reference<T>::type;
+
+    T value;
+    U default_;
+
+    constexpr const value_type& get_value() const noexcept { return value; }
+    value_type& get_value() noexcept { return value; }
+
+    // concept requirements for optional fields
+
+    constexpr explicit operator bool() const { return get_value() != default_; }
+    value_type& emplace() noexcept { return get_value(); }
+
+    constexpr const value_type& operator*() const noexcept { return get_value(); }
+    value_type& operator*() noexcept { return get_value(); }
+
+    void reset() { get_value() = default_; }
+  };
+
+  //! Links `value` with `default_`.
+  template<typename T, typename U>
+  inline constexpr defaulted_<T, U> defaulted(T value, U default_)
+  {
+    return {std::move(value), std::move(default_)};
+  }
+
+  /* read/write functions not needed since `defaulted_` meets the concept
+     requirements for an optional type (optional fields are handled
+     directly by the generic read/write code because the field name is omitted
+     entirely when the value is "empty"). */
+} // wire
+


### PR DESCRIPTION
Getting zero-confirmation notifications via webhooks requires the `--sub` option (and `monerod` must have `--zmq-pub` set as well). The transactions _do not_ show up in the REST API until 1 confirmation. The notifications are nearly instant (everything uses pub/sub instead of polling).

Zero-confirmations in the REST API _might be_ added in the future but that is a little more involved (unless I can come up with an alternative implementation).

The block number and output numbers are omitted from zero-conf output, since they lack valid values.