### PR TITLE
Add ZMQ-PUB support for webhooks

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -146,23 +146,27 @@ height.
 ### webhook_add
 This is used to track a specific payment ID to an address or all general
 payments to an address (where payment ID is zero). Using this endpint requires
-a web address for callback purposes, a primary (not integrated!) address, and
-finally the type ("tx-confirmation"). The event will remain in the database
-until one of the delete commands ([webhook_delete_uuid](#webhook_delete_uuid)
-or [webhook_delete](#webhook_delete)) is used to remove it.
+a web address or `zmq` for callback purposes, a primary (not integrated!)
+address, and finally the type ("tx-confirmation"). The event will remain in the
+database until one of the delete commands ([webhook_delete_uuid](#webhook_delete_uuid)
+or [webhook_delete](#webhook_delete)) is used to remove it. All webhooks are
+published over the ZMQ socket specified by `--zmq-pub` (when enabled/specified
+on command line) in addition to any HTTP server specified in the callback.
 
 > The provided URL will use SSL/TLS if `https://` is prefixed in the URL and
-will use plaintext if `http://` is prefixed in the URL. SSL/TLS connections
-will use the system certificate authority (root-CAs) by default, and will
-ignore all authority checks if `--webhook-ssl-verification none` is provided
-on the command line when starting `monero-lws-daemon`. The webhook will fail
-if there is a mismatch of `http` and `https` between the two servers, and
-will also fail if `https` verification is mismatched. The rule is: (1) if
-the callback server has SSL/TLS disabled, the webhook should use `http://`,
-(2) if the callback server has a self-signed certificate, `https://` and
-`--webhook-ssl-verification none` should be used, and (3) if the callback
-server is using "Let's Encrypt" (or similar), then `https://` with no
-additional command line flag should be used.
+will use plaintext if `http://` is prefixed in the URL. If `zmq` is provided
+as the callback, notifications are performed _only_ over the ZMQ pub socket.
+SSL/TLS connections will use the system certificate authority (root-CAs) by
+default, and will ignore all authority checks if
+`--webhook-ssl-verification none` is provided on the command line when
+starting `monero-lws-daemon`. The webhook will fail if there is a mismatch of
+`http` and `https` between the two servers, and will also fail if `https`
+verification is mismatched. The rule is: (1) if the callback server has
+SSL/TLS disabled, the webhook should use `http://`, (2) if the callback server
+has a self-signed certificate, `https://` and `--webhook-ssl-verification none`
+should be used, and (3) if the callback server is using "Let's Encrypt"
+(or similar), then `https://` with no additional command line flag should be
+used.
 
 
 #### Initial Request to server

--- a/docs/zmq.md
+++ b/docs/zmq.md
@@ -1,0 +1,91 @@
+# monero-lws ZeroMQ Usage
+Monero-lws uses ZeroMQ-RPC to retrieve information from a Monero daemon,
+ZeroMQ-SUB to get immediate notifications of blocks and transactions from a
+Monero daemon, and ZeroMQ-PUB to notify external applications of payment_id
+(web)hooks.
+
+## External "pub" socket
+The bind location of the ZMQ-PUB socket is specified with the `--zmq-pub`
+option. Users are still required to "subscribe" to topics:
+  * `json-full-hooks`: A JSON array of webhook events that have recently
+    triggered (identical output as webhook).
+  * `msgpack-full-hooks`: A msgpack array of webhook events that have recently
+    triggered (identical output as webhook).
+
+
+### `json-full-hooks`/`msgpack-full-hooks`i
+These topics receive PUB messages when a webhook ([`webhook_add`](administration.md)),
+event is triggered. If the specified URL is `zmq`, then notifications are only
+done over the ZMQ-PUB socket, otherwise the notification is sent over ZMQ-PUB
+socket AND the specified URL. Invoking `webhook_add` with a `payment_id` of
+zeroes (the field is optional in `webhook_add), will match on all transactions
+that lack a payment_id`.
+
+Example of the "raw" output from ZMQ-SUB side:
+
+```json
+json-full-hooks:{
+  "index": 2,
+  "events": [
+    {
+      "event": "tx-confirmation",
+      "payment_id": "4f695d197f2a3c54",
+      "token": "single zmq wallet",
+      "confirmations": 1,
+      "event_id": "3894f98f5dd54af5857e4f8a961a4e57",
+      "tx_info": {
+        "id": {
+          "high": 0,
+          "low": 5666767
+        },
+        "block": 2265961,
+        "index": 0,
+        "amount": 100000000000,
+        "timestamp": 1687301600,
+        "tx_hash": "ef3187775584351cc5109de124b877bcc530fb3fdbf77895329dd447902cc566",
+        "tx_prefix_hash": "064884b8a8f903edcfebab830707ed44b633438b47c95a83320f4438b1b28626",
+        "tx_public": "54dce1a6eebafa2fdedcea5e373ef9de1c3d2737ae9f809e80958d1ba4590d74",
+        "rct_mask": "68459964f89d69b7a4b1e0a1a8a384cbc9a76363c8a6e99058d41906908bd005",
+        "payment_id": "4f695d197f2a3c54",
+        "unlock_time": 0,
+        "mixin_count": 15,
+        "coinbase": false
+      }
+    },
+    {
+      "event": "tx-confirmation",
+      "payment_id": "4f695d197f2a3c54",
+      "token": "single zmq wallet",
+      "confirmations": 1,
+      "event_id": "3894f98f5dd54af5857e4f8a961a4e57",
+      "tx_info": {
+        "id": {
+          "high": 0,
+          "low": 5666768
+        },
+        "block": 2265961,
+        "index": 1,
+        "amount": 3117324236131,
+        "timestamp": 1687301600,
+        "tx_hash": "ef3187775584351cc5109de124b877bcc530fb3fdbf77895329dd447902cc566",
+        "tx_prefix_hash": "064884b8a8f903edcfebab830707ed44b633438b47c95a83320f4438b1b28626",
+        "tx_public": "54dce1a6eebafa2fdedcea5e373ef9de1c3d2737ae9f809e80958d1ba4590d74",
+        "rct_mask": "4cdc4c4e340aacb4741ba20f9b0b859242ecdad2fcc251f71d81123a47db3400",
+        "payment_id": "4f695d197f2a3c54",
+        "unlock_time": 0,
+        "mixin_count": 15,
+        "coinbase": false
+      }
+    }
+  ]
+}
+```
+
+Notice the `json-full-hooks:` prefix - this is required for the ZMQ PUB/SUB
+subscription model. The subscriber requests data from a certain "topic" where
+matching is done by string prefixes.
+
+> `index` is a counter used to detect dropped messages.
+
+> The `block` and `id` fields in the above example are NOT present when
+`confirmations == 0`.

--- a/docs/zmq.md
+++ b/docs/zmq.md
@@ -7,24 +7,24 @@ Monero daemon, and ZeroMQ-PUB to notify external applications of payment_id
 ## External "pub" socket
 The bind location of the ZMQ-PUB socket is specified with the `--zmq-pub`
 option. Users are still required to "subscribe" to topics:
-  * `json-full-hooks`: A JSON array of webhook events that have recently
-    triggered (identical output as webhook).
-  * `msgpack-full-hooks`: A msgpack array of webhook events that have recently
-    triggered (identical output as webhook).
+  * `json-full-pyment_hook`: A JSON array of webhook payment events that have
+    recently triggered (identical output as webhook).
+  * `msgpack-full-payment_hook`: A msgpack array of webhook payment events that
+    have recently triggered (identical output as webhook).
 
 
-### `json-full-hooks`/`msgpack-full-hooks`i
+### `json-full-payment_hook`/`msgpack-full-payment_hook`
 These topics receive PUB messages when a webhook ([`webhook_add`](administration.md)),
 event is triggered. If the specified URL is `zmq`, then notifications are only
 done over the ZMQ-PUB socket, otherwise the notification is sent over ZMQ-PUB
 socket AND the specified URL. Invoking `webhook_add` with a `payment_id` of
 zeroes (the field is optional in `webhook_add), will match on all transactions
-that lack a payment_id`.
+that lack a `payment_id`.
 
 Example of the "raw" output from ZMQ-SUB side:
 
 ```json
-json-full-hooks:{
+json-full-payment_hook:{
   "index": 2,
   "event": {
     "event": "tx-confirmation",
@@ -55,7 +55,7 @@ json-full-hooks:{
 
 ```
 
-Notice the `json-full-hooks:` prefix - this is required for the ZMQ PUB/SUB
+Notice the `json-full-payment_hook:` prefix - this is required for the ZMQ PUB/SUB
 subscription model. The subscriber requests data from a certain "topic" where
 matching is done by string prefixes.
 

--- a/docs/zmq.md
+++ b/docs/zmq.md
@@ -26,59 +26,33 @@ Example of the "raw" output from ZMQ-SUB side:
 ```json
 json-full-hooks:{
   "index": 2,
-  "events": [
-    {
-      "event": "tx-confirmation",
+  "event": {
+    "event": "tx-confirmation",
+    "payment_id": "4f695d197f2a3c54",
+    "token": "single zmq wallet",
+    "confirmations": 1,
+    "event_id": "3894f98f5dd54af5857e4f8a961a4e57",
+    "tx_info": {
+      "id": {
+        "high": 0,
+        "low": 5666768
+      },
+      "block": 2265961,
+      "index": 1,
+      "amount": 3117324236131,
+      "timestamp": 1687301600,
+      "tx_hash": "ef3187775584351cc5109de124b877bcc530fb3fdbf77895329dd447902cc566",
+      "tx_prefix_hash": "064884b8a8f903edcfebab830707ed44b633438b47c95a83320f4438b1b28626",
+      "tx_public": "54dce1a6eebafa2fdedcea5e373ef9de1c3d2737ae9f809e80958d1ba4590d74",
+      "rct_mask": "4cdc4c4e340aacb4741ba20f9b0b859242ecdad2fcc251f71d81123a47db3400",
       "payment_id": "4f695d197f2a3c54",
-      "token": "single zmq wallet",
-      "confirmations": 1,
-      "event_id": "3894f98f5dd54af5857e4f8a961a4e57",
-      "tx_info": {
-        "id": {
-          "high": 0,
-          "low": 5666767
-        },
-        "block": 2265961,
-        "index": 0,
-        "amount": 100000000000,
-        "timestamp": 1687301600,
-        "tx_hash": "ef3187775584351cc5109de124b877bcc530fb3fdbf77895329dd447902cc566",
-        "tx_prefix_hash": "064884b8a8f903edcfebab830707ed44b633438b47c95a83320f4438b1b28626",
-        "tx_public": "54dce1a6eebafa2fdedcea5e373ef9de1c3d2737ae9f809e80958d1ba4590d74",
-        "rct_mask": "68459964f89d69b7a4b1e0a1a8a384cbc9a76363c8a6e99058d41906908bd005",
-        "payment_id": "4f695d197f2a3c54",
-        "unlock_time": 0,
-        "mixin_count": 15,
-        "coinbase": false
-      }
-    },
-    {
-      "event": "tx-confirmation",
-      "payment_id": "4f695d197f2a3c54",
-      "token": "single zmq wallet",
-      "confirmations": 1,
-      "event_id": "3894f98f5dd54af5857e4f8a961a4e57",
-      "tx_info": {
-        "id": {
-          "high": 0,
-          "low": 5666768
-        },
-        "block": 2265961,
-        "index": 1,
-        "amount": 3117324236131,
-        "timestamp": 1687301600,
-        "tx_hash": "ef3187775584351cc5109de124b877bcc530fb3fdbf77895329dd447902cc566",
-        "tx_prefix_hash": "064884b8a8f903edcfebab830707ed44b633438b47c95a83320f4438b1b28626",
-        "tx_public": "54dce1a6eebafa2fdedcea5e373ef9de1c3d2737ae9f809e80958d1ba4590d74",
-        "rct_mask": "4cdc4c4e340aacb4741ba20f9b0b859242ecdad2fcc251f71d81123a47db3400",
-        "payment_id": "4f695d197f2a3c54",
-        "unlock_time": 0,
-        "mixin_count": 15,
-        "coinbase": false
-      }
+      "unlock_time": 0,
+      "mixin_count": 15,
+      "coinbase": false
     }
-  ]
+  }
 }
+
 ```
 
 Notice the `json-full-hooks:` prefix - this is required for the ZMQ PUB/SUB

--- a/src/db/account.cpp
+++ b/src/db/account.cpp
@@ -177,3 +177,4 @@ namespace lws
   }
 } // lws
 
+

--- a/src/db/data.cpp
+++ b/src/db/data.cpp
@@ -263,7 +263,7 @@ namespace db
     map_webhook_value(dest, source, payment_id);
   }
 
-  void write_bytes(wire::json_writer& dest, const webhook_tx_confirmation& self)
+  void write_bytes(wire::writer& dest, const webhook_tx_confirmation& self)
   {
     crypto::hash8 payment_id;
     static_assert(sizeof(payment_id) == sizeof(self.value.first.payment_id), "bad memcpy");

--- a/src/db/data.h
+++ b/src/db/data.h
@@ -299,7 +299,7 @@ namespace db
     webhook_value value;
     output tx_info;
   };
-  void write_bytes(wire::json_writer&, const webhook_tx_confirmation&);
+  void write_bytes(wire::writer&, const webhook_tx_confirmation&);
 
   //! References a specific output that triggered a webhook
   struct webhook_output

--- a/src/db/storage.cpp
+++ b/src/db/storage.cpp
@@ -2192,6 +2192,7 @@ namespace db
 
   expect<void> storage::add_webhook(const webhook_type type, const account_address& address, const webhook_value& event)
   {
+    if (event.second.url != "zmq")
     {
       epee::net_utils::http::url_content url{};
       if (event.second.url.empty() || !epee::net_utils::parse_url(event.second.url, url))

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -58,7 +58,9 @@
 #include "rpc/json.h"
 #include "util/source_location.h"
 #include "util/transactions.h"
+#include "wire/adapted/span.h"
 #include "wire/json.h"
+#include "wire/msgpack.h"
 
 #include "serialization/json_object.h"
 
@@ -211,6 +213,8 @@ namespace lws
 
       for (const db::webhook_tx_confirmation& event : events)
       {
+        if (event.value.second.url == "zmq")
+          continue;
         if (event.value.second.url.empty() || !net::parse_url(event.value.second.url, url))
         {
           MERROR("Bad URL for webhook event: " << event.value.second.url);
@@ -240,6 +244,46 @@ namespace lws
           MERROR("Unable to send webhook to " << event.value.second.url);
 
         client.disconnect();
+      }
+    }
+
+    struct zmq_index
+    {
+      const std::uint64_t index;
+      const epee::span<const db::webhook_tx_confirmation> events;
+    };
+
+    void write_bytes(wire::writer& dest, const zmq_index& self)
+    {
+      wire::object(dest, WIRE_FIELD(index), WIRE_FIELD(events));
+    }
+
+    void send_via_zmq(rpc::client& client, const epee::span<const db::webhook_tx_confirmation> events)
+    {
+      struct zmq_order
+      {
+        std::uint64_t current;
+        boost::mutex sync;
+
+        zmq_order()
+          : current(0), sync()
+        {}
+      };
+
+      static zmq_order ordering{};
+
+      //! \TODO monitor XPUB to cull the serialization
+      if (!events.empty() && client.has_publish())
+      {
+        // make sure the event is queued to zmq in order.
+        const boost::unique_lock<boost::mutex> guard{ordering.sync};
+        const zmq_index index{ordering.current++, events};
+        MINFO("Sending ZMQ-PUB topics json-full-hooks and msgpack-full-hooks");
+        expect<void> result = success();
+        if (!(result = client.publish<wire::json>("json-full-hooks:", index)))
+          MERROR("Failed to serialize+send json-full-hooks: " << result.error().message());
+        if (!(result = client.publish<wire::msgpack>("msgpack-full-hooks:", index)))
+          MERROR("Failed to serialize+send msgpack-full-hooks: " << result.error().message());
       }
     }
 
@@ -335,6 +379,7 @@ namespace lws
             events.pop_back(); //cannot compute tx_hash
         }
         send_via_http(epee::to_span(events), std::chrono::seconds{5}, verify_mode_);
+        send_via_zmq(client_, epee::to_span(events));
         return true;
       }
     };
@@ -741,6 +786,7 @@ namespace lws
 
           MINFO("Processed " << blocks.size() << " block(s) against " << users.size() << " account(s)");
           send_via_http(epee::to_span(updated->second), std::chrono::seconds{5}, webhook_verify);
+          send_via_zmq(client, epee::to_span(updated->second));
           if (updated->first != users.size())
           {
             MWARNING("Only updated " << updated->first << " account(s) out of " << users.size() << ", resetting");

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -281,12 +281,12 @@ namespace lws
         for (const auto& event : events)
         {
           const zmq_index_single index{ordering.current++, event};
-          MINFO("Sending ZMQ-PUB topics json-full-hooks and msgpack-full-hooks");
+          MINFO("Sending ZMQ-PUB topics json-full-payment_hook and msgpack-full-payment_hook");
           expect<void> result = success();
-          if (!(result = client.publish<wire::json>("json-full-hooks:", index)))
-            MERROR("Failed to serialize+send json-full-hooks: " << result.error().message());
-          if (!(result = client.publish<wire::msgpack>("msgpack-full-hooks:", index)))
-            MERROR("Failed to serialize+send msgpack-full-hooks: " << result.error().message());
+          if (!(result = client.publish<wire::json>("json-full-payment_hook:", index)))
+            MERROR("Failed to serialize+send json-full-payment_hook: " << result.error().message());
+          if (!(result = client.publish<wire::msgpack>("msgpack-full-payment_hook:", index)))
+            MERROR("Failed to serialize+send msgpack-full-payment_hook: " << result.error().message());
         }
       }
     }

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -247,15 +247,15 @@ namespace lws
       }
     }
 
-    struct zmq_index
+    struct zmq_index_single
     {
       const std::uint64_t index;
-      const epee::span<const db::webhook_tx_confirmation> events;
+      const db::webhook_tx_confirmation& event;
     };
 
-    void write_bytes(wire::writer& dest, const zmq_index& self)
+    void write_bytes(wire::writer& dest, const zmq_index_single& self)
     {
-      wire::object(dest, WIRE_FIELD(index), WIRE_FIELD(events));
+      wire::object(dest, WIRE_FIELD(index), WIRE_FIELD(event));
     }
 
     void send_via_zmq(rpc::client& client, const epee::span<const db::webhook_tx_confirmation> events)
@@ -277,13 +277,17 @@ namespace lws
       {
         // make sure the event is queued to zmq in order.
         const boost::unique_lock<boost::mutex> guard{ordering.sync};
-        const zmq_index index{ordering.current++, events};
-        MINFO("Sending ZMQ-PUB topics json-full-hooks and msgpack-full-hooks");
-        expect<void> result = success();
-        if (!(result = client.publish<wire::json>("json-full-hooks:", index)))
-          MERROR("Failed to serialize+send json-full-hooks: " << result.error().message());
-        if (!(result = client.publish<wire::msgpack>("msgpack-full-hooks:", index)))
-          MERROR("Failed to serialize+send msgpack-full-hooks: " << result.error().message());
+
+        for (const auto& event : events)
+        {
+          const zmq_index_single index{ordering.current++, event};
+          MINFO("Sending ZMQ-PUB topics json-full-hooks and msgpack-full-hooks");
+          expect<void> result = success();
+          if (!(result = client.publish<wire::json>("json-full-hooks:", index)))
+            MERROR("Failed to serialize+send json-full-hooks: " << result.error().message());
+          if (!(result = client.publish<wire::msgpack>("msgpack-full-hooks:", index)))
+            MERROR("Failed to serialize+send msgpack-full-hooks: " << result.error().message());
+        }
       }
     }
 

--- a/src/wire/adapted/span.h
+++ b/src/wire/adapted/span.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2023, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "span.h" // monero/contrib/epee/include
+#include "wire/traits.h"
+
+namespace wire
+{
+  //! Enable span types for array output
+  template<typename T>
+  struct is_array<epee::span<T>>
+    : std::true_type
+  {};
+}


### PR DESCRIPTION
This PR adds ZeroMQ publish support for webhooks. When configured, all webhooks will be simulcast over ZeroMQ. Webhooks can also be created with the http destination "zmq" to indicate that notifications should only happen over ZeroMQ.

There is an `index` field to help receivers detect gaps (ZeroMQ pub/sub drops when the highwater mark is reached). All of this is mentioned in the updated documentation.

Forgot to mention that it supports both JSON and Msgpack. Subscribers choose which feed they want.