### PR TITLE
ZMQ Hardening

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,9 @@ if (WITH_RMQ)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMLWS_RMQ_ENABLED")
 endif()
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+
 set(MONERO_LIBRARIES
   daemon_messages
   serialization

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,9 +40,6 @@ if (WITH_RMQ)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMLWS_RMQ_ENABLED")
 endif()
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
-
 set(MONERO_LIBRARIES
   daemon_messages
   serialization

--- a/src/db/data.cpp
+++ b/src/db/data.cpp
@@ -27,6 +27,7 @@
 #include "data.h"
 
 #include <cstring>
+#include <limits>
 #include <memory>
 
 #include "cryptonote_config.h" // monero/src
@@ -41,7 +42,9 @@
 #include "wire/msgpack.h"
 #include "wire/uuid.h"
 #include "wire/vector.h"
+#include "wire/wrapper/array.h"
 #include "wire/wrapper/defaulted.h"
+#include "wire/wrappers_impl.h"
 
 namespace lws
 {
@@ -82,7 +85,7 @@ namespace db
     {
       wire::object(format,
         wire::field<0>("key", std::ref(self.first)),
-        wire::field<1>("value", std::ref(self.second))
+        wire::optional_field<1>("value", std::ref(self.second))
       );
     }
   }
@@ -91,7 +94,7 @@ namespace db
   {
     bool is_first = true;
     minor_index last = minor_index::primary;
-    for (const auto& elem : self.second)
+    for (const auto& elem : self.second.get_container())
     {
       if (elem[1] < elem[0])
       {

--- a/src/db/data.cpp
+++ b/src/db/data.cpp
@@ -27,7 +27,6 @@
 #include "data.h"
 
 #include <cstring>
-#include <limits>
 #include <memory>
 
 #include "cryptonote_config.h" // monero/src

--- a/src/db/data.h
+++ b/src/db/data.h
@@ -45,6 +45,7 @@
 #include "wire/json/fwd.h"
 #include "wire/msgpack/fwd.h"
 #include "wire/traits.h"
+#include "wire/wrapper/array.h"
 
 namespace lws
 {
@@ -138,7 +139,8 @@ namespace db
   using index_range = std::array<minor_index, 2>;
 
   //! Ranges within a major index
-  using index_ranges = std::vector<index_range>;
+  using min_index_ranges = wire::min_element_size<2>;
+  using index_ranges = wire::array_<std::vector<index_range>, min_index_ranges>;
 
   //! Compatible with msgpack_table
   using subaddress_dict = std::pair<major_index, index_ranges>;

--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -708,7 +708,7 @@ namespace lws
           for (std::uint64_t elem : boost::counting_range(std::uint64_t(major_i), std::uint64_t(major_i) + n_major))
           {
             ranges.emplace_back(
-              db::major_index(elem), db::index_ranges{db::index_range{db::minor_index(minor_i), db::minor_index(minor_i + n_minor - 1)}}
+              db::major_index(elem), db::index_ranges{{db::index_range{db::minor_index(minor_i), db::minor_index(minor_i + n_minor - 1)}}}
             );
           }
           auto upserted = disk.upsert_subaddresses(id, req.creds.address, req.creds.key, ranges, options.max_subaddresses);

--- a/src/rpc/admin.cpp
+++ b/src/rpc/admin.cpp
@@ -49,7 +49,7 @@ namespace wire
 {
   static void write_bytes(wire::writer& dest, const std::pair<lws::db::webhook_key, std::vector<lws::db::webhook_value>>& self)
   {
-    wire::object(dest, wire::field<0>("key", self.first), wire::field<1>("value", self.second));
+    wire::object(dest, wire::field<0>("key", std::cref(self.first)), wire::field<1>("value", std::cref(self.second)));
   }
 }
 
@@ -119,8 +119,14 @@ namespace
   template<typename T, typename... U>
   void read_addresses(wire::reader& source, T& self, U... field)
   {
+    using min_address_size =
+      wire::min_element_sizeof<crypto::public_key, crypto::public_key>;
+
     std::vector<std::string> addresses;
-    wire::object(source, wire::field("addresses", std::ref(addresses)), std::move(field)...);
+    wire::object(source,
+      wire::field("addresses", wire::array<min_address_size>(std::ref(addresses))),
+      std::move(field)...
+    );
 
     self.addresses.reserve(addresses.size());
     for (const auto& elem : addresses)

--- a/src/rpc/client.h
+++ b/src/rpc/client.h
@@ -204,8 +204,10 @@ namespace rpc
       \param rmq_info Required information for RMQ publishing (if enabled)
       \param rates_interval Frequency to retrieve exchange rates. Set value to
         `<= 0` to disable exchange rate retrieval.
+      \param True if additional size constraints should be placed on
+        daemon messages
     */
-    static context make(std::string daemon_addr, std::string sub_addr, std::string pub_addr, rmq_details rmq_info, std::chrono::minutes rates_interval);
+    static context make(std::string daemon_addr, std::string sub_addr, std::string pub_addr, rmq_details rmq_info, std::chrono::minutes rates_interval, const bool untrusted_daemon);
 
     context(context&&) = default;
     context(context const&) = delete;

--- a/src/rpc/daemon_pub.cpp
+++ b/src/rpc/daemon_pub.cpp
@@ -28,25 +28,31 @@
 #include "daemon_pub.h"
 
 #include "cryptonote_basic/cryptonote_basic.h" // monero/src
+#include "cryptonote_config.h"                 // monero/src
 #include "rpc/daemon_zmq.h"
 #include "wire/crypto.h"
 #include "wire/error.h"
 #include "wire/field.h"
 #include "wire/traits.h"
 #include "wire/json/read.h"
+#include "wire/wrapper/array.h"
+#include "wire/wrappers_impl.h"
 
 namespace
 {
+  using max_txes_pub = wire::max_element_count<775>;
+
   struct dummy_chain_array
   {
     using value_type = crypto::hash;
 
-    std::uint64_t count;
+    std::size_t count = 0;
     std::reference_wrapper<crypto::hash> id;
 
     void clear() noexcept {}
     void reserve(std::size_t) noexcept {}
 
+    std::size_t size() const noexcept { return count; }
     crypto::hash& back() noexcept { return id; }
     void emplace_back() { ++count; }
   };
@@ -88,7 +94,7 @@ namespace rpc
 
   static void read_bytes(wire::json_reader& source, full_txpool_pub& self)
   {
-    wire_read::array(source, self.txes);
+    wire_read::bytes(source, wire::array<max_txes_pub>(std::ref(self.txes)));
   }
 
   expect<full_txpool_pub> full_txpool_pub::from_json(std::string&& source)

--- a/src/rpc/daemon_pub.cpp
+++ b/src/rpc/daemon_pub.cpp
@@ -28,7 +28,6 @@
 #include "daemon_pub.h"
 
 #include "cryptonote_basic/cryptonote_basic.h" // monero/src
-#include "cryptonote_config.h"                 // monero/src
 #include "rpc/daemon_zmq.h"
 #include "wire/crypto.h"
 #include "wire/error.h"

--- a/src/rpc/light_wallet.cpp
+++ b/src/rpc/light_wallet.cpp
@@ -50,6 +50,8 @@
 
 namespace
 {
+  using max_subaddrs = wire::max_element_count<16384>;
+
   enum class iso_timestamp : std::uint64_t {};
 
   struct rct_bytes
@@ -178,7 +180,7 @@ namespace lws
   }
   void rpc::read_bytes(wire::json_reader& source, safe_uint64_array& self)
   {
-    for (std::size_t count = source.start_array(); !source.is_array_end(count); --count)
+    for (std::size_t count = source.start_array(0); !source.is_array_end(count); --count)
       self.values.emplace_back(wire::integer::cast_unsigned<std::uint64_t>(source.safe_unsigned_integer()));
     source.end_array();
   }
@@ -374,7 +376,7 @@ namespace lws
     wire::object(source,
       wire::field("address", std::ref(address)),
       wire::field("view_key", std::ref(unwrap(unwrap(self.creds.key)))),
-      WIRE_FIELD(subaddrs),
+      WIRE_FIELD_ARRAY(subaddrs, max_subaddrs),
       WIRE_OPTIONAL_FIELD(get_all)
     );
     convert_address(address, self.creds.address);

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -281,7 +281,7 @@ namespace
 
     boost::filesystem::create_directories(prog.db_path);
     auto disk = lws::db::storage::open(prog.db_path.c_str(), prog.create_queue_max);
-    auto ctx = lws::rpc::context::make(std::move(prog.daemon_rpc), std::move(prog.daemon_sub), std::move(prog.zmq_pub), std::move(prog.rmq), prog.rates_interval);
+    auto ctx = lws::rpc::context::make(std::move(prog.daemon_rpc), std::move(prog.daemon_sub), std::move(prog.zmq_pub), std::move(prog.rmq), prog.rates_interval, prog.untrusted_daemon);
 
     MINFO("Using monerod ZMQ RPC at " << ctx.daemon_address());
     auto client = lws::scanner::sync(disk.clone(), ctx.connect().value(), prog.untrusted_daemon).value();

--- a/src/wire/adapted/array.h
+++ b/src/wire/adapted/array.h
@@ -76,7 +76,7 @@ namespace wire
   template<typename R, typename T, std::size_t N>
   inline void read_bytes(R& source, std::array<T, N>& dest)
   {
-    std::size_t count = source.start_array();
+    std::size_t count = source.start_array(0);
     const bool json = (count == 0);
     if (!json && count != dest.size())
       WIRE_DLOG_THROW(wire::error::schema::array, "Expected array of size " << dest.size());

--- a/src/wire/error.cpp
+++ b/src/wire/error.cpp
@@ -42,6 +42,10 @@ namespace wire
         return "No schema errors";
       case schema::array:
         return "Schema expected array";
+      case schema::array_max_element:
+        return "Schema expected array size to be smaller";
+      case schema::array_min_size:
+        return "Schema expected minimum wire size per array element to be larger";
       case schema::binary:
         return "Schema expected binary value of variable size";
       case schema::boolean:

--- a/src/wire/error.h
+++ b/src/wire/error.h
@@ -54,6 +54,8 @@ namespace wire
     {
       none = 0,        //!< Must be zero for `expect<..>`
       array,           //!< Expected an array value
+      array_max_element,//!< Exceeded max array count 
+      array_min_size,   //!< Below min element wire size
       binary,          //!< Expected a binary value of variable length
       boolean,         //!< Expected a boolean value
       enumeration,     //!< Expected a value from a specific set

--- a/src/wire/json/read.h
+++ b/src/wire/json/read.h
@@ -48,7 +48,6 @@ namespace wire
     struct rapidjson_sax;
 
     std::string source_;
-    epee::span<char> current_;
     rapidjson::Reader reader_;
 
     void read_next_value(rapidjson_sax& handler);
@@ -90,7 +89,7 @@ namespace wire
 
 
     //! \throw wire::exception if next token not `[`.
-    std::size_t start_array() override final;
+    std::size_t start_array(std::size_t) override final;
 
     //! Skips whitespace to next token. \return True if next token is eof or ']'.
     bool is_array_end(std::size_t count) override final;

--- a/src/wire/msgpack/error.cpp
+++ b/src/wire/msgpack/error.cpp
@@ -43,8 +43,12 @@ namespace error
         return "Unable to encode integer in msgpack";
       case msgpack::invalid:
         return "Invalid msgpack encoding";
+      case msgpack::max_tree_size:
+        return "Exceeded tag tracking amount";
       case msgpack::not_enough_bytes:
         return "Expected more bytes in the msgpack stream";
+      case msgpack::underflow_tree:
+        return "Expected more tags";
     }
 
     return "Unknown msgpack error";

--- a/src/wire/msgpack/error.h
+++ b/src/wire/msgpack/error.h
@@ -40,7 +40,9 @@ namespace error
     incomplete,
     integer_encoding,
     invalid,
-    not_enough_bytes
+    max_tree_size,
+    not_enough_bytes,
+    underflow_tree
   };
 
   //! \return Static string describing error `value`.

--- a/src/wire/read.cpp
+++ b/src/wire/read.cpp
@@ -35,6 +35,13 @@ void wire::reader::increment_depth()
     WIRE_DLOG_THROW_(error::schema::maximum_depth);
 }
 
+void wire::reader::decrement_depth()
+{
+  if (!depth_)
+    throw std::logic_error{"reader::decrement_depth() already at zero"};
+  --depth_;
+}
+
 [[noreturn]] void wire::integer::throw_exception(std::intmax_t source, std::intmax_t min, std::intmax_t max)
 {
   static_assert(

--- a/src/wire/wrappers_impl.h
+++ b/src/wire/wrappers_impl.h
@@ -44,7 +44,25 @@ namespace wire
   {
     // see constraints directly above `array_` definition
     static_assert(std::is_same<R, void>::value, "array_ must have a read constraint for memory purposes");
-    wire_read::array(source, wrapper.get_read_object());
+  }
+
+  template<typename R, typename T, std::size_t N>
+  inline void read_bytes(R& source, array_<T, max_element_count<N>>& wrapper)
+  {
+    using array_type = array_<T, max_element_count<N>>;
+    using value_type = typename array_type::value_type;
+    using constraint = typename array_type::constraint;
+    static_assert(constraint::template check<value_type>(), "max reserve bytes exceeded for element");
+    wire_read::array(source, wrapper.get_read_object(), min_element_size<0>{}, constraint{});
+  }
+  template<typename R, typename T, std::size_t N>
+  inline void read_bytes(R& source, array_<T, min_element_size<N>>& wrapper)
+  {
+    using array_type = array_<T, min_element_size<N>>;
+    using value_type = typename array_type::value_type;
+    using constraint = typename array_type::constraint;
+    static_assert(constraint::template check<value_type>(), "max compression ratio exceeded for element");
+    wire_read::array(source, wrapper.get_read_object(), constraint{});
   }
 
   template<typename W, typename T, typename C>

--- a/tests/unit/db/data.test.cpp
+++ b/tests/unit/db/data.test.cpp
@@ -35,41 +35,41 @@ LWS_CASE("db::data::check_subaddress_dict")
   EXPECT(lws::db::check_subaddress_dict(
     {
       lws::db::major_index(0),
-      lws::db::index_ranges{lws::db::index_range{{lws::db::minor_index(0), lws::db::minor_index(0)}}}
+      lws::db::index_ranges{{lws::db::index_range{{lws::db::minor_index(0), lws::db::minor_index(0)}}}}
     }
   ));
   EXPECT(lws::db::check_subaddress_dict(
     {
       lws::db::major_index(0),
-      lws::db::index_ranges{
+      lws::db::index_ranges{{
         lws::db::index_range{{lws::db::minor_index(0), lws::db::minor_index(0)}},
         lws::db::index_range{{lws::db::minor_index(2), lws::db::minor_index(10)}}
-      }
+      }}
     }
   ));
   
   EXPECT(!lws::db::check_subaddress_dict(
     {
       lws::db::major_index(0),
-      lws::db::index_ranges{lws::db::index_range{{lws::db::minor_index(1), lws::db::minor_index(0)}}}
+      lws::db::index_ranges{{lws::db::index_range{{lws::db::minor_index(1), lws::db::minor_index(0)}}}}
     }
   ));
   EXPECT(!lws::db::check_subaddress_dict(
     {
       lws::db::major_index(0),
-      lws::db::index_ranges{
+      lws::db::index_ranges{{
         lws::db::index_range{{lws::db::minor_index(0), lws::db::minor_index(4)}},
         lws::db::index_range{{lws::db::minor_index(1), lws::db::minor_index(10)}}
-      }
+      }}
     }
   ));
   EXPECT(!lws::db::check_subaddress_dict(
     {
       lws::db::major_index(0),
-      lws::db::index_ranges{
+      lws::db::index_ranges{{
         lws::db::index_range{{lws::db::minor_index(0), lws::db::minor_index(0)}},
         lws::db::index_range{{lws::db::minor_index(1), lws::db::minor_index(10)}}
-      }
+      }}
     }
   ));
 

--- a/tests/unit/db/subaddress.test.cpp
+++ b/tests/unit/db/subaddress.test.cpp
@@ -56,7 +56,7 @@ namespace
       lws::db::cursor::subaddress_indexes cur = nullptr;
       for (const auto& major_entry : source)
       {
-        for (const auto& minor_entry : major_entry.second)
+        for (const auto& minor_entry : major_entry.second.get_container())
         {
           for (std::uint64_t elem : boost::counting_range(std::uint64_t(minor_entry[0]), std::uint64_t(minor_entry[1]) + 1))
           {
@@ -96,7 +96,7 @@ LWS_CASE("db::storage::upsert_subaddresses")
       std::vector<lws::db::subaddress_dict> subs{};
       subs.emplace_back(
         lws::db::major_index(0),
-        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}}
       );
       auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
       {
@@ -105,9 +105,9 @@ LWS_CASE("db::storage::upsert_subaddresses")
         EXPECT(result.has_value());
         EXPECT(result->size() == 1);
         EXPECT(result->at(0).first == lws::db::major_index(0));
-        EXPECT(result->at(0).second.size() == 1);
-        EXPECT(result->at(0).second[0][0] == lws::db::minor_index(1));
-        EXPECT(result->at(0).second[0][1] == lws::db::minor_index(100));
+        EXPECT(result->at(0).second.get_container().size() == 1);
+        EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+        EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
 
         check_address_map(lest_env, reader, user, subs);
       }
@@ -121,9 +121,9 @@ LWS_CASE("db::storage::upsert_subaddresses")
       EXPECT(fetched.has_value());
       EXPECT(fetched->size() == 1);
       EXPECT(fetched->at(0).first == lws::db::major_index(0));
-      EXPECT(fetched->at(0).second.size() == 1);
-      EXPECT(fetched->at(0).second[0][0] == lws::db::minor_index(1));
-      EXPECT(fetched->at(0).second[0][1] == lws::db::minor_index(100));
+      EXPECT(fetched->at(0).second.get_container().size() == 1);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
     }
 
     SECTION("Upsert Appended")
@@ -131,15 +131,15 @@ LWS_CASE("db::storage::upsert_subaddresses")
       std::vector<lws::db::subaddress_dict> subs{};
       subs.emplace_back(
         lws::db::major_index(0),
-        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}}
       );
       auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
-      EXPECT(result->at(0).second.size() == 1);
-      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(1));
-      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(100));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
 
       {
         auto reader = MONERO_UNWRAP(db.start_read());
@@ -147,14 +147,14 @@ LWS_CASE("db::storage::upsert_subaddresses")
       }
 
       subs.back().second =
-        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}};
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}};
       result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 200);
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
-      EXPECT(result->at(0).second.size() == 1);
-      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(101));
-      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(200));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(101));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
 
       {
         auto reader = MONERO_UNWRAP(db.start_read());
@@ -162,7 +162,7 @@ LWS_CASE("db::storage::upsert_subaddresses")
       }
 
       subs.back().second =
