### PR TITLE
Remove enumeration function from ::wire reading and writing

### DIFF
--- a/src/wire.h
+++ b/src/wire.h
@@ -59,11 +59,14 @@
   }                                                                     \
   void read_bytes(::wire::reader& source, type_& dest)                  \
   {                                                                     \
-    dest = type_(source.enumeration(map));                              \
+    const auto val = type_ ## _from_string(source.string());            \
+    if (!val)                                                           \
+      WIRE_DLOG_THROW(::wire::error::schema::enumeration, #type_);      \
+    dest = *val;                                                        \
   }                                                                     \
   void write_bytes(::wire::writer& dest, const type_ source)            \
   {                                                                     \
-    dest.enumeration(std::size_t(source), map);                         \
+    dest.string(get_string(source));                                    \
   }
 
 #define WIRE_DEFINE_OBJECT(type, map)                          \

--- a/src/wire/json/read.cpp
+++ b/src/wire/json/read.cpp
@@ -316,22 +316,6 @@ namespace wire
       WIRE_DLOG_THROW(error::schema::fixed_binary, "of size" << dest.size() * 2 << " but got " << value.size());
   }
 
-  std::size_t json_reader::enumeration(epee::span<char const* const> enums)
-  {
-    rapidjson_sax json_enum{error::schema::string};
-    read_next_value(json_enum);
-
-    const boost::string_ref value{json_enum.value.string.ptr, json_enum.value.string.length};
-    for (std::size_t i = 0; i < enums.size(); ++i)
-    {
-      if (value == enums[i])
-        return i;
-    }
-
-    WIRE_DLOG_THROW(error::schema::enumeration, value << " is not a valid enum");
-    return enums.size();
-  }
-
   std::size_t json_reader::start_array()
   {
     if (get_next_token() != '[')

--- a/src/wire/json/read.h
+++ b/src/wire/json/read.h
@@ -88,9 +88,6 @@ namespace wire
     //! \throw wire::exception if next token cannot be read as hex into `dest`.
     void binary(epee::span<std::uint8_t> dest) override final;
 
-    //! \throw wire::exception if invalid next token invalid enum. \return Index in `enums`.
-    std::size_t enumeration(epee::span<char const* const> enums) override final;
-
 
     //! \throw wire::exception if next token not `[`.
     std::size_t start_array() override final;

--- a/src/wire/json/write.cpp
+++ b/src/wire/json/write.cpp
@@ -130,13 +130,6 @@ namespace wire
       //}
   }
 
-  void json_writer::enumeration(const std::size_t index, const epee::span<char const* const> enums)
-  {
-    if (enums.size() < index)
-      throw std::logic_error{"Invalid enum/string value"};
-    string({enums[index], std::strlen(enums[index])});
-  }
-
   void json_writer::start_array(std::size_t)
   {
     formatter_.StartArray();

--- a/src/wire/json/write.h
+++ b/src/wire/json/write.h
@@ -101,8 +101,6 @@ namespace wire
     void string(boost::string_ref) override final;
     void binary(epee::span<const std::uint8_t> source) override final;
 
-    void enumeration(std::size_t index, epee::span<char const* const> enums) override final;
-
     void start_array(std::size_t) override final;
     void end_array() override final;
 

--- a/src/wire/msgpack/read.cpp
+++ b/src/wire/msgpack/read.cpp
@@ -428,14 +428,6 @@ namespace wire
     std::memcpy(dest.data(), bytes.data(), dest.size());
   }
 
-  std::size_t msgpack_reader::enumeration(const epee::span<char const* const> enums)
-  {
-    const std::uintmax_t value = unsigned_integer();
-    if (enums.size() < value)
-      WIRE_DLOG_THROW(error::schema::enumeration, value << " is not a valid enum");
-    return std::size_t(value);
-  }
-
   std::size_t msgpack_reader::start_array()
   {
     const std::size_t upcoming =

--- a/src/wire/msgpack/read.h
+++ b/src/wire/msgpack/read.h
@@ -118,9 +118,6 @@ namespace wire
     //! \throw wire::exception if next token cannot be read as hex into `dest`.
     void binary(epee::span<std::uint8_t> dest) override final;
 
-    //! \throw wire::exception if invalid next token invalid enum. \return Index in `enums`.
-    std::size_t enumeration(epee::span<char const* const> enums) override final;
-
 
     //! \throw wire::exception if next token not `[`.
     std::size_t start_array() override final;

--- a/src/wire/msgpack/write.cpp
+++ b/src/wire/msgpack/write.cpp
@@ -178,13 +178,6 @@ namespace wire
     --expected_;
   }
 
-  void msgpack_writer::enumeration(const std::size_t index, const epee::span<char const* const> enums)
-  {
-    if (enums.size() < index)
-      throw std::logic_error{"Invalid enum/string value"};
-    unsigned_integer(index);
-  }
-
   void msgpack_writer::start_array(const std::size_t items)
   {
     write_count<msgpack::ftag_array, msgpack::array_types>(bytes_, items);

--- a/src/wire/msgpack/write.h
+++ b/src/wire/msgpack/write.h
@@ -136,8 +136,6 @@ namespace wire
     //! \throw wire::exception if `source.size()` exceeds 2^32-1
     void binary(epee::span<const std::uint8_t> source) override final;
 
-    void enumeration(std::size_t index, epee::span<char const* const> enums) override final;
-
     //! \throw wire::exception if `items` exceeds 2^32-1.
     void start_array(std::size_t items) override final;
     void end_array() override final { --expected_; }

--- a/src/wire/read.h
+++ b/src/wire/read.h
@@ -104,9 +104,6 @@ namespace wire
     //! \throw wire::exception if next value cannot be read as binary into `dest`.
     virtual void binary(epee::span<std::uint8_t> dest) = 0;
 
-    //! \throw wire::exception if next value invalid enum. \return Index in `enums`.
-    virtual std::size_t enumeration(epee::span<char const* const> enums) = 0;
-
     //! \throw wire::exception if next value not array
     virtual std::size_t start_array() = 0;
 

--- a/src/wire/write.h
+++ b/src/wire/write.h
@@ -67,8 +67,6 @@ namespace wire
     virtual void string(boost::string_ref) = 0;
     virtual void binary(epee::span<const std::uint8_t> bytes) = 0;
 
-    virtual void enumeration(std::size_t index, epee::span<char const* const> enums) = 0;
-
     virtual void start_array(std::size_t) = 0;
     virtual void end_array() = 0;
 


### PR DESCRIPTION
The "upstream" `::wire` interface (being proposed in monero repo) does not have an `enumeration` function, because there is no use for it. This removes that functionality in preparation for merging with upstream. This does mean that msgpack can no longer output an integer _instead of a string_, but that may be the for the best for compatibility reasons.