### PR TITLE
Update cxx version to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ cmake_minimum_required(VERSION 3.1.0)
 project(monero-lws)
 
 enable_language(CXX)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(BUILD_TESTS "Build Tests" OFF)


### PR DESCRIPTION
The `master` and `develop` builds will soon [need C++17](https://github.com/monero-project/monero/pull/9072) support enabled.