### PR TITLE
Add config-file option

### DIFF
--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -43,6 +43,7 @@
 #include "config.h"
 #include "cryptonote_config.h"   // monero/src/
 #include "db/storage.h"
+#include "error.h"
 #include "options.h"
 #include "rest_server.h"
 #include "scanner.h"
@@ -69,6 +70,7 @@ namespace
     const command_line::arg_descriptor<unsigned short> log_level;
     const command_line::arg_descriptor<bool> disable_admin_auth;
     const command_line::arg_descriptor<std::string> webhook_ssl_verification;
+    const command_line::arg_descriptor<std::string> config_file;
 
     static std::string get_default_zmq()
     {
@@ -103,6 +105,7 @@ namespace
       , log_level{"log-level", "Log level [0-4]", 1}
       , disable_admin_auth{"disable-admin-auth", "Make auth field optional in HTTP-REST requests", false}
       , webhook_ssl_verification{"webhook-ssl-verification", "[<none|system_ca>] specify SSL verification mode for webhooks", "system_ca"}
+      , config_file{"config-file", "Specify any option in a config file; <name>=<value> on separate lines"}
     {}
 
     void prepare(boost::program_options::options_description& description) const
@@ -125,6 +128,7 @@ namespace
       command_line::add_arg(description, log_level);
       command_line::add_arg(description, disable_admin_auth);
       command_line::add_arg(description, webhook_ssl_verification);
+      command_line::add_arg(description, config_file);
     }
   };
 
@@ -165,6 +169,18 @@ namespace
         po::command_line_parser(argc, argv).options(description).run(), args
       );
       po::notify(args);
+
+      if (!command_line::is_arg_defaulted(args, opts.config_file))
+      {
+        boost::filesystem::path config_path{command_line::get_arg(args, opts.config_file)};
+        if (!boost::filesystem::exists(config_path))
+          MONERO_THROW(lws::error::configuration, "Config file does not exist");
+
+        po::store(
+          po::parse_config_file<char>(config_path.string<std::string>().c_str(), description), args
+        );
+        po::notify(args);
+      }
     }
 
     if (command_line::get_arg(args, command_line::arg_help))


### PR DESCRIPTION
Add an option for a config file. This is useful for the upcoming RMQ PR which has a login option.