### PR TITLE
Update chain rollback log message

### DIFF
--- a/src/db/storage.cpp
+++ b/src/db/storage.cpp
@@ -1455,7 +1455,9 @@ namespace db
         {
           if (current <= get_checkpoints().get_max_height())
           {
-            MERROR("Attempting rollback past last checkpoint; invalid daemon chain response");
+            /* Either the daemon is performing an attack with a fake chain, or
+              the daemon is still syncing. */
+            MERROR("Attempting rollback past last checkpoint. Wait until daemon finishes syncing - otherwise daemon is performing an attack.");
             return {lws::error::bad_blockchain};
           }
 


### PR DESCRIPTION
I found an error case with the invalid chain rollback detection - when the daemon is still syncing it sends older blocks. The easiest thing to do (for now) is to update the error message to let the user know they must sync the daemon before using LWS.