### PR TITLE
Fix output_id bug with coinbase transactions

### DIFF
--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -407,7 +407,7 @@ namespace lws
             db::output{
               db::transaction_link{height, tx_hash},
               db::output::spend_meta_{
-                db::output_id{out.amount, out_ids.at(index)},
+                db::output_id{tx.version < 2 ? out.amount : 0, out_ids.at(index)},
                 amount,
                 mixin,
                 boost::numeric_cast<std::uint32_t>(index),


### PR DESCRIPTION
After transaction version 2, coinbases have public `amount`, but are still logically placed in the `0` category for outputs. I have in-progress unit tests that catch this, and I wanted to post this ASAP (so I did a dedicated PR).