-        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(201), lws::db::minor_index(201)}};
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(201), lws::db::minor_index(201)}}};
       result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 200);
       EXPECT(result.has_error());
       EXPECT(result == lws::error::max_subaddresses);
@@ -172,9 +172,9 @@ LWS_CASE("db::storage::upsert_subaddresses")
       EXPECT(fetched.has_value());
       EXPECT(fetched->size() == 1);
       EXPECT(fetched->at(0).first == lws::db::major_index(0));
-      EXPECT(fetched->at(0).second.size() == 1);
-      EXPECT(fetched->at(0).second[0][0] == lws::db::minor_index(1));
-      EXPECT(fetched->at(0).second[0][1] == lws::db::minor_index(200));
+      EXPECT(fetched->at(0).second.get_container().size() == 1);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
     }
 
     SECTION("Upsert Prepended")
@@ -182,15 +182,15 @@ LWS_CASE("db::storage::upsert_subaddresses")
       std::vector<lws::db::subaddress_dict> subs{};
       subs.emplace_back(
         lws::db::major_index(0),
-        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}}
       );
       auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
-      EXPECT(result->at(0).second.size() == 1);
-      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(101));
-      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(200));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(101));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
 
       {
         auto reader = MONERO_UNWRAP(db.start_read());
@@ -198,7 +198,7 @@ LWS_CASE("db::storage::upsert_subaddresses")
       }
 
       subs.back().second =
