### PR TITLE
Update boost::asio usage to conform to newer standards:

### DIFF
--- a/src/client_main.cpp
+++ b/src/client_main.cpp
@@ -294,7 +294,7 @@ namespace
         boost::this_thread::sleep_for(boost::chrono::seconds{1});
 
       self.stop_ = false;
-      self.io_.reset();
+      self.io_.restart();
       if (self.has_shutdown())
         return;
 

--- a/src/net/zmq_async.cpp
+++ b/src/net/zmq_async.cpp
@@ -86,7 +86,7 @@ namespace net { namespace zmq
     }
   }
 
-  expect<async_client> async_client::make(boost::asio::io_service& io, socket zsock)
+  expect<async_client> async_client::make(boost::asio::io_context& io, socket zsock)
   {
     MONERO_PRECOND(zsock != nullptr);
 

--- a/src/net/zmq_async.h
+++ b/src/net/zmq_async.h
@@ -28,7 +28,7 @@
 #pragma once
 
 #include <boost/asio/compose.hpp>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/posix/stream_descriptor.hpp>
 #include <boost/system/error_code.hpp>
 #include <cstddef>
@@ -63,7 +63,7 @@ namespace net { namespace zmq
     asocket asock;
     bool close;
 
-    static expect<async_client> make(boost::asio::io_service& io, socket zsock);
+    static expect<async_client> make(boost::asio::io_context& io, socket zsock);
   };
 
   class read_msg_op
@@ -94,7 +94,7 @@ namespace net { namespace zmq
           return self.complete(make_error_code(msg.error()), 0);
 
         // try again
-        sock_->asock->async_read_some(boost::asio::null_buffers(), std::move(self));
+        sock_->asock->async_wait(boost::asio::posix::stream_descriptor::wait_read, std::move(self));
         return;
       }
 
@@ -133,7 +133,7 @@ namespace net { namespace zmq
           return self.complete(make_error_code(status.error()), 0);
 
         // try again
-        sock_->asock->async_write_some(boost::asio::null_buffers(), std::move(self));
+        sock_->asock->async_wait(boost::asio::posix::stream_descriptor::wait_write, std::move(self));
         return;
       }
 

--- a/src/rest_server.h
+++ b/src/rest_server.h
@@ -27,10 +27,10 @@
 
 #pragma once
 
-#include <boost/asio/io_service.hpp>
 #include <boost/thread/thread.hpp>
-#include <cstddef>
+#include <cstdint>
 #include <list>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -41,19 +41,20 @@
 
 namespace lws
 {
+  struct rest_server_data;
   class rest_server
   {
     struct internal;
     template<typename> struct connection;
     template<typename> struct handler_loop;
     template<typename> struct accept_loop;
-    
-    boost::asio::io_service io_service_; //!< Put first so its destroyed last
+
+    std::unique_ptr<rest_server_data> global_;
     std::list<internal> ports_;
     std::vector<boost::thread> workers_;
 
     void run_io();
-    
+
   public:
     struct configuration
     {
@@ -66,14 +67,14 @@ namespace lws
       bool disable_admin_auth;
       bool auto_accept_creation;
     };
-    
+
     explicit rest_server(epee::span<const std::string> addresses, std::vector<std::string> admin, db::storage disk, rpc::client client, configuration config);
-    
+
     rest_server(rest_server&&) = delete;
     rest_server(rest_server const&) = delete;
-    
+
     ~rest_server() noexcept;
-    
+
     rest_server& operator=(rest_server&&) = delete;
     rest_server& operator=(rest_server const&) = delete;
   };

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -399,7 +399,7 @@ namespace rpc
     return {lws::error::bad_daemon_response};
   }
 
-  expect<net::zmq::async_client> client::make_async_client(boost::asio::io_service& io) const
+  expect<net::zmq::async_client> client::make_async_client(boost::asio::io_context& io) const
   {
     MONERO_PRECOND(ctx != nullptr);
 

--- a/src/rpc/client.h
+++ b/src/rpc/client.h
@@ -26,7 +26,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/optional/optional.hpp>
 #include <chrono>
 #include <memory>
@@ -139,7 +139,7 @@ namespace rpc
     }
 
     //! \return `async_client` to daemon. Thread safe.
-    expect<net::zmq::async_client> make_async_client(boost::asio::io_service& io) const;
+    expect<net::zmq::async_client> make_async_client(boost::asio::io_context& io) const;
 
     /*!
       Queue `message` for sending to daemon. If the queue is full, wait a

--- a/src/rpc/scanner/client.h
+++ b/src/rpc/scanner/client.h
@@ -26,7 +26,7 @@
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <cstddef>
@@ -81,7 +81,7 @@ namespace lws { namespace rpc { namespace scanner
     //! Send `users` upstream for disk storage
     static void send_update(const std::shared_ptr<client>& self, std::vector<lws::account> users, std::vector<crypto::hash> blocks);
 
-    //! Closes socket and calls stop on `io_service`.
+    //! Closes socket and calls stop on `io_context`.
     void cleanup();
   };
 }}} // lws // rpc // scanner

--- a/src/rpc/scanner/connection.cpp
+++ b/src/rpc/scanner/connection.cpp
@@ -31,7 +31,7 @@
 
 namespace lws { namespace rpc { namespace scanner
 {
-  connection::connection(boost::asio::io_service& io)
+  connection::connection(boost::asio::io_context& io)
     : read_buf_(),
       write_bufs_(),
       sock_(io),

--- a/src/rpc/scanner/connection.h
+++ b/src/rpc/scanner/connection.h
@@ -28,7 +28,7 @@
 
 #include <atomic>
 #include <boost/asio/buffer.hpp>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/steady_timer.hpp>
 #include <boost/asio/strand.hpp>
@@ -50,12 +50,14 @@ namespace lws { namespace rpc { namespace scanner
     std::deque<epee::byte_slice> write_bufs_;
     boost::asio::ip::tcp::socket sock_;
     boost::asio::steady_timer write_timeout_;
-    boost::asio::io_service::strand strand_;
+    boost::asio::io_context::strand strand_;
     header next_;
     bool cleanup_;
 
-    explicit connection(boost::asio::io_service& io);
+    explicit connection(boost::asio::io_context& io);
     ~connection();
+
+    boost::asio::io_context& context() const { return strand_.context(); }
 
     boost::asio::ip::tcp::endpoint remote_endpoint();
 

--- a/src/rpc/scanner/server.h
+++ b/src/rpc/scanner/server.h
@@ -27,7 +27,7 @@
 #pragma once
 
 #include <array>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/strand.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/steady_timer.hpp>
@@ -57,7 +57,7 @@ namespace lws { namespace rpc { namespace scanner
       needed (basically a REST server on either end). */
   class server
   {
-    boost::asio::io_service::strand strand_;
+    boost::asio::io_context::strand strand_;
     boost::asio::steady_timer check_timer_;
     boost::asio::ip::tcp::acceptor acceptor_;
     std::set<std::weak_ptr<server_connection>, std::owner_less<std::weak_ptr<server_connection>>> remote_;
@@ -85,7 +85,7 @@ namespace lws { namespace rpc { namespace scanner
   public:
     static boost::asio::ip::tcp::endpoint get_endpoint(const std::string& address);
 
-    explicit server(boost::asio::io_service& io, db::storage disk, rpc::client zclient, std::vector<std::shared_ptr<queue>> local, std::vector<db::account_id> active, ssl_verification_t webhook_verify);
+    explicit server(boost::asio::io_context& io, db::storage disk, rpc::client zclient, std::vector<std::shared_ptr<queue>> local, std::vector<db::account_id> active, ssl_verification_t webhook_verify);
 
     server(const server&) = delete;
     server(server&&) = delete;

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -1080,7 +1080,7 @@ namespace lws
       {
         // Run possible SIGINT handler
         self.io_.poll_one();
-        self.io_.reset();
+        self.io_.restart();
         if (self.has_shutdown())
           return {lws::error::signal_abort_process};
 
@@ -1098,7 +1098,7 @@ namespace lws
       {
         // Run possible SIGINT handler
         self.io_.poll_one();
-        self.io_.reset();
+        self.io_.restart();
         if (self.has_shutdown())
           return {lws::error::signal_abort_process};
 
@@ -1334,11 +1334,11 @@ namespace lws
       thread_count = std::max(std::size_t(1), thread_count);
 
     /*! \NOTE Be careful about references and lifetimes of the callbacks. The
-      ones below are safe because no `io_service::run()` call is after the
+      ones below are safe because no `io_context::run()` call is after the
       destruction of the references.
 
       \NOTE That `ctx` will need a strand or lock if multiple
-        `io_service::run()` calls are used. */
+        `io_context::run()` calls are used. */
 
     boost::asio::steady_timer rate_timer{sync_.io_};
     class rate_updater

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -27,7 +27,7 @@
 #pragma once
 
 #include <atomic>
-#include <boost/asio/io_service.hpp>
+#include <boost/asio/io_context.hpp>
 #include <boost/asio/signal_set.hpp>
 #include <boost/optional/optional.hpp>
 #include <cstdint>
@@ -77,7 +77,7 @@ namespace lws
 
   struct scanner_sync
   {
-    boost::asio::io_service io_;
+    boost::asio::io_context io_;
     std::atomic<bool> stop_;     //!< Stop scanning but do not shutdown
     std::atomic<bool> shutdown_; //!< Exit scanner::run
 


### PR DESCRIPTION
  * Convert boost::asio::io_service to boost::asio::io_context
  * Drop usage of GET_IO_SERVICE macro from monero
  * Refactor REST server to manage resources better