### PR TITLE
Make arrays optional in light_wallet_server api

### DIFF
--- a/src/rpc/light_wallet.cpp
+++ b/src/rpc/light_wallet.cpp
@@ -273,7 +273,7 @@ namespace lws
       WIRE_FIELD_COPY(start_height),
       WIRE_FIELD_COPY(transaction_height),
       WIRE_FIELD_COPY(blockchain_height),
-      wire::field("transactions", wire::array(boost::adaptors::index(self.transactions)))
+      wire::optional_field("transactions", wire::array(boost::adaptors::index(self.transactions)))
     );
   }
 


### PR DESCRIPTION
I thought I fixed #69, but I accidentally set one of the array fields to required.