### PR TITLE
Add (working draft) subaddress support

### DIFF
--- a/src/db/account.h
+++ b/src/db/account.h
@@ -26,6 +26,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
+#include <boost/optional/optional.hpp>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -33,6 +34,7 @@
 
 #include "crypto/crypto.h"
 #include "fwd.h"
+#include "db/data.h"
 #include "db/fwd.h"
 
 namespace lws
@@ -43,19 +45,19 @@ namespace lws
     struct internal;
 
     std::shared_ptr<const internal> immutable_;
-    std::vector<db::output_id> spendable_;
+    std::vector<std::pair<db::output_id, db::address_index>> spendable_;
     std::vector<crypto::public_key> pubs_;
     std::vector<db::spend> spends_;
     std::vector<db::output> outputs_;
     db::block_id height_;
 
-    explicit account(std::shared_ptr<const internal> immutable, db::block_id height, std::vector<db::output_id> spendable, std::vector<crypto::public_key> pubs) noexcept;
+    explicit account(std::shared_ptr<const internal> immutable, db::block_id height, std::vector<std::pair<db::output_id, db::address_index>> spendable, std::vector<crypto::public_key> pubs) noexcept;
     void null_check() const;
 
   public:
 
     //! Construct an account from `source` and current `spendable` outputs.
