### PR TITLE
Add (non-standard) 'daemon_status' endpoint to REST API

### DIFF
--- a/src/rpc/light_wallet.cpp
+++ b/src/rpc/light_wallet.cpp
@@ -40,6 +40,7 @@
 #include "ringct/rctOps.h"     // monero/src
 #include "span.h"              // monero/contrib/epee/include
 #include "util/random_outputs.h"
+#include "wire.h"
 #include "wire/adapted/crypto.h"
 #include "wire/error.h"
 #include "wire/json.h"
@@ -193,6 +194,29 @@ namespace lws
       wire::field("view_key", std::ref(unwrap(unwrap(self.key))))
     );
     convert_address(address, self.address);
+  }
+
+  namespace rpc
+  {
+    namespace
+    {
+      constexpr const char* map_daemon_state[] = {"ok", "no_connections", "synchronizing", "unavailable"};
+      constexpr const char* map_network_type[] = {"main", "test", "stage", "fake"};
+    }
+    WIRE_DEFINE_ENUM(daemon_state, map_daemon_state);
+    WIRE_DEFINE_ENUM(network_type, map_network_type);
+  }
+
+  void rpc::write_bytes(wire::json_writer& dest, const daemon_status_response& self)
+  {
+    wire::object(dest,
+      WIRE_FIELD(outgoing_connections_count),
+      WIRE_FIELD(incoming_connections_count),
+      WIRE_FIELD(height),
+      WIRE_FIELD(target_height),
+      WIRE_FIELD(network),
+      WIRE_FIELD(state)
+    );
   }
 
   void rpc::write_bytes(wire::json_writer& dest, const new_subaddrs_response& self)

--- a/src/rpc/light_wallet.h
+++ b/src/rpc/light_wallet.h
@@ -33,8 +33,10 @@
 #include <utility>
 #include <vector>
 
-#include "common/expect.h" // monero/src
-#include "crypto/crypto.h" // monero/src
+#include "common/expect.h"     // monero/src
+#include "cryptonote_config.h" // monero/src
+#include "cryptonote_basic/difficulty.h" // monero/src
+#include "crypto/crypto.h"     // monero/src
 #include "db/data.h"
 #include "rpc/rates.h"
 #include "util/fwd.h"
@@ -63,6 +65,44 @@ namespace rpc
     crypto::secret_key key;
   };
   void read_bytes(wire::json_reader&, account_credentials&);
+
+
+  enum class daemon_state : std::uint8_t
+  {
+    ok = 0,
+    no_connections,
+    synchronizing,
+    unavailable
+  };
+  WIRE_DECLARE_ENUM(daemon_state);
+
+  enum class network_type : std::uint8_t
+  {
+    main = 0,
+    test,
+    stage,
+    fake
+  };
+  WIRE_DECLARE_ENUM(network_type);
+
+  struct daemon_status_request
+  {
+    daemon_status_request() = delete;
+  };
+  inline void read_bytes(const wire::reader&, const daemon_status_request&)
+  {}
+
+  struct daemon_status_response
+  {
+    daemon_status_response() = delete;
+    std::uint64_t outgoing_connections_count;
+    std::uint64_t incoming_connections_count;
+    std::uint64_t height;
+    std::uint64_t target_height;
+    network_type network;
+    daemon_state state;
+  };
+  void write_bytes(wire::json_writer&, const daemon_status_response&);
 
 
   struct new_subaddrs_response


### PR DESCRIPTION
Requested privately. Mostly a relay to from the daemon. Possibly useful to clients that only have access to LWS REST.