### PR TITLE
Refuse chain rollback past a checkpoint

### DIFF
--- a/src/db/storage.cpp
+++ b/src/db/storage.cpp
@@ -1453,7 +1453,7 @@ namespace db
 
         if (*hash != chain.front())
         {
-          if (current < get_checkpoints().get_max_height())
+          if (current <= get_checkpoints().get_max_height())
           {
             MERROR("Attempting rollback past last checkpoint; invalid daemon chain response");
             return {lws::error::bad_blockchain};

--- a/src/db/storage.cpp
+++ b/src/db/storage.cpp
@@ -409,52 +409,6 @@ namespace db
       }
     }
 
-    //! \return a single instance of compiled-in checkpoints for lws
-    cryptonote::checkpoints const& get_checkpoints()
-    {
-      struct initializer
-      {
-        cryptonote::checkpoints data;
-
-        initializer()
-          : data()
-        {
-          data.init_default_checkpoints(lws::config::network);
-
-          std::string const* genesis_tx = nullptr;
-          std::uint32_t genesis_nonce = 0;
-
-          switch (lws::config::network)
-          {
-          case cryptonote::TESTNET:
-            genesis_tx = std::addressof(::config::testnet::GENESIS_TX);
-            genesis_nonce = ::config::testnet::GENESIS_NONCE;
-            break;
-
-          case cryptonote::STAGENET:
-            genesis_tx = std::addressof(::config::stagenet::GENESIS_TX);
-            genesis_nonce = ::config::stagenet::GENESIS_NONCE;
-            break;
-
-          case cryptonote::MAINNET:
-            genesis_tx = std::addressof(::config::GENESIS_TX);
-            genesis_nonce = ::config::GENESIS_NONCE;
-            break;
-
-          default:
-            MONERO_THROW(lws::error::bad_blockchain, "Unsupported net type");
-          }
-          cryptonote::block b;
-          cryptonote::generate_genesis_block(b, *genesis_tx, genesis_nonce);
-          crypto::hash block_hash = cryptonote::get_block_hash(b);
-          if (!data.add_checkpoint(0, epee::to_hex::string(epee::as_byte_span(block_hash))))
-            MONERO_THROW(lws::error::bad_blockchain, "Genesis tx and checkpoints file mismatch");
-        }
-      };
-      static const initializer instance;
-      return instance.data;
-    }
-
     //! \return Current block hash at `id` using `cur`.
     expect<crypto::hash> do_get_block_hash(MDB_cursor& cur, block_id id) noexcept
     {
@@ -469,7 +423,7 @@ namespace db
       cursor::blocks cur = MONERO_UNWRAP(lmdb::open_cursor<cursor::close_blocks>(txn, tbl));
 
       std::map<std::uint64_t, crypto::hash> const& points =
-        get_checkpoints().get_points();
+        storage::get_checkpoints().get_points();
 
       if (points.empty() || points.begin()->first != 0)
         MONERO_THROW(lws::error::bad_blockchain, "Checkpoints are empty/expected genesis hash");
@@ -558,7 +512,7 @@ namespace db
         return success();
       };
 
-      const std::uint64_t checkpoint = get_checkpoints().get_max_height();
+      const std::uint64_t checkpoint = lws::db::storage::get_checkpoints().get_max_height();
       const std::uint64_t anchor = lmdb::to_native(out.back().id);
 
       for (unsigned i = 1; i <= max_internal; ++i)
@@ -1155,6 +1109,51 @@ namespace db
     return nullptr;
   }
 