-    explicit account(db::account const& source, std::vector<db::output_id> spendable, std::vector<crypto::public_key> pubs);
+    explicit account(db::account const& source, std::vector<std::pair<db::output_id, db::address_index>> spendable, std::vector<crypto::public_key> pubs);
 
     /*!
       \return False if this is a "moved-from" account (i.e. the internal memory
@@ -96,8 +98,8 @@ namespace lws
     //! \return Current scan height of `this`.
     db::block_id scan_height() const noexcept { return height_; }
 
-    //! \return True iff `id` is spendable by `this`.
-    bool has_spendable(db::output_id const& id) const noexcept;
+    //! \return Subaddress index iff `id` is spendable by `this`.
+    boost::optional<db::address_index> get_spendable(db::output_id const& id) const noexcept;
 
     //! \return Outputs matched during the latest scan.
     std::vector<db::output> const& outputs() const noexcept { return outputs_; }

--- a/src/db/storage.cpp
+++ b/src/db/storage.cpp
@@ -57,6 +57,7 @@
 #include "lmdb/value_stream.h"
 #include "net/net_parse_helpers.h" // monero/contrib/epee/include
 #include "span.h"
+#include "wire/adapted/array.h"
 #include "wire/filters.h"
 #include "wire/json.h"
 #include "wire/vector.h"
@@ -102,7 +103,62 @@ namespace db
       sizeof(output) == 8 + 32 + (8 * 3) + (4 * 2) + 32 + (8 * 2) + (32 * 3) + 7 + 1 + 32,
       "padding in output"
     );
+
+    //! Original db value, with no subaddress
+    struct spend
+    {
+      transaction_link link;    //!< Orders and links `spend` to `output`.
+      crypto::key_image image;  //!< Unique ID for the spend
+      // `link` and `image` must in this order for LMDB optimizations
+      output_id source;         //!< The output being spent
+      std::uint64_t timestamp;  //!< Timestamp of spend
+      std::uint64_t unlock_time;//!< Unlock time of spend
+      std::uint32_t mixin_count;//!< Ring-size of TX output
+      char reserved[3];
+      std::uint8_t length;      //!< Length of `payment_id` field (0..32).
+      crypto::hash payment_id;  //!< Unencrypted only, can't decrypt spend
+    };
+    static_assert(sizeof(spend) == 8 + 32 * 2 + 8 * 4 + 4 + 3 + 1 + 32, "padding in spend");
   }
+
+  namespace v1
+  {
+    //! Second DB value, with no subaddress
+    struct output
+    {
+      transaction_link link;        //! Orders and links `output` to `spend`s.
+
+      //! Data that a linked `spend` needs in some REST endpoints.
+      struct spend_meta_
+      {
+        output_id id;             //!< Unique id for output within monero
+        // `link` and `id` must be in this order for LMDB optimizations
+        std::uint64_t amount;
+        std::uint32_t mixin_count;//!< Ring-size of TX
+        std::uint32_t index;      //!< Offset within a tx
+        crypto::public_key tx_public;
+      } spend_meta;
+
+      std::uint64_t timestamp;
+      std::uint64_t unlock_time; //!< Not always a timestamp; mirrors chain value.
+      crypto::hash tx_prefix_hash;
+      crypto::public_key pub;    //!< One-time spendable public key.
+      rct::key ringct_mask;      //!< Unencrypted CT mask
+      char reserved[7];
+      extra_and_length extra;    //!< Extra info + length of payment id
+      union payment_id_
+      {
+        crypto::hash8 short_;  //!< Decrypted short payment id
+        crypto::hash long_;    //!< Long version of payment id (always decrypted)
+      } payment_id;
+      std::uint64_t fee;       //!< Total fee for transaction
+    };
+    static_assert(
+      sizeof(output) == 8 + 32 + (8 * 3) + (4 * 2) + 32 + (8 * 2) + (32 * 3) + 7 + 1 + 32 + 8,
+      "padding in output"
+    );
+  }
+
 
   namespace
   {
@@ -237,11 +293,17 @@ namespace db
     constexpr const lmdb::basic_table<account_id, v0::output> outputs_v0{
       "outputs_by_account_id,block_id,tx_hash,output_id", MDB_DUPSORT, &output_compare
     };
+    constexpr const lmdb::basic_table<account_id, v1::output> outputs_v1{
+      "outputs_v1_by_account_id,block_id,tx_hash,output_id", MDB_DUPSORT, &output_compare
+    };
     constexpr const lmdb::basic_table<account_id, output> outputs{
-      "outputs_v1_by_account_id,block_id,tx_hash,output_id", (MDB_CREATE | MDB_DUPSORT), &output_compare
+      "outputs_v2_by_account_id,block_id,tx_hash,output_id", (MDB_CREATE | MDB_DUPSORT), &output_compare
+    };
+    constexpr const lmdb::basic_table<account_id, v0::spend> spends_v0{
+      "spends_by_account_id,block_id,tx_hash,image", MDB_DUPSORT, &spend_compare
     };
     constexpr const lmdb::basic_table<account_id, spend> spends{
-      "spends_by_account_id,block_id,tx_hash,image", (MDB_CREATE | MDB_DUPSORT), &spend_compare
+      "spends_v1_by_account_id,block_id,tx_hash,image", (MDB_CREATE | MDB_DUPSORT), &spend_compare
     };
     constexpr const lmdb::basic_table<output_id, db::key_image> images{
       "key_images_by_output_id,image", (MDB_CREATE | MDB_DUPSORT), MONERO_COMPARE(db::key_image, value)
@@ -254,6 +316,12 @@ namespace db
     };
     constexpr const lmdb::basic_table<account_id, webhook_event> events_by_account_id{
       "webhook_events_by_account_id,type,block_id,tx_hash,output_id,payment_id,event_id", (MDB_CREATE | MDB_DUPSORT), &lmdb::less<webhook_event>
+    };
+    constexpr const lmdb::msgpack_table<account_id, major_index, index_ranges> subaddress_ranges{
+      "subaddress_ranges_by_account_id,major_index", (MDB_CREATE | MDB_DUPSORT), &lmdb::less<db::major_index>
+    };
+    constexpr const lmdb::basic_table<account_id, subaddress_map> subaddress_indexes{
+      "subaddress_indexes_by_account_id,public_key", (MDB_CREATE | MDB_DUPSORT), MONERO_COMPARE(subaddress_map, subaddress)
     };
 
     template<typename D>
@@ -547,6 +615,8 @@ namespace db
       MDB_dbi requests;
       MDB_dbi webhooks;
       MDB_dbi events;
+      MDB_dbi subaddress_ranges;
+      MDB_dbi subaddress_indexes;
     } tables;
 
     const unsigned create_queue_max;
@@ -567,12 +637,26 @@ namespace db
       tables.requests    = requests.open(*txn).value();
       tables.webhooks    = webhooks.open(*txn).value();
       tables.events      = events_by_account_id.open(*txn).value();
+      tables.subaddress_ranges  = subaddress_ranges.open(*txn).value();
+      tables.subaddress_indexes = subaddress_indexes.open(*txn).value(); 
 
       const auto v0_outputs = outputs_v0.open(*txn);
       if (v0_outputs)
         MONERO_UNWRAP(convert_table<v0::output, output>(*txn, *v0_outputs, tables.outputs));
       else if (v0_outputs != lmdb::error(MDB_NOTFOUND))
         MONERO_THROW(v0_outputs.error(), "Error opening old outputs table");
+
+      const auto v1_outputs = outputs_v1.open(*txn);
+      if (v1_outputs)
+        MONERO_UNWRAP(convert_table<v1::output, output>(*txn, *v1_outputs, tables.outputs));
+      else if (v1_outputs != lmdb::error(MDB_NOTFOUND))
+        MONERO_THROW(v1_outputs.error(), "Error opening old outputs table");
+
+      const auto v0_spends = spends_v0.open(*txn);
+      if (v0_spends)
+        MONERO_UNWRAP(convert_table<v0::spend, spend>(*txn, *v0_spends, tables.spends));
+      else if (v0_spends != lmdb::error(MDB_NOTFOUND))
+        MONERO_THROW(v0_spends.error(), "Error opening old spends table");
 
       check_blockchain(*txn, tables.blocks);
 
@@ -749,6 +833,52 @@ namespace db
     return requests.get_value<request_info>(value);
   }
 
+  expect<std::vector<subaddress_dict>>
+  storage_reader::get_subaddresses(account_id id, cursor::subaddress_ranges cur) noexcept
+  {
+    MONERO_PRECOND(txn != nullptr);
+    assert(db != nullptr);
+
+    MONERO_CHECK(check_cursor(*txn, db->tables.subaddress_ranges, cur));
+
+    MDB_val key = lmdb::to_val(id);
+    MDB_val value{};
+    std::vector<subaddress_dict> ranges{};
+    int err = mdb_cursor_get(cur.get(), &key, &value, MDB_SET_KEY);
+    if (!err)
+    {
+      std::size_t count = 0;
+      if (mdb_cursor_count(cur.get(), &count) == 0)
+        ranges.reserve(count);
+    }
+    for (;;)
+    {
+      if (err)
+      {
+        if (err == MDB_NOTFOUND)
+          break;
+        return {lmdb::error(err)};
+      }
+      ranges.push_back(MONERO_UNWRAP(subaddress_ranges.get_value(value)));
+      err = mdb_cursor_get(cur.get(), &key, &value, MDB_NEXT_DUP);
+    }
+    return {std::move(ranges)};
+  }
+
+  expect<address_index>
+  storage_reader::find_subaddress(account_id id, crypto::public_key const& address, cursor::subaddress_indexes& cur) noexcept
+  {
+    MONERO_PRECOND(txn != nullptr);
+    assert(db != nullptr);
+
+    MONERO_CHECK(check_cursor(*txn, db->tables.subaddress_indexes, cur));
+    MDB_val key = lmdb::to_val(id);
+    MDB_val value = lmdb::to_val(address);
+
+    MONERO_LMDB_CHECK(mdb_cursor_get(cur.get(), &key, &value, MDB_GET_BOTH));
+    return subaddress_indexes.get_value<MONERO_FIELD(subaddress_map, index)>(value);
+  }
+
   expect<std::vector<webhook_value>>
   storage_reader::find_webhook(webhook_key const& key, crypto::hash8 const& payment_id, cursor::webhooks cur)
   {
@@ -883,6 +1013,14 @@ namespace db
     );
   }
 
+  static void write_bytes(wire::json_writer& dest, const std::pair<lws::db::account_id, std::vector<std::pair<lws::db::major_index, std::vector<std::array<lws::db::minor_index, 2>>>>>& self)
+  {
+    wire::object(dest,
+      wire::field("id", std::cref(self.first)),
+      wire::field("subaddress_indexes", std::cref(self.second))
+    );
+  }
+
   expect<void> storage_reader::json_debug(std::ostream& out, bool show_keys)
   {
     using boost::adaptors::reverse;
@@ -903,6 +1041,8 @@ namespace db
     cursor::requests requests_cur;
     cursor::webhooks webhooks_cur;
     cursor::webhooks events_cur;
+    cursor::subaddress_ranges ranges_cur;
+    cursor::subaddress_indexes indexes_cur;
 
     MONERO_CHECK(check_cursor(*txn, db->tables.blocks, curs.blocks_cur));
     MONERO_CHECK(check_cursor(*txn, db->tables.accounts, accounts_cur));
@@ -914,6 +1054,8 @@ namespace db
     MONERO_CHECK(check_cursor(*txn, db->tables.requests, requests_cur));
     MONERO_CHECK(check_cursor(*txn, db->tables.webhooks, webhooks_cur));
     MONERO_CHECK(check_cursor(*txn, db->tables.events, events_cur));
+    MONERO_CHECK(check_cursor(*txn, db->tables.subaddress_ranges, ranges_cur));
+    MONERO_CHECK(check_cursor(*txn, db->tables.subaddress_indexes, indexes_cur));
 
     auto blocks_partial =
       get_blocks<boost::container::static_vector<block_info, 12>>(*curs.blocks_cur, 0);
@@ -952,6 +1094,14 @@ namespace db
     if (!requests_stream)
       return requests_stream.error();
 
+    const auto ranges_data = subaddress_ranges.get_all(*ranges_cur);
+    if (!ranges_data)
+        return ranges_data.error();
+
+    auto indexes_stream = subaddress_indexes.get_key_stream(std::move(indexes_cur));
+    if (!indexes_stream)
+      return indexes_stream.error();
+
     // This list should be smaller ... ?
     const auto webhooks_data = webhooks.get_all(*webhooks_cur);
     if (!webhooks_data)
@@ -972,6 +1122,8 @@ namespace db
       wire::field(spends.name, wire::as_object(spends_stream->make_range(), wire::as_integer, wire::as_array)),
       wire::field(images.name, wire::as_object(images_stream->make_range(), output_id_key{}, wire::as_array)),
       wire::field(requests.name, wire::as_object(requests_stream->make_range(), wire::enum_as_string, toggle_keys_filter)),
+      wire::field(subaddress_ranges.name, std::cref(*ranges_data)),
+      wire::field(subaddress_indexes.name, wire::as_object(indexes_stream->make_range(), wire::as_integer, wire::as_array)),
       wire::field(webhooks.name, std::cref(*webhooks_data)),
       wire::field(events_by_account_id.name, wire::as_object(events_stream->make_range(), wire::as_integer, wire::as_array))
     );
@@ -2209,6 +2361,173 @@ namespace db
     });
   }
 
+  expect<std::vector<subaddress_dict>>
+  storage::upsert_subaddresses(const account_id id, const account_address& address, const crypto::secret_key& view_key, std::vector<subaddress_dict> subaddrs, const std::uint32_t max_subaddr)
+  {
+    MONERO_PRECOND(db != nullptr);
+    std::sort(subaddrs.begin(), subaddrs.end());
+
+    return db->try_write([this, id, &address, &view_key, &subaddrs, max_subaddr] (MDB_txn& txn) -> expect<std::vector<subaddress_dict>>
+    {
+      std::size_t subaddr_count = 0;
+      std::vector<subaddress_dict> out{};
+      index_ranges new_dict{};
+      const auto add_out = [&out] (major_index major, index_range minor)
+      {
+        if (out.empty() || out.back().first != major)
+          out.emplace_back(major, index_ranges{minor});
+        else
+          out.back().second.push_back(minor);
+      };
+
+      const auto check_max_range = [&subaddr_count, max_subaddr] (const index_range& range) -> bool
+      {
+        const auto more = std::uint32_t(range[1]) - std::uint32_t(range[0]);
+        if (max_subaddr - subaddr_count <= more)
+          return false;
+        subaddr_count += more + 1;
+        return true;
+      };
+      const auto check_max_ranges = [&check_max_range] (const index_ranges& ranges) -> bool
+      {
+        for (const auto& range : ranges)
+        {
+          if (!check_max_range(range))
+            return false;
+        }
+        return true;
+      };
+
+      cursor::subaddress_ranges   ranges_cur;
+      cursor::subaddress_indexes  indexes_cur;
+
+      MONERO_CHECK(check_cursor(txn, this->db->tables.subaddress_ranges, ranges_cur));
+      MONERO_CHECK(check_cursor(txn, this->db->tables.subaddress_indexes, indexes_cur));
+
+      MDB_val key = lmdb::to_val(id);
+      MDB_val value{};
+      int err = mdb_cursor_get(indexes_cur.get(), &key, &value, MDB_SET);
+      if (err)
+      {
+        if (err != MDB_NOTFOUND)
+          return {lmdb::error(err)};
+      }
+      else
+      {
+        MONERO_LMDB_CHECK(mdb_cursor_count(indexes_cur.get(), &subaddr_count));
+        if (max_subaddr < subaddr_count)
+          return {error::max_subaddresses};
+      }
+
+      for (auto& major_entry : subaddrs)
+      {
+        new_dict.clear();
+        if (!check_subaddress_dict(major_entry))
+        {
+          MERROR("Invalid subaddress_dict given to storage::upsert_subaddrs");
+          return {wire::error::schema::array};
+        }
+
+        value = lmdb::to_val(major_entry.first);
+        err = mdb_cursor_get(ranges_cur.get(), &key, &value, MDB_GET_BOTH);
+        if (err)
+        {
+          if (err != MDB_NOTFOUND)
+            return {lmdb::error(err)};
+          if (!check_max_ranges(major_entry.second))
+            return {error::max_subaddresses};
+          out.push_back(major_entry);
+          new_dict = std::move(major_entry.second);
+        }
+        else // merge new minor index ranges with old
+        {
+          auto old_dict = subaddress_ranges.get_value(value);
+          if (!old_dict)
+            return old_dict.error();
+
+          auto& old_range = old_dict->second;
+          const auto& new_range = major_entry.second;
+
+          auto old_loc = old_range.begin();
+          auto new_loc = new_range.begin();
+          for ( ; old_loc != old_range.end() && new_loc != new_range.end(); )
+          {
+            if (std::uint64_t(new_loc->at(1)) + 1 < std::uint32_t(old_loc->at(0)))
+            { // new has no overlap with existing
+              if (!check_max_range(*new_loc))
+                return {error::max_subaddresses};
+
+              new_dict.push_back(*new_loc);
+              add_out(major_entry.first, *new_loc);
+              ++new_loc;
+            }
+            else if (std::uint64_t(old_loc->at(1)) + 1 < std::uint32_t(new_loc->at(0)))
+            { // existing has no overlap with new
+              new_dict.push_back(*old_loc);
+              ++old_loc;
+            }
+            else if (old_loc->at(0) <= new_loc->at(0) && new_loc->at(1) <= old_loc->at(1))
+            { // new is completely within existing
+              ++new_loc;
+            }
+            else // new overlap at beginning, end, or both
+            {
+              if (new_loc->at(0) < old_loc->at(0))
+              { // overlap at beginning
+                const index_range new_range{new_loc->at(0), minor_index(std::uint32_t(old_loc->at(0)) - 1)};
+                if (!check_max_range(new_range))
+                  return {error::max_subaddresses};
+                add_out(major_entry.first, new_range);
+                old_loc->at(0) = new_loc->at(0);
+              }
+              if (old_loc->at(1) < new_loc->at(1))
+              { // overlap at end
+                const index_range new_range{minor_index(std::uint32_t(old_loc->at(1)) + 1), new_loc->at(1)};
+                if (!check_max_range(new_range))
+                  return {error::max_subaddresses};
+                add_out(major_entry.first, new_range);
+                old_loc->at(1) = new_loc->at(1);
+              }
+              ++new_loc;
+            }
+          }
+
+          std::copy(old_loc, old_range.end(), std::back_inserter(new_dict));
+          for ( ; new_loc != new_range.end(); ++new_loc)
+          {
+            if (!check_max_range(*new_loc))
+              return {error::max_subaddresses};
+            new_dict.push_back(*new_loc);
+            add_out(major_entry.first, *new_loc);
+          }
+        }
+
+        for (const auto& new_indexes : new_dict)
+        {
+          for (std::uint64_t minor : boost::counting_range(std::uint64_t(new_indexes[0]), std::uint64_t(new_indexes[1]) + 1))
+          {
+            subaddress_map new_value{};
+            new_value.index = address_index{major_entry.first, minor_index(minor)};
+            new_value.subaddress = new_value.index.get_spend_public(address, view_key);
+
+            value = lmdb::to_val(new_value);
+
+            MONERO_LMDB_CHECK(mdb_cursor_put(indexes_cur.get(), &key, &value, 0));
+          }
+        }
+
+        const expect<epee::byte_slice> value_bytes =
+          subaddress_ranges.make_value(major_entry.first, new_dict);
+        if (!value_bytes)
+          return value_bytes.error();
+        value = MDB_val{value_bytes->size(), const_cast<void*>(static_cast<const void*>(value_bytes->data()))};
+        MONERO_LMDB_CHECK(mdb_cursor_put(ranges_cur.get(), &key, &value, 0));
+      }
+
+      return {std::move(out)};
+    });
+  }
+
   expect<void> storage::add_webhook(const webhook_type type, const boost::optional<account_address>& address, const webhook_value& event)
   {
     if (event.second.url != "zmq")
@@ -2247,8 +2566,10 @@ namespace db
         return {error::bad_webhook};
 
       lmkey = lmdb::to_val(key);
-      const epee::byte_slice value = webhooks.make_value(event.first, event.second);
-      lmvalue = MDB_val{value.size(), const_cast<void*>(static_cast<const void*>(value.data()))};
+      const expect<epee::byte_slice> value = webhooks.make_value(event.first, event.second);
+      if (!value)
+        return value.error();
+      lmvalue = MDB_val{value->size(), const_cast<void*>(static_cast<const void*>(value->data()))};
       MONERO_LMDB_CHECK(mdb_cursor_put(webhooks_cur.get(), &lmkey, &lmvalue, 0));
       return success();
     });

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -85,10 +85,14 @@ namespace lws
         return "Unspecified error when retrieving exchange rates";
       case error::http_server:
         return "HTTP server failed";
+      case error::invalid_range:
+        return "Invalid subaddress range provided";
       case error::json_rpc:
         return "Error returned by JSON-RPC server";
       case error::exchange_rates_old:
         return "Exchange rates are older than cache interval";
+      case error::max_subaddresses:
+        return "Max subaddresses exceeded";
       case error::not_enough_mixin:
         return "Not enough outputs to meet requested mixin count";
       case error::signal_abort_process:

--- a/src/error.h
+++ b/src/error.h
@@ -57,7 +57,9 @@ namespace lws
     exchange_rates_fetch,       //!< Exchange rates fetching failed
     exchange_rates_old,         //!< Exchange rates are older than cache interval
     http_server,                //!< HTTP server failure (init or run)
+    invalid_range,              //!< Invalid subaddress range provided
     json_rpc,                   //!< Error returned by JSON-RPC server
+    max_subaddresses,           //!< Max subaddresses exceeded
     not_enough_mixin,           //!< Not enough outputs to meet mixin count
     signal_abort_process,       //!< In process ZMQ PUB to abort the process was received
     signal_abort_scan,          //!< In process ZMQ PUB to abort the scan was received

--- a/src/rest_server.h
+++ b/src/rest_server.h
@@ -53,6 +53,7 @@ namespace lws
       epee::net_utils::ssl_authentication_t auth;
       std::vector<std::string> access_controls;
       std::size_t threads;
+      std::uint32_t max_subaddresses;
       epee::net_utils::ssl_verification_t webhook_verify;
       bool allow_external;
       bool disable_admin_auth;

--- a/src/rpc/light_wallet.h
+++ b/src/rpc/light_wallet.h
@@ -65,6 +65,15 @@ namespace rpc
   void read_bytes(wire::json_reader&, account_credentials&);
 
 
+  struct new_subaddrs_response
+  {
+    new_subaddrs_response() = delete;
+    std::vector<db::subaddress_dict> new_subaddrs;
+    std::vector<db::subaddress_dict> all_subaddrs;
+  };
+  void write_bytes(wire::json_writer&, const new_subaddrs_response&);
+
+
   struct transaction_spend
   {
     transaction_spend() = delete;
@@ -164,6 +173,14 @@ namespace rpc
   void write_bytes(wire::json_writer&, const get_unspent_outs_response&);
 
 
+  struct get_subaddrs_response
+  {
+    get_subaddrs_response() = delete;
+    std::vector<db::subaddress_dict> all_subaddrs;
+  };
+  void write_bytes(wire::json_writer&, const get_subaddrs_response&);
+
+
   struct import_response
   {
     import_response() = delete;
@@ -193,6 +210,19 @@ namespace rpc
   void write_bytes(wire::json_writer&, login_response);
 
 
+  struct provision_subaddrs_request
+  {
+    provision_subaddrs_request() = delete;
+    account_credentials creds;
+    boost::optional<std::uint32_t> maj_i;
+    boost::optional<std::uint32_t> min_i;
+    boost::optional<std::uint32_t> n_maj;
+    boost::optional<std::uint32_t> n_min;
+    boost::optional<bool> get_all;
+  };
+  void read_bytes(wire::json_reader&, provision_subaddrs_request&);
+
+  
   struct submit_raw_tx_request
   {
     submit_raw_tx_request() = delete;
@@ -206,5 +236,15 @@ namespace rpc
     const char* status;
   };
   void write_bytes(wire::json_writer&, submit_raw_tx_response);
+
+
+  struct upsert_subaddrs_request
+  {
+    upsert_subaddrs_request() = delete;
+    account_credentials creds;
+    std::vector<db::subaddress_dict> subaddrs;
+    boost::optional<bool> get_all;
+  };
+  void read_bytes(wire::json_reader&, upsert_subaddrs_request&);
 } // rpc
 } // lws

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -49,7 +49,7 @@ namespace lws
     static expect<rpc::client> sync(db::storage disk, rpc::client client);
 
     //! Poll daemon until `stop()` is called, using `thread_count` threads.
-    static void run(db::storage disk, rpc::context ctx, std::size_t thread_count, epee::net_utils::ssl_verification_t webhook_verify);
+    static void run(db::storage disk, rpc::context ctx, std::size_t thread_count, epee::net_utils::ssl_verification_t webhook_verify, bool enable_subaddresses);
 
     //! \return True if `stop()` has never been called.
     static bool is_running() noexcept { return running; }

--- a/src/wire/adapted/array.h
+++ b/src/wire/adapted/array.h
@@ -1,0 +1,96 @@
+// Copyright (c) 2023, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <cstdint>
+#include "span.h"
+#include "wire/error.h"
+#include "wire/read.h"
+
+namespace wire
+{
+  // enable writing of std::array
+  template<typename T, std::size_t N>
+  struct is_array<std::array<T, N>>
+    : std::true_type
+  {};
+
+  // `std::array`s of `char` and `uint8_t` are not arrays
+  template<std::size_t N>
+  struct is_array<std::array<char, N>>
+    : std::false_type
+  {};
+  template<std::size_t N>
+  struct is_array<std::array<std::uint8_t, N>>
+    : std::false_type
+  {};
+
+  template<typename R, std::size_t N>
+  inline void read_bytes(R& source, std::array<char, N>& dest)
+  {
+    source.binary(epee::to_mut_span(dest));
+  }
+  template<typename R, std::size_t N>
+  inline void read_bytes(R& source, std::array<std::uint8_t, N>& dest)
+  {
+    source.binary(epee::to_mut_span(dest));
+  }
+
+  template<typename W, std::size_t N>
+  inline void write_bytes(W& dest, const std::array<char, N>& source)
+  {
+    source.binary(epee::to_span(source));
+  }
+  template<typename W, std::size_t N>
+  inline void write_bytes(W& dest, const std::array<std::uint8_t, N>& source)
+  {
+    source.binary(epee::to_span(source));
+  }
+
+  // Read a fixed sized array
+  template<typename R, typename T, std::size_t N>
+  inline void read_bytes(R& source, std::array<T, N>& dest)
+  {
+    std::size_t count = source.start_array();
+    const bool json = (count == 0);
+    if (!json && count != dest.size())
+      WIRE_DLOG_THROW(wire::error::schema::array, "Expected array of size " << dest.size());
+
+    for (auto& elem : dest)
+    {
+      if (json && source.is_array_end(count))
+        WIRE_DLOG_THROW(wire::error::schema::array, "Expected array of size " << dest.size());
+      wire_read::bytes(source, elem);
+      --count;
+    }
+    if (!source.is_array_end(count))
+      WIRE_DLOG_THROW(wire::error::schema::array, "Expected array of size " << dest.size());
+    source.end_array();
+  }
+}
+

--- a/src/wire/write.h
+++ b/src/wire/write.h
@@ -206,8 +206,8 @@ namespace wire_write
   inline constexpr std::size_t array_size(const W& dest, const T& source) noexcept
   { return array_size_(dest.need_array_size(), source); }
 
-  template<typename W, typename T>
-  inline void array(W& dest, const T& source)
+  template<typename W, typename T, typename F = wire::identity_>
+  inline void array(W& dest, const T& source, F f = {})
   {
     using value_type = typename T::value_type;
     static_assert(!std::is_same<value_type, char>::value, "write array of chars as binary");
@@ -215,7 +215,7 @@ namespace wire_write
 
     dest.start_array(array_size(dest, source));
     for (const auto& elem : source)
-      bytes(dest, elem);
+      bytes(dest, f(elem));
     dest.end_array();
   }
 
@@ -268,7 +268,7 @@ namespace wire
   template<typename W, typename T, typename F>
   inline void write_bytes(W& dest, const as_array_<T, F> source)
   {
-    wire_write::array(dest, boost::adaptors::transform(source.get_value(), source.filter));
+    wire_write::array(dest, source.get_value(), std::move(source.filter));
   }
   template<typename W, typename T>
   inline std::enable_if_t<is_array<T>::value> write_bytes(W& dest, const T& source)

--- a/tests/unit/db/CMakeLists.txt
+++ b/tests/unit/db/CMakeLists.txt
@@ -26,7 +26,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-add_library(monero-lws-unit-db OBJECT storage.test.cpp webhook.test.cpp)
+add_library(monero-lws-unit-db OBJECT data.test.cpp storage.test.cpp subaddress.test.cpp webhook.test.cpp)
 target_link_libraries(
   monero-lws-unit-db
   monero-lws-unit-framework

--- a/tests/unit/db/data.test.cpp
+++ b/tests/unit/db/data.test.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020, The Monero Project
+// Copyright (c) 2023, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are
@@ -25,44 +25,52 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once
+#include "framework.test.h"
 
-#include <cstdint>
+#include "db/data.h"
 
-namespace lws
+LWS_CASE("db::data::check_subaddress_dict")
 {
-namespace db
-{
-  enum account_flags : std::uint8_t;
-  enum class account_id : std::uint32_t;
-  enum class account_status : std::uint8_t;
-  enum class block_id : std::uint64_t;
-  enum extra : std::uint8_t;
-  enum class extra_and_length : std::uint8_t;
-  enum class major_index : std::uint32_t;
-  enum class minor_index : std::uint32_t;
-  enum class request : std::uint8_t;
-  enum class webhook_type : std::uint8_t; 
+  EXPECT(lws::db::check_subaddress_dict({lws::db::major_index(0), lws::db::index_ranges{}}));
+  EXPECT(lws::db::check_subaddress_dict(
+    {
+      lws::db::major_index(0),
+      lws::db::index_ranges{lws::db::index_range{{lws::db::minor_index(0), lws::db::minor_index(0)}}}
+    }
+  ));
+  EXPECT(lws::db::check_subaddress_dict(
+    {
+      lws::db::major_index(0),
+      lws::db::index_ranges{
+        lws::db::index_range{{lws::db::minor_index(0), lws::db::minor_index(0)}},
+        lws::db::index_range{{lws::db::minor_index(2), lws::db::minor_index(10)}}
+      }
+    }
+  ));
+  
+  EXPECT(!lws::db::check_subaddress_dict(
+    {
+      lws::db::major_index(0),
+      lws::db::index_ranges{lws::db::index_range{{lws::db::minor_index(1), lws::db::minor_index(0)}}}
+    }
+  ));
+  EXPECT(!lws::db::check_subaddress_dict(
+    {
+      lws::db::major_index(0),
+      lws::db::index_ranges{
+        lws::db::index_range{{lws::db::minor_index(0), lws::db::minor_index(4)}},
+        lws::db::index_range{{lws::db::minor_index(1), lws::db::minor_index(10)}}
+      }
+    }
+  ));
+  EXPECT(!lws::db::check_subaddress_dict(
+    {
+      lws::db::major_index(0),
+      lws::db::index_ranges{
+        lws::db::index_range{{lws::db::minor_index(0), lws::db::minor_index(0)}},
+        lws::db::index_range{{lws::db::minor_index(1), lws::db::minor_index(10)}}
+      }
+    }
+  ));
 
-  struct account;
-  struct account_address;
-  struct address_index;
-  struct block_info;
-  struct key_image;
-  struct output;
-  struct output_id;
-  struct request_info;
-  struct spend;
-  class storage;
-  struct subaddress_map;
-  struct transaction_link;
-  struct view_key;
-  struct webhook_data;
-  struct webhook_dupsort;
-  struct webhook_event;
-  struct webhook_key;
-  struct webhook_new_account;
-  struct webhook_output;
-  struct webhook_tx_confirmation;
-} // db
-} // lws
+}

--- a/tests/unit/db/subaddress.test.cpp
+++ b/tests/unit/db/subaddress.test.cpp
@@ -1,0 +1,422 @@
+// Copyright (c) 2023, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "framework.test.h"
+
+#include <boost/range/counting_range.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <cstdint>
+#include "crypto/crypto.h" // monero/src
+#include "db/data.h"
+#include "db/storage.h"
+#include "db/storage.test.h"
+#include "error.h"
+#include "wire/error.h"
+
+namespace
+{
+  struct user_account
+  {
+    lws::db::account_address account;
+    crypto::secret_key view;
+
+    user_account()
+      : account{}, view{}
+    {}
+  };
+
+  void check_address_map(lest::env& lest_env, lws::db::storage_reader& reader, const user_account& user, const std::vector<lws::db::subaddress_dict>& source)
+  {
+    SETUP("check_address_map")
+    {
+      lws::db::cursor::subaddress_indexes cur = nullptr;
+      for (const auto& major_entry : source)
+      {
+        for (const auto& minor_entry : major_entry.second)
+        {
+          for (std::uint64_t elem : boost::counting_range(std::uint64_t(minor_entry[0]), std::uint64_t(minor_entry[1]) + 1))
+          {
+            const lws::db::address_index index{major_entry.first, lws::db::minor_index(elem)};
+            auto result = reader.find_subaddress(lws::db::account_id(1), index.get_spend_public(user.account, user.view), cur);
+            EXPECT(result.has_value());
+            EXPECT(result == index);
+          }
+        }
+      }
+    }
+  }
+}
+
+LWS_CASE("db::storage::upsert_subaddresses")
+{
+  user_account user{};
+  crypto::generate_keys(user.account.spend_public, user.view);
+  crypto::generate_keys(user.account.view_public, user.view);
+
+  SETUP("One Account DB")
+  {
+    lws::db::test::cleanup_db on_scope_exit{};
+    lws::db::storage db = lws::db::test::get_fresh_db();
+    const lws::db::block_info last_block =
+      MONERO_UNWRAP(MONERO_UNWRAP(db.start_read()).get_last_block());
+    MONERO_UNWRAP(db.add_account(user.account, user.view));
+
+    SECTION("Empty get_subaddresses")
+    {
+      lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
+      EXPECT(MONERO_UNWRAP(reader.get_subaddresses(lws::db::account_id(1))).empty());
+    }
+
+    SECTION("Upsert Basic")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
+      {
+        lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
+
+        EXPECT(result.has_value());
+        EXPECT(result->size() == 1);
+        EXPECT(result->at(0).first == lws::db::major_index(0));
+        EXPECT(result->at(0).second.size() == 1);
+        EXPECT(result->at(0).second[0][0] == lws::db::minor_index(1));
+        EXPECT(result->at(0).second[0][1] == lws::db::minor_index(100));
+
+        check_address_map(lest_env, reader, user, subs);
+      }
+      subs.back().first = lws::db::major_index(1);
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 199);
+      EXPECT(result.has_error());
+      EXPECT(result == lws::error::max_subaddresses);
+
+      lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.size() == 1);
+      EXPECT(fetched->at(0).second[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second[0][1] == lws::db::minor_index(100));
+    }
+
+    SECTION("Upsert Appended")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.size() == 1);
+      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(100));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}};
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 200);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.size() == 1);
+      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(101));
+      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(200));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(201), lws::db::minor_index(201)}};
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 200);
+      EXPECT(result.has_error());
+      EXPECT(result == lws::error::max_subaddresses);
+
+      auto reader = MONERO_UNWRAP(db.start_read());
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.size() == 1);
+      EXPECT(fetched->at(0).second[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second[0][1] == lws::db::minor_index(200));
+    }
+
+    SECTION("Upsert Prepended")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.size() == 1);
+      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(101));
+      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(200));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}};
+
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 199);
+      EXPECT(result.has_error());
+      EXPECT(result == lws::error::max_subaddresses);
+
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 200);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.size() == 1);
+      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(100));
+
+      lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
+      check_address_map(lest_env, reader, user, subs);
+
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.size() == 1);
+      EXPECT(fetched->at(0).second[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second[0][1] == lws::db::minor_index(200));
+    }
+
+    SECTION("Upsert Wrapped")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.size() == 1);
+      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(101));
+      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(200));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(300)}};
+      
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 299);
+      EXPECT(result.has_error());
+      EXPECT(result == lws::error::max_subaddresses);
+
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 300);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.size() == 2);
+      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(100));
+      EXPECT(result->at(0).second[1][0] == lws::db::minor_index(201));
+      EXPECT(result->at(0).second[1][1] == lws::db::minor_index(300));
+
+      lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
+      check_address_map(lest_env, reader, user, subs);
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.size() == 1);
+      EXPECT(fetched->at(0).second[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second[0][1] == lws::db::minor_index(300));
+    }
+
+    SECTION("Upsert After")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.size() == 1);
+      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(100));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(102), lws::db::minor_index(200)}};
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 198);
+      EXPECT(result.has_error());
+      EXPECT(result == lws::error::max_subaddresses);
+
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 199);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.size() == 1);
+      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(102));
+      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(200));
+
+      auto reader = MONERO_UNWRAP(db.start_read());
+      check_address_map(lest_env, reader, user, subs);
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.size() == 2);
+      EXPECT(fetched->at(0).second[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second[0][1] == lws::db::minor_index(100));
+      EXPECT(fetched->at(0).second[1][0] == lws::db::minor_index(102));
+      EXPECT(fetched->at(0).second[1][1] == lws::db::minor_index(200));
+    }
+
+    SECTION("Upsert Before")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.size() == 1);
+      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(101));
+      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(200));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(99)}};
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 198);
+      EXPECT(result.has_error());
+      EXPECT(result == lws::error::max_subaddresses);
+
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 199);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.size() == 1);
+      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(99));
+
+      auto reader = MONERO_UNWRAP(db.start_read());
+      check_address_map(lest_env, reader, user, subs);
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.size() == 2);
+      EXPECT(fetched->at(0).second[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second[0][1] == lws::db::minor_index(99));
+      EXPECT(fetched->at(0).second[1][0] == lws::db::minor_index(101));
+      EXPECT(fetched->at(0).second[1][1] == lws::db::minor_index(200));
+    }
+
+    SECTION("Upsert Encapsulated")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(200)}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 200);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.size() == 1);
+      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(200));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(5), lws::db::minor_index(99)}};
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 300);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 0);
+
+      auto reader = MONERO_UNWRAP(db.start_read());
+      check_address_map(lest_env, reader, user, subs);
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.size() == 1);
+      EXPECT(fetched->at(0).second[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second[0][1] == lws::db::minor_index(200));
+    }
+
+
+    SECTION("Bad subaddress_dict")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}
+      );
+      subs.back().second.push_back(
+        lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
+      EXPECT(result.has_error());
+      EXPECT(result == wire::error::schema::array);
+    }
+  }
+}


### PR DESCRIPTION
This brings subaddress support to MLWS by implementing the [working draft for LWS subaddresses](https://github.com/monero-project/meta/pull/647). If the spec changes before being finalized, then MLWS will be modified to match the spec changes.