-        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}};
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}};
 
       result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 199);
       EXPECT(result.has_error());
@@ -208,9 +208,9 @@ LWS_CASE("db::storage::upsert_subaddresses")
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
-      EXPECT(result->at(0).second.size() == 1);
-      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(1));
-      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(100));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
 
       lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
       check_address_map(lest_env, reader, user, subs);
@@ -219,9 +219,9 @@ LWS_CASE("db::storage::upsert_subaddresses")
       EXPECT(fetched.has_value());
       EXPECT(fetched->size() == 1);
       EXPECT(fetched->at(0).first == lws::db::major_index(0));
-      EXPECT(fetched->at(0).second.size() == 1);
-      EXPECT(fetched->at(0).second[0][0] == lws::db::minor_index(1));
-      EXPECT(fetched->at(0).second[0][1] == lws::db::minor_index(200));
+      EXPECT(fetched->at(0).second.get_container().size() == 1);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
     }
 
     SECTION("Upsert Wrapped")
@@ -229,15 +229,15 @@ LWS_CASE("db::storage::upsert_subaddresses")
       std::vector<lws::db::subaddress_dict> subs{};
       subs.emplace_back(
         lws::db::major_index(0),
-        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}}
       );
       auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
-      EXPECT(result->at(0).second.size() == 1);
-      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(101));
-      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(200));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(101));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
 
       {
         auto reader = MONERO_UNWRAP(db.start_read());
@@ -245,7 +245,7 @@ LWS_CASE("db::storage::upsert_subaddresses")
       }
 
       subs.back().second =
