### PR TITLE
Fix several bugs:

### DIFF
--- a/src/db/account.cpp
+++ b/src/db/account.cpp
@@ -165,7 +165,7 @@ namespace lws
 
   void account::updated(db::block_id new_height) noexcept
   {
-    height_ = new_height;
+    height_ = std::max(height_, new_height);
     spends_.clear();
     spends_.shrink_to_fit();
     outputs_.clear();

--- a/src/db/account.h
+++ b/src/db/account.h
@@ -88,7 +88,7 @@ namespace lws
     //! \return A copy of `this`.
     account clone() const;
 
-    //! \return A copy of `this` with a new height and `outputs().empty()`.
+    //! \post `height() == max(new_height, height())`, `outputs().empty()`, and `spends.empty()`.
     void updated(db::block_id new_height) noexcept;
 
     //! \return Unique ID from the account database, possibly `db::account_id::kInvalid`.

--- a/tests/unit/db/chain.test.cpp
+++ b/tests/unit/db/chain.test.cpp
@@ -130,6 +130,19 @@ LWS_CASE("db::storage::sync_chain")
       const auto sync_result = db.sync_chain(lws::db::block_id(point->first), fchain);
       EXPECT(sync_result == lws::error::bad_blockchain);
     }
+
+    SECTION("Old Blocks dont rollback height")
+    {
+      lws::account accounts[1] {lws::account{get_account(), {}, {}}};
+      const auto old_block = lws::db::block_id(lmdb::to_native(last_block.id) - 5);
+      const auto new_block = lws::db::block_id(lmdb::to_native(last_block.id) + 4);
+      EXPECT(accounts[0].scan_height() == new_block);
+      EXPECT(db.update(old_block, chain, accounts, nullptr));
+      EXPECT(get_account().scan_height == new_block);
+
+      accounts[0].updated(old_block);
+      EXPECT(accounts[0].scan_height() == new_block);
+    }
   }
 }
 

--- a/tests/unit/scanner.test.cpp
+++ b/tests/unit/scanner.test.cpp
@@ -194,7 +194,7 @@ namespace
     transaction out{};
     EXPECT(
       cryptonote::construct_tx_and_get_tx_key(
-        keys, subaddresses, sources, destinations, keys.m_account_address, {}, out.tx, 0, unused_key,
+        keys, subaddresses, sources, destinations, keys.m_account_address, {}, out.tx, /* 0, */ unused_key,
         out.additional_keys, true, {rct::RangeProofType::RangeProofBulletproof, 2}, use_view_tag
       )
     );


### PR DESCRIPTION
  * lws::account height update should only go up.
  * Webhook confirmations can start after first new block
  * Webhook confirmations could face a rescan

Found these issues while digging deeper in the remote scanning code (although not related to that code). This will get merged relatively soon as these bugs need to be back-ported to release branch.