### PR TITLE
Add RabbitMQ support for payment hooks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,11 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(BUILD_TESTS "Build Tests" OFF)
+option(WITH_RMQ "Build with RMQ publish support" OFF)
+if (WITH_RMQ)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DMLWS_RMQ_ENABLED")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMLWS_RMQ_ENABLED")
+endif()
 
 set(MONERO_LIBRARIES
   daemon_messages
@@ -160,6 +165,13 @@ if (NOT (Boost_THREAD_LIBRARY STREQUAL monero_Boost_THREAD_LIBRARY_RELEASE))
   message(FATAL_ERROR "Boost libraries for monero build differs from this project")
 endif()
 
+if (WITH_RMQ)
+  find_path(RMQ_INCLUDE_DIR "amqp.h")
+  find_library(RMQ_LIBRARY rabbitmq REQUIRED)
+else()
+  set(RMQ_INCLUDE_DIR "")
+  set(RMQ_LIBRARY "")
+endif()
 
 set(LMDB_INCLUDE "${monero_LMDB_INCLUDE}")
 set(LMDB_LIB_PATH "monero::lmdb")

--- a/docs/rmq.md
+++ b/docs/rmq.md
@@ -1,0 +1,55 @@
+# monero-lws RabbitMQ Usage
+Monero-lws uses RabbitMQ to provide JSON notifications of payment_id
+(web)hooks. The feature is optional - by default LWS is _not_ compiled with
+RabbitMQ support. The cmake option -DWITH_RMQ=ON must be specified during the
+configuration stage to enable the feature.
+
+The notification location is specified with `--rmq-address`, the login details
+are specified with `--rmq-credentials` (specified as `user:pass`), the exchange
+is specified with `--rmq-exchange`, and routing name is specified with
+`--rmq-routing`. 
+
+## `json-full-payment_hook`
+Only events of this type are sent to RabbitMQ. They are always "simulcast" with
+the webhook URL. If the webhook URL is `zmq` then no simulcast occurs - the
+event is only sent via ZeroMQ and/or RabbitMQ (if both are configured then it
+sent to both, otherwise it is only sent to the one configured).
+
+Example of the "raw" output to RabbitMQ:
+
+```json
+{
+  "index": 2,
+  "event": {
+    "event": "tx-confirmation",
+    "payment_id": "4f695d197f2a3c54",
+    "token": "single zmq wallet",
+    "confirmations": 1,
+    "event_id": "3894f98f5dd54af5857e4f8a961a4e57",
+    "tx_info": {
+      "id": {
+        "high": 0,
+        "low": 5666768
+      },
+      "block": 2265961,
+      "index": 1,
+      "amount": 3117324236131,
+      "timestamp": 1687301600,
+      "tx_hash": "ef3187775584351cc5109de124b877bcc530fb3fdbf77895329dd447902cc566",
+      "tx_prefix_hash": "064884b8a8f903edcfebab830707ed44b633438b47c95a83320f4438b1b28626",
+      "tx_public": "54dce1a6eebafa2fdedcea5e373ef9de1c3d2737ae9f809e80958d1ba4590d74",
+      "rct_mask": "4cdc4c4e340aacb4741ba20f9b0b859242ecdad2fcc251f71d81123a47db3400",
+      "payment_id": "4f695d197f2a3c54",
+      "unlock_time": 0,
+      "mixin_count": 15,
+      "coinbase": false
+    }
+  }
+}
+```
+> `index` is a counter used to detect dropped messages. It is not useful to
+RabbitMQ but is a carry-over from ZeroMQ (the same serialized message is used
+to send to both).
+
+> The `block` and `id` fields in the above example are NOT present when
+`confirmations == 0`.

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -99,6 +99,8 @@ namespace lws
         return "An unknown in-process message was received";
       case error::system_clock_invalid_range:
         return "System clock is out of range for account storage format";
+      case error::rmq_failure:
+        return "Failure within the RMQ library";
       case error::tx_relay_failed:
         return "The daemon failed to relay transaction from REST client";
       default:

--- a/src/error.h
+++ b/src/error.h
@@ -63,6 +63,7 @@ namespace lws
     signal_abort_scan,          //!< In process ZMQ PUB to abort the scan was received
     signal_unknown,             //!< An unknown in process ZMQ PUB was received
     system_clock_invalid_range, //!< System clock is out of range for storage format
+    rmq_failure,                //!< Error within RMQ library
     tx_relay_failed             //!< Daemon failed to relayed tx from REST client
   };
 

--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -30,4 +30,5 @@ set(monero-lws-rpc_sources admin.cpp client.cpp daemon_pub.cpp daemon_zmq.cpp li
 set(monero-lws-rpc_headers admin.h client.h daemon_pub.h daemon_zmq.h fwd.h json.h light_wallet.h rates.h)
 
 add_library(monero-lws-rpc ${monero-lws-rpc_sources} ${monero-lws-rpc_headers})
-target_link_libraries(monero-lws-rpc monero::libraries monero-lws-wire-json monero-lws-wire-wrapper)
+target_include_directories(monero-lws-rpc PRIVATE ${RMQ_INCLUDE_DIR})
+target_link_libraries(monero-lws-rpc monero::libraries monero-lws-wire-json monero-lws-wire-wrapper ${RMQ_LIBRARY})

--- a/src/rpc/client.h
+++ b/src/rpc/client.h
@@ -38,7 +38,6 @@
 #include "rpc/message.h"   // monero/src
 #include "rpc/daemon_pub.h"
 #include "rpc/rates.h"
-#include "span.h"          // monero/contrib/epee/include
 #include "util/source_location.h"
 
 namespace lws
@@ -60,6 +59,14 @@ namespace rpc
     struct context;
   }
 
+  struct rmq_details
+  {
+    std::string address;
+    std::string credentials;
+    std::string exchange;
+    std::string routing;
+  };
+
   //! Abstraction for ZMQ RPC client. Only `get_rates()` thread-safe; use `clone()`.
   class client
   {
@@ -76,6 +83,9 @@ namespace rpc
     expect<void> get_response(cryptonote::rpc::Message& response, std::chrono::seconds timeout, source_location loc);
 
   public:
+
+    static constexpr const char* payment_topic_json() { return "json-full-payment_hook:"; }
+    static constexpr const char* payment_topic_msgpack() { return "msgpack-full-payment_hook:"; }
 
     enum class topic : std::uint8_t
     {
@@ -191,10 +201,11 @@ namespace rpc
 
       \param daemon_addr Location of ZMQ enabled `monerod` RPC.
       \param pub_addr Bind location for publishing ZMQ events.
+      \param rmq_info Required information for RMQ publishing (if enabled)
       \param rates_interval Frequency to retrieve exchange rates. Set value to
         `<= 0` to disable exchange rate retrieval.
     */
-    static context make(std::string daemon_addr, std::string sub_addr, std::string pub_addr, std::chrono::minutes rates_interval);
+    static context make(std::string daemon_addr, std::string sub_addr, std::string pub_addr, rmq_details rmq_info, std::chrono::minutes rates_interval);
 
     context(context&&) = default;
     context(context const&) = delete;


### PR DESCRIPTION
This will need a rebase after #79 gets merged. RabbitMQ is an optional dependency that defaults to "OFF".

The CI has **not** been updated yet to verify RabbitMQ enabled builds (it only checks the OFF case).