-        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(300)}};
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(300)}}};
       
       result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 299);
       EXPECT(result.has_error());
@@ -255,11 +255,11 @@ LWS_CASE("db::storage::upsert_subaddresses")
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
-      EXPECT(result->at(0).second.size() == 2);
-      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(1));
-      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(100));
-      EXPECT(result->at(0).second[1][0] == lws::db::minor_index(201));
-      EXPECT(result->at(0).second[1][1] == lws::db::minor_index(300));
+      EXPECT(result->at(0).second.get_container().size() == 2);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
+      EXPECT(result->at(0).second.get_container()[1][0] == lws::db::minor_index(201));
+      EXPECT(result->at(0).second.get_container()[1][1] == lws::db::minor_index(300));
 
       lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
       check_address_map(lest_env, reader, user, subs);
@@ -267,9 +267,9 @@ LWS_CASE("db::storage::upsert_subaddresses")
       EXPECT(fetched.has_value());
       EXPECT(fetched->size() == 1);
       EXPECT(fetched->at(0).first == lws::db::major_index(0));
-      EXPECT(fetched->at(0).second.size() == 1);
-      EXPECT(fetched->at(0).second[0][0] == lws::db::minor_index(1));
-      EXPECT(fetched->at(0).second[0][1] == lws::db::minor_index(300));
+      EXPECT(fetched->at(0).second.get_container().size() == 1);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(300));
     }
 
     SECTION("Upsert After")
