### PR TITLE
Webhooks for New Accounts

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -148,7 +148,7 @@ This is used to track events happening in the database: (1) a new payment to
 an optional payment_id, or (2) a new account creation. This endpoint always
 requires a URL for callback purposes.
 
-When the event type is `tx-confirmation, this endpint requires a web address
+When the event type is `tx-confirmation`, this endpint requires a web address
 for callback purposes, a primary (not integrated!) address, and finally the
 type ("tx-confirmation"). The event will remain in the database until one of
 the delete commands ([webhook_delete_uuid](#webhook_delete_uuid) or
@@ -156,7 +156,7 @@ the delete commands ([webhook_delete_uuid](#webhook_delete_uuid) or
 
 When the event type is `new-account`, this endpoint requires a web address
 for callback purposes, and the type ("new-account"). Spurious information
-will be returned for this endpoint to simplify the server informatin (i.e.
+will be returned for this endpoint to simplify the server implementation (i.e.
 several fields returned in the initial call are not useful to new account
 creations).
 

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -305,7 +305,7 @@ Example response:
 ```json
 {
   "payment_id": "0000000000000000",
-  "event_id": "fa10a4db485145f1a24dc09c19a79d43",
+  "event_id": "c5a735e71b1e4f0a8bfaeff661d0b38a"",
   "token": "1234",
   "confirmations": 1,
   "url": "http://127.0.0.1:7000"

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -144,14 +144,21 @@ This tells the scanner to rescan specific account(s) from the specified
 height.
 
 ### webhook_add
-This is used to track a specific payment ID to an address or all general
-payments to an address (where payment ID is zero). Using this endpint requires
-a web address or `zmq` for callback purposes, a primary (not integrated!)
-address, and finally the type ("tx-confirmation"). The event will remain in the
-database until one of the delete commands ([webhook_delete_uuid](#webhook_delete_uuid)
-or [webhook_delete](#webhook_delete)) is used to remove it. All webhooks are
-published over the ZMQ socket specified by `--zmq-pub` (when enabled/specified
-on command line) in addition to any HTTP server specified in the callback.
+This is used to track events happening in the database: (1) a new payment to
+an optional payment_id, or (2) a new account creation. This endpoint always
+requires a URL for callback purposes.
+
+When the event type is `tx-confirmation, this endpint requires a web address
+for callback purposes, a primary (not integrated!) address, and finally the
+type ("tx-confirmation"). The event will remain in the database until one of
+the delete commands ([webhook_delete_uuid](#webhook_delete_uuid) or
+[webhook_delete](#webhook_delete)) is used to remove it.
+
+When the event type is `new-account`, this endpoint requires a web address
+for callback purposes, and the type ("new-account"). Spurious information
+will be returned for this endpoint to simplify the server informatin (i.e.
+several fields returned in the initial call are not useful to new account
+creations).
 
 > The provided URL will use SSL/TLS if `https://` is prefixed in the URL and
 will use plaintext if `http://` is prefixed in the URL. If `zmq` is provided
@@ -169,7 +176,8 @@ should be used, and (3) if the callback server is using "Let's Encrypt"
 used.
 
 
-#### Initial Request to server
+#### `tx-confirmation`
+##### Initial Request to server
 Example where admin authentication is required (`--disable-admin-auth` NOT
 set on start which is the default):
 ```json
@@ -222,7 +230,7 @@ executable, the event should be listed in the
 event will remain in the database until an explicit
 [`webhook_delete_uuid`](#webhook_delete_uuid) is invoked.
 
-#### Callback from Server
+##### Callback from Server
 When the event "fires" due to a transaction, the provided URL is invoked
 with a JSON payload that looks like the below:
 
@@ -257,6 +265,71 @@ which is the same information provided by the user API. The database will
 contain an entry in the `webhook_events_by_account_id,type,block_id,tx_hash,output_id,payment_id,event_id`
 field of the JSON object provided by the `debug_database` command. The
 entry will be removed when the number of confirmations has been reached.
+
+#### `new-account`
+##### Initial Request to server
+Example where admin authentication is required (`--disable-admin-auth` NOT
+set on start which is the default):
+```json
+{
+  "auth": "f50922f5fcd186eaa4bd7070b8072b66fea4fd736f06bd82df702e2314187d09",
+  "params": {
+    "type": "new-account",
+    "url": "http://127.0.0.1:7001",
+    "token": "1234"
+  }
+}
+```
+
+Example where admin authentication is not required (`--disable-admin-auth` set on start):
+```json
+{
+  "params": {
+    "type": "new-account",
+    "url": "http://127.0.0.1:7001",
+    "token": "1234"
+  }
+}
+```
+
+As noted above - `token` is optional - it will default to the empty string.
+
+##### Initial Response from Server
+The server will replay all values back to the user for confirmation. An
+additional field - `event_id` - is also returned which contains a globally
+unique value (internally this is a 128-bit `UUID`). The fields
+`confirmations`, and `payment_id` are sent to simplify the backend, and
+can be ignored when the type is `new-account`.
+
+Example response:
+```json
+{
+  "payment_id": "0000000000000000",
+  "event_id": "fa10a4db485145f1a24dc09c19a79d43",
+  "token": "1234",
+  "confirmations": 1,
+  "url": "http://127.0.0.1:7000"
+}
+```
+
+If you use the `debug_database` command provided by the `monero-lws-admin`
+executable, the event should be listed in the
+`webhooks_by_account_id,payment_id` field of the returned JSON object. The
+event will remain in the database until an explicit
+[`webhook_delete_uuid`](#webhook_delete_uuid) is invoked.
+
+##### Callback from Server
+When the event "fires" due to a new account creation, the provided URL is
+invoked with a JSON payload that looks like the below:
+
+```json
+{
+  "event_id": "c5a735e71b1e4f0a8bfaeff661d0b38a",
+  "token": "",
+  "address": "9zGwnfWRMTF9nFVW9DNKp46aJ43CRtQBWNFvPqFVSN3RUKHuc37u2RDi2GXGp1wRdSRo5juS828FqgyxkumDaE4s9qyyi9B"
+}
+```
+
 
 ### webhook_delete
 Deletes all webhooks associated with a specific Monero primary address.

--- a/src/db/data.cpp
+++ b/src/db/data.cpp
@@ -293,7 +293,7 @@ namespace db
     );
   }
 
-  void write_bytes(wire::json_writer& dest, const webhook_new_account& self)
+  void write_bytes(wire::writer& dest, const webhook_new_account& self)
   {
     wire::object(dest,
       wire::field<0>("event_id", std::cref(self.value.first.event_id)),

--- a/src/db/data.cpp
+++ b/src/db/data.cpp
@@ -29,6 +29,7 @@
 #include <cstring>
 #include <memory>
 
+#include "db/string.h"
 #include "wire.h"
 #include "wire/crypto.h"
 #include "wire/json/write.h"
@@ -215,7 +216,7 @@ namespace db
 
   namespace
   {
-    constexpr const char* map_webhook_type[] = {"tx-confirmation"};
+    constexpr const char* map_webhook_type[] = {"tx-confirmation", "new-account"};
 
     template<typename F, typename T>
     void map_webhook_key(F& format, T& self)
@@ -289,6 +290,15 @@ namespace db
       wire::field<1>("output_id", std::cref(self.link.out)),
       wire::field<2>("payment_id", std::cref(payment_id)),
       wire::field<3>("event_id", std::cref(self.link_webhook.event_id))
+    );
+  }
+
+  void write_bytes(wire::json_writer& dest, const webhook_new_account& self)
+  {
+    wire::object(dest,
+      wire::field<0>("event_id", std::cref(self.value.first.event_id)),
+      wire::field<1>("token", std::cref(self.value.second.token)),
+      wire::field<2>("address", address_string(self.account))
     );
   }
 

--- a/src/db/data.h
+++ b/src/db/data.h
@@ -252,7 +252,8 @@ namespace db
 
   enum class webhook_type : std::uint8_t
   {
-    tx_confirmation = 0,
+    tx_confirmation = 0, // cannot change values - stored in DB
+    new_account
     // unconfirmed_tx,
     // new_block
     // confirmed_tx,
@@ -315,6 +316,14 @@ namespace db
     webhook_dupsort link_webhook;
   };
   void write_bytes(wire::json_writer&, const webhook_event&);
+
+  //! Returned by DB when a webhook event "tripped"
+  struct webhook_new_account
+  {
+    webhook_value value;
+    account_address account;
+  };
+  void write_bytes(wire::json_writer&, const webhook_new_account&);
 
   bool operator==(transaction_link const& left, transaction_link const& right) noexcept;
   bool operator<(transaction_link const& left, transaction_link const& right) noexcept;

--- a/src/db/data.h
+++ b/src/db/data.h
@@ -323,7 +323,7 @@ namespace db
     webhook_value value;
     account_address account;
   };
-  void write_bytes(wire::json_writer&, const webhook_new_account&);
+  void write_bytes(wire::writer&, const webhook_new_account&);
 
   bool operator==(transaction_link const& left, transaction_link const& right) noexcept;
   bool operator<(transaction_link const& left, transaction_link const& right) noexcept;

--- a/src/db/storage.h
+++ b/src/db/storage.h
@@ -212,7 +212,7 @@ namespace db
       rescan(block_id height, epee::span<const account_address> addresses);
 
     //! Add an account for later approval. For use with the login endpoint.
-    expect<void> creation_request(account_address const& address, crypto::secret_key const& key, account_flags flags) noexcept;
+    expect<std::vector<webhook_new_account>> creation_request(account_address const& address, crypto::secret_key const& key, account_flags flags) noexcept;
 
     /*!
       Request lock height of an existing account. No effect if the `start_height`
@@ -249,12 +249,12 @@ namespace db
      
       \param type The webhook event type to be tracked by the DB.
       \param address is required for `type == tx_confirmation`, and is not
-        not needed for all other types (use default construction of zeroes).
+        not needed for all other types.
       \param event Additional information for the webhook. A valid "http"
         or "https" URL must be provided (or else error). All other information
         is optional.
      */
-    expect<void> add_webhook(webhook_type type, const account_address& address, const webhook_value& event);
+    expect<void> add_webhook(webhook_type type, const boost::optional<account_address>& address, const webhook_value& event);
 
     /*! Delete all webhooks associated with every value in `addresses`. This is
       likely only valid for `tx_confirmation` event types. */

--- a/src/rest_server.h
+++ b/src/rest_server.h
@@ -53,6 +53,7 @@ namespace lws
       epee::net_utils::ssl_authentication_t auth;
       std::vector<std::string> access_controls;
       std::size_t threads;
+      epee::net_utils::ssl_verification_t webhook_verify;
       bool allow_external;
       bool disable_admin_auth;
     };

--- a/src/rpc/webhook.h
+++ b/src/rpc/webhook.h
@@ -1,0 +1,97 @@
+
+#include <boost/utility/string_ref.hpp>
+#include <chrono>
+#include <string>
+#include "byte_slice.h"      // monero/contrib/epee/include
+#include "misc_log_ex.h"             // monero/contrib/epee/include
+#include "net/http_client.h" // monero/contrib/epee/include
+#include "span.h"
+#include "wire/json.h"
+
+namespace lws { namespace rpc
+{
+  namespace net = epee::net_utils;
+
+  template<typename T>
+  void http_send(net::http::http_simple_client& client, boost::string_ref uri, const T& event, const net::http::fields_list& params, const std::chrono::milliseconds timeout)
+  {
+    if (uri.empty())
+      uri = "/";
+
+    epee::byte_slice bytes{};
+    const std::string& url = event.value.second.url;
+    const std::error_code json_error = wire::json::to_bytes(bytes, event);
+    const net::http::http_response_info* info = nullptr;
+    if (json_error)
+    {
+      MERROR("Failed to generate webhook JSON: " << json_error.message());
+      return;
+    }
+
+    MINFO("Sending webhook to " << url);
+    if (!client.invoke(uri, "POST", std::string{bytes.begin(), bytes.end()}, timeout, std::addressof(info), params))
+    {
+      MERROR("Failed to invoke http request to  " << url);
+      return;
+    }
+
+    if (!info)
+    {
+      MERROR("Failed to invoke http request to  " << url << ", internal error (null response ptr)");
+      return;
+    }
+
+    if (info->m_response_code != 200)
+    {
+      MERROR("Failed to invoke http request to  " << url << ", wrong response code: " << info->m_response_code);
+      return;
+    }
+  }
+
+  template<typename T>
+  void http_send(const epee::span<const T> events, const std::chrono::milliseconds timeout, net::ssl_verification_t verify_mode)
+  {
+    if (events.empty())
+      return;
+
+    net::http::url_content url{};
+    net::http::http_simple_client client{};
+
+    net::http::fields_list params;
+    params.emplace_back("Content-Type", "application/json; charset=utf-8");
+
+    for (const auto& event : events)
+    {
+      if (event.value.second.url.empty() || !net::parse_url(event.value.second.url, url))
+      {
+        MERROR("Bad URL for webhook event: " << event.value.second.url);
+        continue;
+      }
+
+      const bool https = (url.schema == "https");
+      if (!https && url.schema != "http")
+      {
+        MERROR("Only http or https connections: " << event.value.second.url);
+        continue;
+      }
+
+      const net::ssl_support_t ssl_mode = https ?
+        net::ssl_support_t::e_ssl_support_enabled : net::ssl_support_t::e_ssl_support_disabled;
+      net::ssl_options_t ssl_options{ssl_mode};
+      if (https)
+        ssl_options.verification = verify_mode;
+
+      if (url.port == 0)
+        url.port = https ? 443 : 80;
+
+      client.set_server(url.host, std::to_string(url.port), boost::none, std::move(ssl_options));
+      if (client.connect(timeout))
+        http_send(client, url.uri, event, params, timeout);
+      else
+        MERROR("Unable to send webhook to " << event.value.second.url);
+
+      client.disconnect();
+    }
+  }
+
+}} // lws // rpc

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -49,18 +49,16 @@
 #include "db/account.h"
 #include "db/data.h"
 #include "error.h"
-#include "misc_log_ex.h"             // monero/contrib/epee/include
-#include "net/http_client.h"
+#include "misc_log_ex.h"           // monero/contrib/epee/include
 #include "net/net_parse_helpers.h"
-#include "rpc/daemon_messages.h"      // monero/src
-#include "rpc/message_data_structs.h" // monero/src
+#include "net/net_ssl.h"           // monero/contrib/epee/include
+#include "rpc/daemon_messages.h"   // monero/src
 #include "rpc/daemon_zmq.h"
 #include "rpc/json.h"
+#include "rpc/message_data_structs.h" // monero/src
+#include "rpc/webhook.h"
 #include "util/source_location.h"
 #include "util/transactions.h"
-#include "wire/adapted/span.h"
-#include "wire/json.h"
-#include "wire/msgpack.h"
 
 #include "serialization/json_object.h"
 
@@ -165,130 +163,9 @@ namespace lws
       return true;
     }
 
-    void send_via_http(net::http::http_simple_client& client, boost::string_ref uri, const db::webhook_tx_confirmation& event, const net::http::fields_list& params, const std::chrono::milliseconds timeout)
+    void send_payment_hook(const epee::span<const db::webhook_tx_confirmation>, net::ssl_verififcation_t verify_mode)
     {
-      if (uri.empty())
-        uri = "/";
-
-      epee::byte_slice bytes{};
-      const std::string& url = event.value.second.url;
-      const std::error_code json_error = wire::json::to_bytes(bytes, event);
-      const net::http::http_response_info* info = nullptr;
-      if (json_error)
-      {
-        MERROR("Failed to generate webhook JSON: " << json_error.message());
-        return;
-      }
-
-      MINFO("Sending webhook to " << url);
-      if (!client.invoke(uri, "POST", std::string{bytes.begin(), bytes.end()}, timeout, std::addressof(info), params))
-      {
-        MERROR("Failed to invoke http request to  " << url);
-        return;
-      }
-
-      if (!info)
-      {
-        MERROR("Failed to invoke http request to  " << url << ", internal error (null response ptr)");
-        return;
-      }
-
-      if (info->m_response_code != 200 && info->m_response_code != 201)
-      {
-        MERROR("Failed to invoke http request to  " << url << ", wrong response code: " << info->m_response_code);
-        return;
-      }
-    }
-
-    void send_via_http(const epee::span<const db::webhook_tx_confirmation> events, const std::chrono::milliseconds timeout, net::ssl_verification_t verify_mode)
-    {
-      if (events.empty())
-        return;
-
-      net::http::url_content url{};
-      net::http::http_simple_client client{};
-
-      net::http::fields_list params;
-      params.emplace_back("Content-Type", "application/json; charset=utf-8");
-
-      for (const db::webhook_tx_confirmation& event : events)
-      {
-        if (event.value.second.url == "zmq")
-          continue;
-        if (event.value.second.url.empty() || !net::parse_url(event.value.second.url, url))
-        {
-          MERROR("Bad URL for webhook event: " << event.value.second.url);
-          continue;
-        }
-
-        const bool https = (url.schema == "https");
-        if (!https && url.schema != "http")
-        {
-          MERROR("Only http or https connections: " << event.value.second.url);
-          continue;
-        }
-
-        const net::ssl_support_t ssl_mode = https ?
-          net::ssl_support_t::e_ssl_support_enabled : net::ssl_support_t::e_ssl_support_disabled;
-        net::ssl_options_t ssl_options{ssl_mode};
-        if (https)
-          ssl_options.verification = verify_mode;
-
-        if (url.port == 0)
-          url.port = https ? 443 : 80;
-
-        client.set_server(url.host, std::to_string(url.port), boost::none, std::move(ssl_options));
-        if (client.connect(timeout))
-          send_via_http(client, url.uri, event, params, timeout);
-        else
-          MERROR("Unable to send webhook to " << event.value.second.url);
-
-        client.disconnect();
-      }
-    }
-
-    struct zmq_index_single
-    {
-      const std::uint64_t index;
-      const db::webhook_tx_confirmation& event;
-    };
-
-    void write_bytes(wire::writer& dest, const zmq_index_single& self)
-    {
-      wire::object(dest, WIRE_FIELD(index), WIRE_FIELD(event));
-    }
-
-    void send_via_zmq(rpc::client& client, const epee::span<const db::webhook_tx_confirmation> events)
-    {
-      struct zmq_order
-      {
-        std::uint64_t current;
-        boost::mutex sync;
-
-        zmq_order()
-          : current(0), sync()
-        {}
-      };
-
-      static zmq_order ordering{};
-
-      //! \TODO monitor XPUB to cull the serialization
-      if (!events.empty() && client.has_publish())
-      {
-        // make sure the event is queued to zmq in order.
-        const boost::unique_lock<boost::mutex> guard{ordering.sync};
-
-        for (const auto& event : events)
-        {
-          const zmq_index_single index{ordering.current++, event};
-          MINFO("Sending ZMQ-PUB topics json-full-payment_hook and msgpack-full-payment_hook");
-          expect<void> result = success();
-          if (!(result = client.publish<wire::json>("json-full-payment_hook:", index)))
-            MERROR("Failed to serialize+send json-full-payment_hook: " << result.error().message());
-          if (!(result = client.publish<wire::msgpack>("msgpack-full-payment_hook:", index)))
-            MERROR("Failed to serialize+send msgpack-full-payment_hook: " << result.error().message());
-        }
-      }
+      rpc::send_webhook(events, "json-full-payment_hook", "msgpack-full-payment_hook" std::chrono::seconds{5}, verify_mode);
     }
 
     struct by_height
@@ -382,8 +259,7 @@ namespace lws
           else
             events.pop_back(); //cannot compute tx_hash
         }
-        send_via_http(epee::to_span(events), std::chrono::seconds{5}, verify_mode_);
-        send_via_zmq(client_, epee::to_span(events));
+        send_payment_hook(epee::to_span(events), verify_mode_);
         return true;
       }
     };
@@ -789,8 +665,7 @@ namespace lws
           }
 
           MINFO("Processed " << blocks.size() << " block(s) against " << users.size() << " account(s)");
-          send_via_http(epee::to_span(updated->second), std::chrono::seconds{5}, webhook_verify);
-          send_via_zmq(client, epee::to_span(updated->second));
+          send_payment_hook(epee::to_span(updated->second), webhook_verify);
           if (updated->first != users.size())
           {
             MWARNING("Only updated " << updated->first << " account(s) out of " << users.size() << ", resetting");
@@ -1033,15 +908,9 @@ namespace lws
     return {std::move(client)};
   }
 
-  void scanner::run(db::storage disk, rpc::context ctx, std::size_t thread_count, const boost::string_ref webhook_ssl_verification)
+  void scanner::run(db::storage disk, rpc::context ctx, std::size_t thread_count, const epee::net_utils::ssl_verification_t webhook_verify)
   {
     thread_count = std::max(std::size_t(1), thread_count);
-
-    net::ssl_verification_t webhook_verify = net::ssl_verification_t::none;
-    if (webhook_ssl_verification == "system_ca")
-      webhook_verify = net::ssl_verification_t::system_ca;
-    else if (webhook_ssl_verification != "none")
-      MONERO_THROW(lws::error::configuration, "Invalid webhook ssl verification mode");
 
     rpc::client client{};
     for (;;)

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -163,9 +163,9 @@ namespace lws
       return true;
     }
 
-    void send_payment_hook(const epee::span<const db::webhook_tx_confirmation>, net::ssl_verififcation_t verify_mode)
+    void send_payment_hook(rpc::client& client, const epee::span<const db::webhook_tx_confirmation> events, net::ssl_verification_t verify_mode)
     {
-      rpc::send_webhook(events, "json-full-payment_hook", "msgpack-full-payment_hook" std::chrono::seconds{5}, verify_mode);
+      rpc::send_webhook(client, events, "json-full-payment_hook:", "msgpack-full-payment_hook:", std::chrono::seconds{5}, verify_mode);
     }
 
     struct by_height
@@ -259,7 +259,7 @@ namespace lws
           else
             events.pop_back(); //cannot compute tx_hash
         }
-        send_payment_hook(epee::to_span(events), verify_mode_);
+        send_payment_hook(client_, epee::to_span(events), verify_mode_);
         return true;
       }
     };
@@ -665,7 +665,7 @@ namespace lws
           }
 
           MINFO("Processed " << blocks.size() << " block(s) against " << users.size() << " account(s)");
-          send_payment_hook(epee::to_span(updated->second), webhook_verify);
+          send_payment_hook(client, epee::to_span(updated->second), webhook_verify);
           if (updated->first != users.size())
           {
             MWARNING("Only updated " << updated->first << " account(s) out of " << users.size() << ", resetting");

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -32,6 +32,7 @@
 #include <string>
 
 #include "db/storage.h"
+#include "net/net_ssl.h" // monero/contrib/epee/include
 #include "rpc/client.h"
 
 namespace lws
@@ -48,7 +49,7 @@ namespace lws
     static expect<rpc::client> sync(db::storage disk, rpc::client client);
 
     //! Poll daemon until `stop()` is called, using `thread_count` threads.
-    static void run(db::storage disk, rpc::context ctx, std::size_t thread_count, boost::string_ref webhook_ssl_verification);
+    static void run(db::storage disk, rpc::context ctx, std::size_t thread_count, epee::net_utils::ssl_verification_t webhook_verify);
 
     //! \return True if `stop()` has never been called.
     static bool is_running() noexcept { return running; }

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -43,6 +43,7 @@
 #include "config.h"
 #include "cryptonote_config.h"   // monero/src/
 #include "db/storage.h"
+#include "error.h"
 #include "options.h"
 #include "rest_server.h"
 #include "scanner.h"
@@ -180,6 +181,13 @@ namespace
     opts.set_network(args); // do this first, sets global variable :/
     mlog_set_log_level(command_line::get_arg(args, opts.log_level));
 
+    const auto webhook_verify_raw = command_line::get_arg(args, opts.webhook_ssl_verification);
+    epee::net_utils::ssl_verification_t webhook_verify = epee::net_utils::ssl_verification_t::none;
+    if (webhook_verify_raw == "system_ca")
+      webhook_verify = epee::net_utils::ssl_verification_t::system_ca;
+    else if (webhook_verify_raw != "none")
+      MONERO_THROW(lws::error::configuration, "Invalid webhook ssl verification mode");
+
     program prog{
       command_line::get_arg(args, opts.db_path),
       command_line::get_arg(args, opts.rest_servers),
@@ -188,6 +196,7 @@ namespace
         {command_line::get_arg(args, opts.rest_ssl_key), command_line::get_arg(args, opts.rest_ssl_cert)},
         command_line::get_arg(args, opts.access_controls),
         command_line::get_arg(args, opts.rest_threads),
+        webhook_verify,
         command_line::get_arg(args, opts.external_bind),
         command_line::get_arg(args, opts.disable_admin_auth)
       },
@@ -220,6 +229,7 @@ namespace
     MINFO("Using monerod ZMQ RPC at " << ctx.daemon_address());
     auto client = lws::scanner::sync(disk.clone(), ctx.connect().value()).value();
 
+    const auto webhook_verify = prog.rest_config.webhook_verify;
     lws::rest_server server{
       epee::to_span(prog.rest_servers), prog.admin_rest_servers, disk.clone(), std::move(client), std::move(prog.rest_config)
     };
@@ -229,7 +239,7 @@ namespace
       MINFO("Listening for REST admin clients at " << address);
 
     // blocks until SIGINT
-    lws::scanner::run(std::move(disk), std::move(ctx), prog.scan_threads, prog.webhook_ssl_verification);
+    lws::scanner::run(std::move(disk), std::move(ctx), prog.scan_threads, webhook_verify);
   }
 } // anonymous
 


### PR DESCRIPTION
Adds webhooks on new account creation _request_. Currently the server must be polled for new account creation requests. Auto-accepting all account creation requests still not possible (yet!).