### PR TITLE
/login update access_time, status

### DIFF
--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -701,6 +701,17 @@ namespace lws
             if (is_hidden(account->first))
               return {lws::error::account_not_found};
 
+            // Update access time
+            auto update_result = disk.update_access_time(req.creds.address);
+            if (!update_result)
+              return update_result.error();
+
+            // Move account state to active
+            epee::span<const lws::db::account_address> address_span(&req.creds.address, 1);
+            auto change_status_result = disk.change_status(db::account_status::active, address_span);
+            if (!change_status_result)
+              return change_status_result.error();
+
             // Do not count a request for account creation as login
             return response{false, bool(account->second.flags & db::account_generated_locally)};
           }


### PR DESCRIPTION
Upon calling /login endpoint update
  - access_time
  - status to active
  
This is a step for automation that I think many users might appreciate. We are used to put accounts in an inactive status after some time period has passed. When user logs in back into the solution, we want their account to become active again. These little changes are thus helpful and needed for our automation.

Ideally this should be behind some flag, just raising the PR as I got other devs asking to show an example solution.