@@ -277,15 +277,15 @@ LWS_CASE("db::storage::upsert_subaddresses")
       std::vector<lws::db::subaddress_dict> subs{};
       subs.emplace_back(
         lws::db::major_index(0),
-        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}}
       );
       auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
-      EXPECT(result->at(0).second.size() == 1);
-      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(1));
-      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(100));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
 
       {
         auto reader = MONERO_UNWRAP(db.start_read());
@@ -293,7 +293,7 @@ LWS_CASE("db::storage::upsert_subaddresses")
       }
 
       subs.back().second =
-        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(102), lws::db::minor_index(200)}};
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(102), lws::db::minor_index(200)}}};
       result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 198);
       EXPECT(result.has_error());
       EXPECT(result == lws::error::max_subaddresses);
@@ -302,9 +302,9 @@ LWS_CASE("db::storage::upsert_subaddresses")
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
-      EXPECT(result->at(0).second.size() == 1);
-      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(102));
-      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(200));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(102));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
 
       auto reader = MONERO_UNWRAP(db.start_read());
       check_address_map(lest_env, reader, user, subs);
@@ -312,11 +312,11 @@ LWS_CASE("db::storage::upsert_subaddresses")
       EXPECT(fetched.has_value());
       EXPECT(fetched->size() == 1);
       EXPECT(fetched->at(0).first == lws::db::major_index(0));
