### PR TITLE
/get_random_outs is now fully async using stackful coroutines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ if(STATIC)
   set(Boost_USE_STATIC_LIBS ON)
   set(Boost_USE_STATIC_RUNTIME ON)
 endif()
-find_package(Boost 1.70 QUIET REQUIRED COMPONENTS chrono filesystem program_options regex serialization system thread)
+find_package(Boost 1.70 QUIET REQUIRED COMPONENTS chrono coroutine filesystem program_options regex serialization system thread)
 
 if (NOT (Boost_THREAD_LIBRARY STREQUAL monero_Boost_THREAD_LIBRARY_RELEASE))
   message(STATUS "Found Boost_THREAD_LIBRARY: ${Boost_THREAD_LIBRARY}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(monero-lws-daemon-common
     monero-lws-wire-json
     monero-lws-util
     ${Boost_CHRONO_LIBRARY}
+    ${Boost_COROUTINE_LIBRARY}
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     ${Boost_THREAD_LIBRARY}

--- a/src/net/zmq_async.h
+++ b/src/net/zmq_async.h
@@ -143,20 +143,20 @@ namespace net { namespace zmq
 
   //! Cannot have an `async_read` and `async_write` at same time (edge trigger)
   template<typename F>
-  void async_read(async_client& sock, std::string& buffer, F&& f)
+  auto async_read(async_client& sock, std::string& buffer, F&& f)
   {
     // async_compose is required for correct strand invocation, etc
-    boost::asio::async_compose<F, void(boost::system::error_code, std::size_t)>(
+    return boost::asio::async_compose<F, void(boost::system::error_code, std::size_t)>(
       read_msg_op{sock, buffer}, f, *sock.asock
     );
   }
 
   //! Cannot have an `async_write` and `async_read` at same time (edge trigger)
   template<typename F>
-  void async_write(async_client& sock, epee::byte_slice msg, F&& f)
+  auto async_write(async_client& sock, epee::byte_slice msg, F&& f)
   {
     // async_compose is required for correct strand invocation, etc
-    boost::asio::async_compose<F, void(boost::system::error_code, std::size_t)>(
+    return boost::asio::async_compose<F, void(boost::system::error_code, std::size_t)>(
       write_msg_op{sock, std::move(msg)}, f, *sock.asock
     );
   }


### PR DESCRIPTION
As the title says. I punted on a ASIO stackless implementation, as things got a little messy. Only one stack is spawned at a time, so the memory and setup time is kept to a minimum.

The only blocking calls left on the REST server are the optional HTTP callbacks for account creation in the `/login` endpoint. Still working on testing that, as I am moving all HTTP clients away from `epee` and to `boost::beast`.