+  cryptonote::checkpoints const& storage::get_checkpoints()
+  {
+    struct initializer
+    {
+      cryptonote::checkpoints data;
+
+      initializer()
+        : data()
+      {
+        data.init_default_checkpoints(lws::config::network);
+
+        std::string const* genesis_tx = nullptr;
+        std::uint32_t genesis_nonce = 0;
+
+        switch (lws::config::network)
+        {
+        case cryptonote::TESTNET:
+          genesis_tx = std::addressof(::config::testnet::GENESIS_TX);
+          genesis_nonce = ::config::testnet::GENESIS_NONCE;
+          break;
+
+        case cryptonote::STAGENET:
+          genesis_tx = std::addressof(::config::stagenet::GENESIS_TX);
+          genesis_nonce = ::config::stagenet::GENESIS_NONCE;
+          break;
+
+        case cryptonote::MAINNET:
+          genesis_tx = std::addressof(::config::GENESIS_TX);
+          genesis_nonce = ::config::GENESIS_NONCE;
+          break;
+
+        default:
+          MONERO_THROW(lws::error::bad_blockchain, "Unsupported net type");
+        }
+        cryptonote::block b;
+        cryptonote::generate_genesis_block(b, *genesis_tx, genesis_nonce);
+        crypto::hash block_hash = cryptonote::get_block_hash(b);
+        if (!data.add_checkpoint(0, epee::to_hex::string(epee::as_byte_span(block_hash))))
+          MONERO_THROW(lws::error::bad_blockchain, "Genesis tx and checkpoints file mismatch");
+      }
+    };
+    static const initializer instance;
+    return instance.data;
+  }
+
   storage storage::open(const char* path, unsigned create_queue_max)
   {
     return {
@@ -1421,10 +1420,6 @@ namespace db
     MONERO_PRECOND(!hashes.empty());
     MONERO_PRECOND(db != nullptr);
 
-    // refuse to rollback past a checkpoint
-    if (height < block_id(get_checkpoints().get_max_height()))
-      return {lws::error::bad_blockchain};
-
     return db->try_write([this, height, hashes] (MDB_txn& txn) -> expect<void>
     {
       cursor::blocks blocks_cur;
@@ -1458,6 +1453,12 @@ namespace db
 
         if (*hash != chain.front())
         {
+          if (current < get_checkpoints().get_max_height())
+          {
+            MERROR("Attempting rollback past last checkpoint; invalid daemon chain response");
+            return {lws::error::bad_blockchain};
+          }
+
           MONERO_CHECK(rollback_chain(this->db->tables, txn, *blocks_cur, db::block_id(current)));
           break;
         }

--- a/src/db/storage.cpp
+++ b/src/db/storage.cpp
@@ -1421,6 +1421,10 @@ namespace db
     MONERO_PRECOND(!hashes.empty());
     MONERO_PRECOND(db != nullptr);
 
+    // refuse to rollback past a checkpoint
+    if (height < block_id(get_checkpoints().get_max_height()))
+      return {lws::error::bad_blockchain};
+
     return db->try_write([this, height, hashes] (MDB_txn& txn) -> expect<void>
     {
       cursor::blocks blocks_cur;

--- a/src/db/storage.h
+++ b/src/db/storage.h
@@ -41,6 +41,7 @@
 #include "lmdb/key_stream.h"
 #include "lmdb/value_stream.h"
 
+namespace cryptonote { class checkpoints; }
 namespace lws
 {
 namespace db
@@ -167,6 +168,10 @@ namespace db
     {}
 
   public:
+
+    //! \return A single instance of compiled-in checkpoints for lws
+    static cryptonote::checkpoints const& get_checkpoints();
+
     /*!
       Open a light_wallet_server LDMB database.
 

--- a/tests/unit/db/chain.test.cpp
+++ b/tests/unit/db/chain.test.cpp
@@ -29,7 +29,6 @@
 
 #include <cstdint>
 #include "checkpoints/checkpoints.h" // monero/src
-#include "config.h"
 #include "db/storage.test.h"
 #include "error.h"
 

--- a/tests/unit/db/chain.test.cpp
+++ b/tests/unit/db/chain.test.cpp
@@ -117,14 +117,11 @@ LWS_CASE("db::storage::sync_chain")
 
     SECTION("Fork past checkpoint")
     {
-      cryptonote::checkpoints checkpoints;
-      checkpoints.init_default_checkpoints(lws::config::network);
-
+      const auto& checkpoints = lws::db::storage::get_checkpoints();
       const auto& points = checkpoints.get_points();
-      EXPECT(3 <= points.size());
+      EXPECT(!points.empty());
 
-      auto point = ++points.begin();
-
+      auto point = points.begin();
       const crypto::hash fchain[3] = {
         point->second,
         crypto::rand<crypto::hash>(),

--- a/tests/unit/scanner.test.cpp
+++ b/tests/unit/scanner.test.cpp
@@ -282,8 +282,6 @@ namespace
 
 LWS_CASE("lws::scanner::sync and lws::scanner::run")
 {
-   mlog_set_log_level(4);
-
   cryptonote::account_keys keys{};
   crypto::generate_keys(keys.m_account_address.m_spend_public_key, keys.m_spend_secret_key);
   crypto::generate_keys(keys.m_account_address.m_view_public_key, keys.m_view_secret_key);


### PR DESCRIPTION
This prevents the daemon from attempting to fork the blockchain past a hard-coded checkpoint. The daemon cannot rollback past a checkpoint, so this can only happen with a "bad" daemon.