-      EXPECT(fetched->at(0).second.size() == 2);
-      EXPECT(fetched->at(0).second[0][0] == lws::db::minor_index(1));
-      EXPECT(fetched->at(0).second[0][1] == lws::db::minor_index(100));
-      EXPECT(fetched->at(0).second[1][0] == lws::db::minor_index(102));
-      EXPECT(fetched->at(0).second[1][1] == lws::db::minor_index(200));
+      EXPECT(fetched->at(0).second.get_container().size() == 2);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
+      EXPECT(fetched->at(0).second.get_container()[1][0] == lws::db::minor_index(102));
+      EXPECT(fetched->at(0).second.get_container()[1][1] == lws::db::minor_index(200));
     }
 
     SECTION("Upsert Before")
@@ -324,15 +324,15 @@ LWS_CASE("db::storage::upsert_subaddresses")
       std::vector<lws::db::subaddress_dict> subs{};
       subs.emplace_back(
         lws::db::major_index(0),
-        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}}
       );
       auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
-      EXPECT(result->at(0).second.size() == 1);
-      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(101));
-      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(200));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(101));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
 
       {
         auto reader = MONERO_UNWRAP(db.start_read());
@@ -340,7 +340,7 @@ LWS_CASE("db::storage::upsert_subaddresses")
       }
 
       subs.back().second =
