### PR TITLE
Fix warnings in unit tests

### DIFF
--- a/tests/unit/wire/read.test.cpp
+++ b/tests/unit/wire/read.test.cpp
@@ -47,7 +47,7 @@ namespace
     {
       EXPECT(Target(0) == wire::integer::cast_unsigned<Target>(std::uintmax_t(0)));
       EXPECT(limit::max() == wire::integer::cast_unsigned<Target>(std::uintmax_t(limit::max())));
-      if (limit::max() < max)
+      if constexpr (limit::max() < max)
       {
         EXPECT_THROWS_AS(wire::integer::cast_unsigned<Target>(std::uintmax_t(limit::max()) + 1), wire::exception);
         EXPECT_THROWS_AS(wire::integer::cast_unsigned<Target>(max), wire::exception);
@@ -68,7 +68,7 @@ namespace
 
     SETUP("intmax_t to " + boost::core::demangle(typeid(Target).name()))
     {
-      if (min < limit::min())
+      if constexpr (min < limit::min())
       {
         EXPECT_THROWS_AS(wire::integer::cast_signed<Target>(std::intmax_t(limit::min()) - 1), wire::exception);
         EXPECT_THROWS_AS(wire::integer::cast_signed<Target>(min), wire::exception);
@@ -76,7 +76,7 @@ namespace
       EXPECT(limit::min() == wire::integer::cast_signed<Target>(std::intmax_t(limit::min())));
       EXPECT(Target(0) == wire::integer::cast_signed<Target>(std::intmax_t(0)));
       EXPECT(limit::max() == wire::integer::cast_signed<Target>(std::intmax_t(limit::max())));
-      if (limit::max() < max)
+      if constexpr (limit::max() < max)
       {
         EXPECT_THROWS_AS(wire::integer::cast_signed<Target>(std::intmax_t(limit::max()) + 1), wire::exception);
         EXPECT_THROWS_AS(wire::integer::cast_signed<Target>(max), wire::exception);


### PR DESCRIPTION
Now that C++17 has landed in develop, we can silence some of the warnings about integers out of range.