-        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(99)}};
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(99)}}};
       result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 198);
       EXPECT(result.has_error());
       EXPECT(result == lws::error::max_subaddresses);
@@ -349,9 +349,9 @@ LWS_CASE("db::storage::upsert_subaddresses")
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
-      EXPECT(result->at(0).second.size() == 1);
-      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(1));
-      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(99));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(99));
 
       auto reader = MONERO_UNWRAP(db.start_read());
       check_address_map(lest_env, reader, user, subs);
@@ -359,11 +359,11 @@ LWS_CASE("db::storage::upsert_subaddresses")
       EXPECT(fetched.has_value());
       EXPECT(fetched->size() == 1);
       EXPECT(fetched->at(0).first == lws::db::major_index(0));
-      EXPECT(fetched->at(0).second.size() == 2);
-      EXPECT(fetched->at(0).second[0][0] == lws::db::minor_index(1));
-      EXPECT(fetched->at(0).second[0][1] == lws::db::minor_index(99));
-      EXPECT(fetched->at(0).second[1][0] == lws::db::minor_index(101));
-      EXPECT(fetched->at(0).second[1][1] == lws::db::minor_index(200));
+      EXPECT(fetched->at(0).second.get_container().size() == 2);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(99));
+      EXPECT(fetched->at(0).second.get_container()[1][0] == lws::db::minor_index(101));
+      EXPECT(fetched->at(0).second.get_container()[1][1] == lws::db::minor_index(200));
     }
 
     SECTION("Upsert Encapsulated")
@@ -371,15 +371,15 @@ LWS_CASE("db::storage::upsert_subaddresses")
       std::vector<lws::db::subaddress_dict> subs{};
       subs.emplace_back(
         lws::db::major_index(0),
-        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(200)}}
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(200)}}}
       );
       auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 200);
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
-      EXPECT(result->at(0).second.size() == 1);
-      EXPECT(result->at(0).second[0][0] == lws::db::minor_index(1));
-      EXPECT(result->at(0).second[0][1] == lws::db::minor_index(200));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
 
       {
         auto reader = MONERO_UNWRAP(db.start_read());
@@ -387,7 +387,7 @@ LWS_CASE("db::storage::upsert_subaddresses")
       }
 
       subs.back().second =
-        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(5), lws::db::minor_index(99)}};
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(5), lws::db::minor_index(99)}}};
       result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 300);
       EXPECT(result.has_value());
       EXPECT(result->size() == 0);
@@ -398,9 +398,9 @@ LWS_CASE("db::storage::upsert_subaddresses")
       EXPECT(fetched.has_value());
       EXPECT(fetched->size() == 1);
       EXPECT(fetched->at(0).first == lws::db::major_index(0));
-      EXPECT(fetched->at(0).second.size() == 1);
-      EXPECT(fetched->at(0).second[0][0] == lws::db::minor_index(1));
-      EXPECT(fetched->at(0).second[0][1] == lws::db::minor_index(200));
+      EXPECT(fetched->at(0).second.get_container().size() == 1);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
     }
 
 
@@ -409,9 +409,9 @@ LWS_CASE("db::storage::upsert_subaddresses")
       std::vector<lws::db::subaddress_dict> subs{};
       subs.emplace_back(
         lws::db::major_index(0),
-        lws::db::index_ranges{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}}
       );
-      subs.back().second.push_back(
+      subs.back().second.get_container().push_back(
         lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}
       );
       auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);

--- a/tests/unit/scanner.test.cpp
+++ b/tests/unit/scanner.test.cpp
@@ -321,7 +321,7 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
   {
     lws::scanner::reset();
     auto rpc = 
-      lws::rpc::context::make(rendevous, {}, {}, {}, std::chrono::minutes{0});
+      lws::rpc::context::make(rendevous, {}, {}, {}, std::chrono::minutes{0}, false);
 
 
     lws::db::test::cleanup_db on_scope_exit{};
@@ -412,7 +412,7 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
           lws::db::subaddress_dict{
             lws::db::major_index::primary,
             lws::db::index_ranges{
-              lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(2)}
+              {lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(2)}}
             }
           }
         };
@@ -421,12 +421,12 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
         EXPECT(result);
         EXPECT(result->size() == 1);
         EXPECT(result->at(0).first == lws::db::major_index::primary);
-        EXPECT(result->at(0).second.size() == 1);
-        EXPECT(result->at(0).second.at(0).size() == 2);
-        EXPECT(result->at(0).second.at(0).at(0) == lws::db::minor_index(1));
-        EXPECT(result->at(0).second.at(0).at(1) == lws::db::minor_index(2));
-      }
- 
+        EXPECT(result->at(0).second.get_container().size() == 1);
+        EXPECT(result->at(0).second.get_container().at(0).size() == 2);
+        EXPECT(result->at(0).second.get_container().at(0).at(0) == lws::db::minor_index(1));
+        EXPECT(result->at(0).second.get_container().at(0).at(1) == lws::db::minor_index(2));
+      } 
+
       std::vector<cryptonote::tx_destination_entry> destinations;
       destinations.emplace_back();
       destinations.back().amount = 8000;

--- a/tests/unit/wire/json/read.write.test.cpp
+++ b/tests/unit/wire/json/read.write.test.cpp
@@ -10,6 +10,8 @@
 #include "wire/json/read.h"
 #include "wire/json/write.h"
 #include "wire/vector.h"
+#include "wire/wrapper/array.h"
+#include "wire/wrappers_impl.h"
 
 #include "wire/base.test.h"
 
@@ -31,7 +33,8 @@ namespace
   template<typename F, typename T>
   void basic_object_map(F& format, T& self)
   {
-    wire::object(format, WIRE_FIELD(utf8), WIRE_FIELD(vec), WIRE_FIELD(data), WIRE_FIELD(choice));
+    using max_vec = wire::max_element_count<100>;
+    wire::object(format, WIRE_FIELD(utf8), WIRE_FIELD_ARRAY(vec, max_vec), WIRE_FIELD(data), WIRE_FIELD(choice));
   }
 
   template<typename T>

--- a/tests/unit/wire/msgpack/read.write.test.cpp
+++ b/tests/unit/wire/msgpack/read.write.test.cpp
@@ -30,9 +30,12 @@
 #include <boost/range/algorithm/equal.hpp>
 #include <cstdint>
 #include <type_traits>
+#include "wire/field.h"
 #include "wire/traits.h"
 #include "wire/msgpack.h"
 #include "wire/vector.h"
+#include "wire/wrapper/array.h"
+#include "wire/wrappers_impl.h"
 
 #include "wire/base.test.h"
 
@@ -65,9 +68,10 @@ namespace
   template<typename F, typename T>
   void basic_object_map(F& format, T& self)
   {
+    using vec_max = wire::max_element_count<100>;
     wire::object(format,
       WIRE_FIELD_ID(0, utf8),
-      WIRE_FIELD_ID(1, vec),
+      wire::field<1>("vec", wire::array<vec_max>(std::ref(self.vec))),
       WIRE_FIELD_ID(2, data),
       WIRE_FIELD_ID(254, choice)
     );

--- a/tests/unit/wire/read.write.test.cpp
+++ b/tests/unit/wire/read.write.test.cpp
@@ -36,6 +36,8 @@
 #include "wire/json.h"
 #include "wire/msgpack.h"
 #include "wire/vector.h"
+#include "wire/wrapper/array.h"
+#include "wire/wrappers_impl.h"
 
 #include "wire/base.test.h"
 
@@ -70,12 +72,13 @@ namespace
   template<typename F, typename T>
   void complex_map(F& format, T& self)
   {
+    using max_vec = wire::max_element_count<100>;
     wire::object(format,
-      WIRE_FIELD(objects),
-      WIRE_FIELD(ints),
-      WIRE_FIELD(uints),
+      WIRE_FIELD_ARRAY(objects, max_vec),
+      WIRE_FIELD_ARRAY(ints, max_vec),
+      WIRE_FIELD_ARRAY(uints, max_vec),
       WIRE_FIELD(blobs),
-      WIRE_FIELD(strings),
+      WIRE_FIELD_ARRAY(strings, max_vec),
       WIRE_FIELD(choice)
     );
   }


### PR DESCRIPTION
This is a "best effort" to make it difficult to perform a memory exhaustion from the daemon side. If `--untrusted-daemon` is selected, size limits for responses are placed via ZMQ options. Additionally, there are now limits for all json arrays (the code from `monerod` was merged back into this codebase).