### PR TITLE
Switch from epee http client to boost::beast. All HTTP now non-blocking.

### DIFF
--- a/src/net/CMakeLists.txt
+++ b/src/net/CMakeLists.txt
@@ -26,8 +26,10 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+add_subdirectory(http)
+
 set(monero-lws-net_sources zmq_async.cpp)
 set(monero-lws-net_headers zmq_async.h)
 
 add_library(monero-lws-net ${monero-lws-net_sources} ${monero-lws-net_headers})
-target_link_libraries(monero-lws-net monero::libraries)
+target_link_libraries(monero-lws-net monero-lws-net-http monero::libraries)

--- a/src/net/http/CMakeLists.txt
+++ b/src/net/http/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, The Monero Project
+# Copyright (c) 2024, The Monero Project
 #
 # All rights reserved.
 #
@@ -26,31 +26,8 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-add_library(monero-lws-unit-framework framework.test.cpp)
-target_include_directories(monero-lws-unit-framework PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_SOURCE_DIR}/src")
-target_link_libraries(monero-lws-unit-framework)
+set(monero-lws-net-http_sources client.cpp)
+set(monero-lws-net-http_headers client.h slice_body.h)
 
-add_subdirectory(db)
-add_subdirectory(net)
-add_subdirectory(rpc)
-add_subdirectory(wire)
-
-add_executable(monero-lws-unit main.cpp rest.test.cpp scanner.test.cpp)
-target_link_libraries(monero-lws-unit
-  monero::libraries
-  monero-lws-daemon-common
-  monero-lws-unit-db
-  monero-lws-unit-framework
-  monero-lws-unit-net
-  monero-lws-unit-net-http
-  monero-lws-unit-rpc
-  monero-lws-unit-wire
-  monero-lws-unit-wire-json
-  monero-lws-unit-wire-msgpack
-  ${Boost_FILESYSTEM_LIBRARY}
-  ${Boost_PROGRAM_OPTIONS_LIBRARY}
-  ${Boost_THREAD_LIBRARY}
-  ${Boost_THREAD_LIBS_INIT}
-  Threads::Threads
-)
-add_test(NAME monero-lws-unit COMMAND monero-lws-unit -v)
+add_library(monero-lws-net-http ${monero-lws-net-http_sources} ${monero-lws-net-http_headers})
+target_link_libraries(monero-lws-net-http ${Boost_SYSTEM_LIBRARY} monero::libraries)

--- a/src/net/http/client.cpp
+++ b/src/net/http/client.cpp
@@ -1,0 +1,482 @@
+// Copyright (c) 2024, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "client.h"
+
+#include <boost/asio/bind_executor.hpp>
+#include <boost/asio/coroutine.hpp>
+#include <boost/asio/dispatch.hpp>
+#include <boost/asio/ip/address_v6.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/post.hpp>
+#include <boost/asio/ssl/context.hpp>
+#include <boost/asio/ssl/stream.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <boost/asio/strand.hpp>
+#include <boost/beast/core/flat_static_buffer.hpp>
+#include <boost/beast/http/parser.hpp>
+#include <boost/beast/http/read.hpp>
+#include <boost/beast/http/string_body.hpp>
+#include <boost/beast/http/write.hpp>
+#include <boost/beast/version.hpp>
+#include <boost/optional/optional.hpp>
+#include <boost/thread/lock_types.hpp>
+#include <cstdint>
+#include <deque>
+#include <limits>
+#include <ostream>
+
+#include "error.h"
+#include "misc_log_ex.h"           // monero/contrib/epee/include
+#include "net/http_base.h"         // monero/contrib/epee/include
+#include "net/http/slice_body.h"
+#include "net/net_parse_helpers.h" // monero/contrib/epee/include
+
+namespace net { namespace http
+{
+  namespace
+  {
+    constexpr const unsigned http_version = 11;
+    constexpr const std::size_t http_parser_buffer_size = 16 * 1024;
+    constexpr const std::size_t max_body_size = 4 * 1024;
+
+    //! Timeout for 1 entire HTTP request (connect, handshake, send, receive).
+    constexpr const std::chrono::seconds message_timeout{30};
+
+    struct message
+    {
+      message(epee::byte_slice json_body, std::string host, std::string target, std::uint16_t port, bool https, std::function<server_response_func>&& notifier)
+        : json_body(std::move(json_body)),
+          notifier(std::move(notifier)),
+          host(std::move(host)),
+          target(std::move(target)),
+          port(port),
+          https(https)
+      {}
+
+      message(message&&) = default;
+      message(const message& rhs)
+        : json_body(rhs.json_body.clone()),
+          notifier(rhs.notifier),
+          host(rhs.host),
+          target(rhs.target),
+          port(rhs.port),
+          https(rhs.https)
+      {}
+
+      epee::byte_slice json_body;
+      std::function<server_response_func> notifier;
+      std::string host;
+      std::string target;
+      std::uint16_t port;
+      bool https;
+    };
+
+    std::ostream& operator<<(std::ostream& out, const message& src)
+    {
+      out << (src.https ? "https://" : "http://") << src.host << ':' << src.port << src.target;
+      return out;
+    }
+  } // anonymous
+
+  struct client_state
+  {
+    std::shared_ptr<boost::asio::ssl::context> ssl;
+    boost::beast::flat_static_buffer<http_parser_buffer_size> buffer;
+    std::deque<message> outgoing;
+    std::string last_host;
+    boost::asio::ip::tcp::resolver resolver;
+    boost::asio::steady_timer timer;
+    boost::asio::io_context::strand strand;
+    boost::asio::ip::tcp::endpoint endpoint;
+    boost::beast::http::request<slice_body> request;
+    boost::optional<boost::asio::ssl::stream<boost::asio::ip::tcp::socket>> sock;
+    boost::optional<boost::beast::http::parser<false, boost::beast::http::string_body>> parser;
+    std::size_t iteration;
+
+    client_state(boost::asio::io_context& io, std::shared_ptr<boost::asio::ssl::context> in)
+      : ssl(std::move(in)),
+        buffer{},
+        outgoing(),
+        last_host(),
+        resolver(io),
+        timer(io),
+        strand(io),
+        endpoint(),
+        request{},
+        sock(),
+        parser(),
+        iteration(0)
+    {
+      assert(ssl);
+      sock.emplace(io, *ssl);
+    }
+
+    template<typename F>
+    void async_write(F&& callback)
+    {
+      assert(sock);
+      assert(!outgoing.empty());
+      const bool no_body = outgoing.front().json_body.empty();
+      request = {
+        outgoing.front().notifier ? boost::beast::http::verb::get : boost::beast::http::verb::post,
+        outgoing.front().target,
+        http_version,
+        std::move(outgoing.front().json_body)
+      };
+      request.set(boost::beast::http::field::user_agent, BOOST_BEAST_VERSION_STRING);
+      if (!no_body)
+        request.set(boost::beast::http::field::content_type, "application/json");
+
+      // Setting Host is tricky. Check for v6 and non-standard ports
+      boost::system::error_code error{};
+      boost::asio::ip::make_address_v6(outgoing.front().host, error);
+      if (!error)
+        request.set(boost::beast::http::field::host, "[" + outgoing.front().host + "]:" + std::to_string(outgoing.front().port));
+      else if ((outgoing.front().https && outgoing.front().port == 443) || (!outgoing.front().https && outgoing.front().port == 80))
+        request.set(boost::beast::http::field::host, outgoing.front().host);
+      else
+        request.set(boost::beast::http::field::host, outgoing.front().host + ":" + std::to_string(outgoing.front().port));
+
+      request.prepare_payload();
+      if (outgoing.front().https)
+        boost::beast::http::async_write(*sock, request, boost::asio::bind_executor(strand, std::forward<F>(callback)));
+      else
+        boost::beast::http::async_write(sock->next_layer(), request, boost::asio::bind_executor(strand, std::forward<F>(callback)));
+    }
+
+    template<typename F>
+    void async_read(F&& callback)
+    {
+      assert(sock);
+      assert(!outgoing.empty());
+      parser.emplace();
+      parser->body_limit(max_body_size);
+      if (outgoing.front().https)
+        boost::beast::http::async_read(*sock, buffer, *parser, boost::asio::bind_executor(strand, std::forward<F>(callback)));
+      else
+        boost::beast::http::async_read(sock->next_layer(), buffer, *parser, boost::asio::bind_executor(strand, std::forward<F>(callback)));
+    }
+
+    void notify_error(const boost::system::error_code& error) const
+    {
+      assert(!outgoing.empty()); 
+      if (outgoing.front().notifier)
+        outgoing.front().notifier(error, {});
+    }
+  };  
+
+  namespace
+  {
+    class client_loop : public boost::asio::coroutine
+    {
+      std::shared_ptr<client_state> self_;
+
+    public:
+      explicit client_loop(std::shared_ptr<client_state> self) noexcept
+        : boost::asio::coroutine(), self_(std::move(self))
+      {}
+
+      bool set_timeout(const std::chrono::steady_clock::duration timeout)
+      {
+        if (!self_)
+          return false;
+
+        struct on_timeout
+        {
+          on_timeout() = delete;
+          std::shared_ptr<client_state> self_;
+          std::size_t iteration;
+
+          void operator()(boost::system::error_code error) const
+          {
+            if (!self_ || error == boost::asio::error::operation_aborted)
+              return;
+            if (iteration < self_->iteration)
+              return;
+
+            assert(self_->strand.running_in_this_thread());
+            assert(self_->sock);
+            if (!self_->outgoing.empty())
+              MWARNING("Timeout in HTTP attempt to " << self_->outgoing.front());
+            else
+              MERROR("Unexpected empty message stack");
+
+            self_->resolver.cancel();
+            self_->sock->next_layer().cancel(error);
+            self_->sock->next_layer().shutdown(boost::asio::ip::tcp::socket::shutdown_both, error);
+          }
+        };
+
+        self_->timer.expires_after(timeout);
+        self_->timer.async_wait(boost::asio::bind_executor(self_->strand, on_timeout{self_, self_->iteration}));
+        return true;
+      }
+
+      void operator()(boost::system::error_code error = {}, std::size_t = 0)
+      {
+        if (!self_)
+          return;
+
+        bool reuse = false;
+        bool is_https = false;
+        std::uint16_t last_port = 0;
+        client_state& self = *self_;
+        assert(self.strand.running_in_this_thread());
+        assert(self.sock);
+        BOOST_ASIO_CORO_REENTER(*this)
+        {
+          while (!self.outgoing.empty())
+          {
+            struct resolve
+            {
+              client_loop continue_;
+
+              void operator()(const boost::system::error_code error, const boost::asio::ip::tcp::resolver::results_type& ips)
+              {
+                if (error)
+                  std::move(continue_)(error, 0);
+                else if (ips.empty())
+                  std::move(continue_)(boost::asio::error::host_not_found, 0);
+                else if (continue_.self_)
+                {
+                  continue_.self_->endpoint = *ips.begin();
+                  std::move(continue_)(error, 0);
+                }
+              }
+            };
+
+            set_timeout(message_timeout);
+
+            if (!reuse)
+            {
+              MDEBUG("Resolving " << self.outgoing.front().host << " for HTTP");
+              BOOST_ASIO_CORO_YIELD self.resolver.async_resolve(
+                self.outgoing.front().host,
+                std::to_string(self.outgoing.front().port),
+                boost::asio::bind_executor(self.strand, resolve{std::move(*this)})
+              );
+            }
+
+            if (!error)
+            {
+              if (!reuse)
+              {
+                MDEBUG("Connecting to " << self.endpoint << " / " << self.outgoing.front().host << " for HTTP");
+                BOOST_ASIO_CORO_YIELD self.sock->next_layer().async_connect(
+                  self.endpoint, boost::asio::bind_executor(self.strand, std::move(*this))
+                );
+                self.buffer.clear(); // do not re-use http buffer
+              }
+
+              if (!error)
+              {
+                if (!reuse && self.outgoing.front().https)
+                {
+                  {
+                    SSL* const ssl_ctx = self.sock->native_handle();                                
+                    if (ssl_ctx)
+                      SSL_set_tlsext_host_name(ssl_ctx, self.outgoing.front().host.c_str());
+                  }
+                  MDEBUG("Starting SSL handshake to " << self.outgoing.front().host << " for HTTP");
+                  BOOST_ASIO_CORO_YIELD self.sock->async_handshake(
+                    boost::asio::ssl::stream<boost::asio::ip::tcp::socket>::client,
+                    boost::asio::bind_executor(self.strand, std::move(*this))
+                  );
+                }
+
+                if (!error)
+                {
+                  reuse = false;
+                  MDEBUG("Sending " << self.outgoing.front().json_body.size() << " bytes in HTTP " << (self.outgoing.front().notifier ? "GET" : "POST") << " to " << self.outgoing.front());
+                  BOOST_ASIO_CORO_YIELD self.async_write(std::move(*this));
+                  
+                  if (!error)
+                  {
+                    MDEBUG("Starting read from " << self.outgoing.front() << " to previous HTTP message");
+                    BOOST_ASIO_CORO_YIELD self.async_read(std::move(*this));
+                    
+                    if (error)
+                      MERROR("Failed to parse HTTP response from " << self.outgoing.front() << ": " << error.message());
+                    else if (self.parser->get().result_int() != 200 && self.parser->get().result_int() != 201)
+                    {
+                      MERROR(self.outgoing.front() << " returned " << self.parser->get().result_int() << " status code");
+                      self.notify_error(boost::asio::error::operation_not_supported);
+                    }
+                    else
+                    {
+                      MDEBUG(self.outgoing.front() << " successful");
+                      reuse = self.parser->get().keep_alive();
+                      if (self.outgoing.front().notifier)
+                        self.outgoing.front().notifier({}, std::move(self.parser->get()).body());
+                    }
+                  }
+                  else
+                    MERROR("Failed HTTP " << (self.outgoing.front().notifier ? "GET" : "POST") << " to " << self.outgoing.front() << ": " << error.message());
+                }
+                else
+                  MERROR("SSL handshake to " << self.outgoing.front().host << " failed: " << error.message());
+              }
+              else
+                MERROR("Failed to connect to " << self.outgoing.front().host << ": " << error.message());
+            }
+            else
+              MERROR("Failed to resolve TCP/IP address for " << self.outgoing.front().host << ": " << error.message());
+
+            if (error)
+              self.notify_error(error);
+
+            is_https = self.outgoing.front().https;
+            self.last_host = std::move(self.outgoing.front().host);
+            last_port = self.outgoing.front().port;
+            self.outgoing.pop_front();
+
+            reuse = reuse &&
+              !self.outgoing.empty() && 
+              self.last_host == self.outgoing.front().host &&
+              last_port == self.outgoing.front().port;
+
+            if (!reuse)
+            {
+              if (is_https)
+              {
+                MDEBUG("Starting SSL shutdown on " << self.last_host);
+                BOOST_ASIO_CORO_YIELD self.sock->async_shutdown(
+                  boost::asio::bind_executor(self.strand, std::move(*this))
+                );
+                is_https = true;
+              }
+
+              MDEBUG("Cleaning up connection to " << self.last_host);
+              self.sock->next_layer().shutdown(boost::asio::ip::tcp::socket::shutdown_both, error);
+              self.sock->next_layer().close(error);
+              if (is_https) // must clear SSL state
+                self.sock.emplace(self.timer.get_executor(), *self.ssl);
+            }
+ 
+            ++self.iteration;
+          }
+        }
+      }
+    };
+
+    boost::asio::ssl::context make_context(epee::net_utils::ssl_verification_t verify)
+    {
+      epee::net_utils::ssl_options_t ssl{
+        epee::net_utils::ssl_support_t::e_ssl_support_enabled
+      };
+      ssl.verification = verify;
+      return ssl.create_context();
+    }
+  } // anonymous
+
+  expect<void> client::queue_async(boost::asio::io_context& io, std::string url, epee::byte_slice json_body, std::function<server_response_func> notifier)
+  {
+    static constexpr const std::uint16_t max_port = std::numeric_limits<std::uint16_t>::max();
+
+    epee::net_utils::http::url_content parsed{};
+    if (!epee::net_utils::parse_url(std::move(url), parsed) || max_port < parsed.port)
+      return {lws::error::bad_url};
+    if (parsed.schema != "http" && parsed.schema != "https")
+      return {lws::error::bad_url};
+
+    if (!parsed.port)
+      parsed.port = (parsed.schema == "http") ? 80 : 443;
+
+    if (parsed.uri.empty())
+      parsed.uri = "/";
+
+    message msg{
+      std::move(json_body),
+      std::move(parsed.host),
+      std::move(parsed.uri),
+      std::uint16_t(parsed.port),
+      bool(parsed.schema == "https"),
+      std::move(notifier)
+    };
+
+    MDEBUG("Queueing HTTP " << (msg.notifier ? "GET" : "POST") << " to " << msg << " using " << this);
+    boost::unique_lock<boost::mutex> lock{sync_};
+    auto state = state_.lock();
+    if (!state)
+    {
+      // `make_shared` delays freeing of data section, use `make_unique`
+      MDEBUG("Creating new net::http::client_state for " << this);
+      state = {std::make_unique<client_state>(io, ssl_)};
+      state_ = state;
+      state->outgoing.push_back(std::move(msg));
+
+      lock.unlock();
+      boost::asio::post(state->strand, client_loop{state});
+    }
+    else
+    {
+      lock.unlock();
+      boost::asio::dispatch(
+        state->strand,
+        [state, msg = std::move(msg)] () mutable
+        {
+          const bool empty = state->outgoing.empty();
+          state->outgoing.push_back(std::move(msg));
+          if (empty)
+            boost::asio::post(state->strand, client_loop{state});
+        }
+      );
+    }
+
+    return success();
+  }
+
+  client::client(epee::net_utils::ssl_verification_t verify)
+    : state_(),
+      ssl_(std::make_shared<boost::asio::ssl::context>(make_context(verify))),
+      sync_()
+  {}
+
+  client::client(std::shared_ptr<boost::asio::ssl::context> ssl)
+    : state_(), ssl_(std::move(ssl)), sync_()
+  {
+    if (!ssl_)
+      throw std::logic_error{"boost::asio::ssl::context cannot be nullptr"};
+  }
+
+  client::~client()
+  {}
+
+  expect<void> client::post_async(boost::asio::io_context& io, std::string url, epee::byte_slice json_body)
+  {
+    return queue_async(io, std::move(url), std::move(json_body), {});
+  }
+
+  expect<void> client::get_async(boost::asio::io_context& io, std::string url, std::function<server_response_func> notifier)
+  {
+    if (!notifier)
+      throw std::logic_error{"net::http::client::get_async requires callback"};
+    return queue_async(io, std::move(url), epee::byte_slice{}, std::move(notifier));
+  }
+}} // net // http
+

--- a/src/net/http/client.h
+++ b/src/net/http/client.h
@@ -1,0 +1,72 @@
+// Copyright (c) 2024, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/ssl/context.hpp>
+#include <boost/system/error_code.hpp>
+#include <boost/thread/mutex.hpp>
+#include <functional>
+#include <memory>
+#include <string>
+#include "byte_slice.h"    // monero/contrib/epee/include
+#include "common/expect.h" // monero/src
+#include "net/net_ssl.h"   // monero/contrib/epee/include
+
+namespace net { namespace http
+{
+  struct client_state;
+  using server_response_func = void(boost::system::error_code, std::string);
+
+  //! Primarily for webhooks, where the response is (basically) ignored.
+  class client
+  {
+    std::weak_ptr<client_state> state_;
+    std::shared_ptr<boost::asio::ssl::context> ssl_;
+    boost::mutex sync_;
+
+    expect<void> queue_async(boost::asio::io_context& io, std::string url, epee::byte_slice json_body, std::function<server_response_func> notifier);
+
+  public:
+    explicit client(epee::net_utils::ssl_verification_t verify);
+    explicit client(std::shared_ptr<boost::asio::ssl::context> ssl);
+    ~client();
+
+    const std::shared_ptr<boost::asio::ssl::context>& ssl_context() const noexcept
+    { return ssl_; }
+
+    //! Never blocks. Thread safe. \return `success()` if `url` is valid.
+    expect<void> post_async(boost::asio::io_context& io, std::string url, epee::byte_slice json_body);
+
+    /*! Never blocks. Thread safe. Calls `notifier` with server response iff
+      `success()` is returned.
+      \return `success()` if `url` is valid. */
+    expect<void> get_async(boost::asio::io_context& io, std::string url, std::function<server_response_func> notifier);
+  };
+}} // net // http
+

--- a/src/rpc/client.h
+++ b/src/rpc/client.h
@@ -148,10 +148,10 @@ namespace rpc
     */
     expect<void> send(epee::byte_slice message, std::chrono::seconds timeout) noexcept;
 
-    //! Publish `payload` to ZMQ external pub socket.
+    //! Publish `payload` to ZMQ external pub socket. Blocks iff RMQ.
     expect<void> publish(epee::byte_slice payload) const;
 
-    //! Publish `data` after `topic` to ZMQ external pub socket.
+    //! Publish `data` after `topic` to ZMQ external pub socket. Blocks iff RMQ.
     template<typename F, typename T>
     expect<void> publish(const boost::string_ref topic, const T& data) const
     {
@@ -250,14 +250,11 @@ namespace rpc
     expect<void> raise_abort_process() noexcept;
 
     /*!
-      Retrieve exchange rates, if enabled and past cache interval. Not
-      thread-safe (this can be invoked from one thread only, but this is
-      thread-safe with `client::get_rates()`). All clients will see new rates
-      immediately.
+      Retrieve exchange rates, if enabled. Thread-safe. All clients will see
+      new rates once completed.
 
-      \return Rates iff they were updated.
-    */
-    expect<boost::optional<lws::rates>> retrieve_rates();
+      \return `success()` if HTTP GET was queued. */
+    expect<void> retrieve_rates_async(boost::asio::io_context& io);
   };
 } // rpc
 } // lws

--- a/src/rpc/rates.h
+++ b/src/rpc/rates.h
@@ -64,8 +64,7 @@ namespace lws
   {
     struct crypto_compare_
     {
-      static const char host[];
-      static const char path[];
+      static const char url[];
 
       expect<lws::rates> operator()(std::string&& body) const;
     };

--- a/src/rpc/scanner/server.h
+++ b/src/rpc/scanner/server.h
@@ -38,6 +38,7 @@
 
 #include "db/fwd.h"
 #include "db/storage.h"
+#include "net/http/client.h"
 #include "net/net_ssl.h" // monero/contrib/epee/include
 #include "rpc/client.h"
 #include "rpc/scanner/queue.h"
@@ -65,11 +66,11 @@ namespace lws { namespace rpc { namespace scanner
     std::vector<db::account_id> active_;
     db::storage disk_;
     rpc::client zclient_;
+    net::http::client webhook_;
     db::cursor::accounts accounts_cur_;
     std::size_t next_thread_;
     std::array<unsigned char, 32> pass_hashed_;
     std::array<unsigned char, crypto_pwhash_SALTBYTES> pass_salt_;
-    const ssl_verification_t webhook_verify_;
     bool stop_;
 
     //! Async acceptor routine
@@ -85,7 +86,7 @@ namespace lws { namespace rpc { namespace scanner
   public:
     static boost::asio::ip::tcp::endpoint get_endpoint(const std::string& address);
 
-    explicit server(boost::asio::io_context& io, db::storage disk, rpc::client zclient, std::vector<std::shared_ptr<queue>> local, std::vector<db::account_id> active, ssl_verification_t webhook_verify);
+    explicit server(boost::asio::io_context& io, db::storage disk, rpc::client zclient, std::vector<std::shared_ptr<queue>> local, std::vector<db::account_id> active, std::shared_ptr<boost::asio::ssl::context> ssl);
 
     server(const server&) = delete;
     server(server&&) = delete;

--- a/src/rpc/webhook.h
+++ b/src/rpc/webhook.h
@@ -27,161 +27,103 @@
 
 #pragma once
 
+#include <boost/asio/io_context.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/utility/string_ref.hpp>
 #include <chrono>
 #include <string>
 #include "byte_slice.h"      // monero/contrib/epee/include
 #include "misc_log_ex.h"             // monero/contrib/epee/include
-#include "net/http_client.h" // monero/contrib/epee/include
+#include "net/http/client.h"
 #include "span.h"
 #include "wire/json.h"
 #include "wire/msgpack.h"
 
 namespace lws { namespace rpc
 {
-  namespace net = epee::net_utils;
-
-  template<typename T>
-  void http_send(net::http::http_simple_client& client, boost::string_ref uri, const T& event, const net::http::fields_list& params, const std::chrono::milliseconds timeout)
+template<typename T>
+void http_async(boost::asio::io_context& io, net::http::client& client, const epee::span<const T> events)
+{
+  for (const auto& event : events)
   {
-    if (uri.empty())
-      uri = "/";
-
-    epee::byte_slice bytes{};
-    const std::string& url = event.value.second.url;
-    const std::error_code json_error = wire::json::to_bytes(bytes, event);
-    const net::http::http_response_info* info = nullptr;
-    if (json_error)
+    if (event.value.second.url != "zmq")
     {
-      MERROR("Failed to generate webhook JSON: " << json_error.message());
-      return;
-    }
-
-    MINFO("Sending webhook to " << url);
-    if (!client.invoke(uri, "POST", std::string{bytes.begin(), bytes.end()}, timeout, std::addressof(info), params))
-    {
-      MERROR("Failed to invoke http request to  " << url);
-      return;
-    }
-
-    if (!info)
-    {
-      MERROR("Failed to invoke http request to  " << url << ", internal error (null response ptr)");
-      return;
-    }
-
-    if (info->m_response_code != 200 && info->m_response_code != 201)
-    {
-      MERROR("Failed to invoke http request to  " << url << ", wrong response code: " << info->m_response_code);
-      return;
+      epee::byte_slice bytes{};
+      const std::error_code json_error = wire::json::to_bytes(bytes, event);
+      if (!json_error)
+      {
+        MINFO("Sending webhook to " << event.value.second.url);
+        const expect<void> rc =
+          client.post_async(io, event.value.second.url, std::move(bytes));
+        if (!rc)
+          MERROR("Failed to send HTTP webhook to " << event.value.second.url << ": " << rc.error().message());
+      }
+      else
+        MERROR("Failed to generate webhook JSON: " << json_error.message());
     }
   }
+}
 
-  template<typename T>
-  void http_send(const epee::span<const T> events, const std::chrono::milliseconds timeout, net::ssl_verification_t verify_mode)
+template<typename T>
+struct zmq_index_single
+{
+  const std::uint64_t index;
+  const T& event;
+};
+
+template<typename T>
+void write_bytes(wire::writer& dest, const zmq_index_single<T>& self)
+{
+  wire::object(dest, WIRE_FIELD(index), WIRE_FIELD(event));
+}
+
+template<typename T>
+void zmq_send(const rpc::client& client, const epee::span<const T> events, const boost::string_ref json_topic, const boost::string_ref msgpack_topic)
+{
+  // Each `T` should have a unique count. This is desired.
+  struct zmq_order
   {
-    if (events.empty())
-      return;
+    std::uint64_t current;
+    boost::mutex sync;
 
-    net::http::url_content url{};
-    net::http::http_simple_client client{};
+    zmq_order()
+      : current(0), sync()
+    {}
+  };
 
-    net::http::fields_list params;
-    params.emplace_back("Content-Type", "application/json; charset=utf-8");
+  static zmq_order ordering{};
+
+  //! \TODO monitor XPUB to cull the serialization
+  if (!events.empty() && client.has_publish())
+  {
+    // make sure the event is queued to zmq in order.
+    const boost::unique_lock<boost::mutex> guard{ordering.sync};
 
     for (const auto& event : events)
     {
-      if (event.value.second.url.empty() || !net::parse_url(event.value.second.url, url))
-      {
-        MERROR("Bad URL for webhook event: " << event.value.second.url);
-        continue;
-      }
-
-      const bool https = (url.schema == "https");
-      if (!https && url.schema != "http")
-      {
-        MERROR("Only http or https connections: " << event.value.second.url);
-        continue;
-      }
-
-      const net::ssl_support_t ssl_mode = https ?
-        net::ssl_support_t::e_ssl_support_enabled : net::ssl_support_t::e_ssl_support_disabled;
-      net::ssl_options_t ssl_options{ssl_mode};
-      if (https)
-        ssl_options.verification = verify_mode;
-
-      if (url.port == 0)
-        url.port = https ? 443 : 80;
-
-      client.set_server(url.host, std::to_string(url.port), boost::none, std::move(ssl_options));
-      if (client.connect(timeout))
-        http_send(client, url.uri, event, params, timeout);
-      else
-        MERROR("Unable to send webhook to " << event.value.second.url);
-
-      client.disconnect();
+      const zmq_index_single<T> index{ordering.current++, event};
+      MINFO("Sending ZMQ-PUB topics " << json_topic << " and " << msgpack_topic);
+      expect<void> result = success();
+      if (!(result = client.publish<wire::json>(json_topic, index)))
+        MERROR("Failed to serialize+send " << json_topic << " " << result.error().message());
+      if (!(result = client.publish<wire::msgpack>(msgpack_topic, index)))
+        MERROR("Failed to serialize+send " << msgpack_topic << " " << result.error().message());
     }
   }
+}
 
-  template<typename T>
-  struct zmq_index_single
-  {
-    const std::uint64_t index;
-    const T& event;
-  };
-
-  template<typename T>
-  void write_bytes(wire::writer& dest, const zmq_index_single<T>& self)
-  {
-    wire::object(dest, WIRE_FIELD(index), WIRE_FIELD(event));
-  }
-
-  template<typename T>
-  void zmq_send(const rpc::client& client, const epee::span<const T> events, const boost::string_ref json_topic, const boost::string_ref msgpack_topic)
-  {
-    // Each `T` should have a unique count. This is desired.
-    struct zmq_order
-    {
-      std::uint64_t current;
-      boost::mutex sync;
-
-      zmq_order()
-        : current(0), sync()
-      {}
-    };
-
-    static zmq_order ordering{};
-
-    //! \TODO monitor XPUB to cull the serialization
-    if (!events.empty() && client.has_publish())
-    {
-      // make sure the event is queued to zmq in order.
-      const boost::unique_lock<boost::mutex> guard{ordering.sync};
-
-      for (const auto& event : events)
-      {
-        const zmq_index_single<T> index{ordering.current++, event};
-        MINFO("Sending ZMQ-PUB topics " << json_topic << " and " << msgpack_topic);
-        expect<void> result = success();
-        if (!(result = client.publish<wire::json>(json_topic, index)))
-          MERROR("Failed to serialize+send " << json_topic << " " << result.error().message());
-        if (!(result = client.publish<wire::msgpack>(msgpack_topic, index)))
-          MERROR("Failed to serialize+send " << msgpack_topic << " " << result.error().message());
-      }
-    }
-  }
-
-  template<typename T>
-  void send_webhook(
+template<typename T>
+  void send_webhook_async(
+    boost::asio::io_context& io,
     const rpc::client& client,
+    net::http::client& http_client,
     const epee::span<const T> events,
     const boost::string_ref json_topic,
-    const boost::string_ref msgpack_topic,
-    const std::chrono::seconds timeout,
-    epee::net_utils::ssl_verification_t verify_mode)
+    const boost::string_ref msgpack_topic)
   {
-    http_send(events, timeout, verify_mode);
+    http_async(io, http_client, events);
+
+    // ZMQ PUB sockets never block, but RMQ does. No easy way around this.
     zmq_send(client, events, json_topic, msgpack_topic);
   }
 }} // lws // rpc

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -296,13 +296,12 @@ namespace
     auto ctx = lws::rpc::context::make(std::move(prog.daemon_rpc), std::move(prog.daemon_sub), std::move(prog.zmq_pub), std::move(prog.rmq), prog.rates_interval, prog.untrusted_daemon);
 
     //! SIGINT handle registered by `scanner` constructor
-    lws::scanner scanner{disk.clone()};
+    lws::scanner scanner{disk.clone(), prog.rest_config.webhook_verify};
 
     MINFO("Using monerod ZMQ RPC at " << ctx.daemon_address());
     auto client = scanner.sync(ctx.connect().value(), prog.untrusted_daemon).value();
 
     const auto enable_subaddresses = bool(prog.rest_config.max_subaddresses);
-    const auto webhook_verify = prog.rest_config.webhook_verify;
     lws::rest_server server{
       epee::to_span(prog.rest_servers), prog.admin_rest_servers, std::move(disk), std::move(client), std::move(prog.rest_config)
     };
@@ -317,7 +316,7 @@ namespace
       prog.scan_threads,
       std::move(prog.lws_server_addr),
       std::move(prog.lws_server_pass),
-      lws::scanner_options{webhook_verify, enable_subaddresses, prog.untrusted_daemon}
+      lws::scanner_options{enable_subaddresses, prog.untrusted_daemon}
     );
   }
 } // anonymous

--- a/tests/unit/net/CMakeLists.txt
+++ b/tests/unit/net/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, The Monero Project
+# Copyright (c) 2024, The Monero Project
 #
 # All rights reserved.
 #
@@ -26,31 +26,7 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-add_library(monero-lws-unit-framework framework.test.cpp)
-target_include_directories(monero-lws-unit-framework PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_SOURCE_DIR}/src")
-target_link_libraries(monero-lws-unit-framework)
+add_subdirectory(http)
 
-add_subdirectory(db)
-add_subdirectory(net)
-add_subdirectory(rpc)
-add_subdirectory(wire)
-
-add_executable(monero-lws-unit main.cpp rest.test.cpp scanner.test.cpp)
-target_link_libraries(monero-lws-unit
-  monero::libraries
-  monero-lws-daemon-common
-  monero-lws-unit-db
-  monero-lws-unit-framework
-  monero-lws-unit-net
-  monero-lws-unit-net-http
-  monero-lws-unit-rpc
-  monero-lws-unit-wire
-  monero-lws-unit-wire-json
-  monero-lws-unit-wire-msgpack
-  ${Boost_FILESYSTEM_LIBRARY}
-  ${Boost_PROGRAM_OPTIONS_LIBRARY}
-  ${Boost_THREAD_LIBRARY}
-  ${Boost_THREAD_LIBS_INIT}
-  Threads::Threads
-)
-add_test(NAME monero-lws-unit COMMAND monero-lws-unit -v)
+add_library(monero-lws-unit-net)
+target_link_libraries(monero-lws-unit-net monero-lws-unit-net-http)

--- a/tests/unit/net/http/CMakeLists.txt
+++ b/tests/unit/net/http/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, The Monero Project
+# Copyright (c) 2024, The Monero Project
 #
 # All rights reserved.
 #
@@ -26,31 +26,9 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-add_library(monero-lws-unit-framework framework.test.cpp)
-target_include_directories(monero-lws-unit-framework PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_SOURCE_DIR}/src")
-target_link_libraries(monero-lws-unit-framework)
-
-add_subdirectory(db)
-add_subdirectory(net)
-add_subdirectory(rpc)
-add_subdirectory(wire)
-
-add_executable(monero-lws-unit main.cpp rest.test.cpp scanner.test.cpp)
-target_link_libraries(monero-lws-unit
-  monero::libraries
-  monero-lws-daemon-common
-  monero-lws-unit-db
-  monero-lws-unit-framework
-  monero-lws-unit-net
+add_library(monero-lws-unit-net-http OBJECT client.test.cpp)
+target_link_libraries(
   monero-lws-unit-net-http
-  monero-lws-unit-rpc
-  monero-lws-unit-wire
-  monero-lws-unit-wire-json
-  monero-lws-unit-wire-msgpack
-  ${Boost_FILESYSTEM_LIBRARY}
-  ${Boost_PROGRAM_OPTIONS_LIBRARY}
-  ${Boost_THREAD_LIBRARY}
-  ${Boost_THREAD_LIBS_INIT}
-  Threads::Threads
-)
-add_test(NAME monero-lws-unit COMMAND monero-lws-unit -v)
+  monero-lws-net-http
+  monero-lws-unit-framework
+  monero::libraries)

--- a/tests/unit/net/http/client.test.cpp
+++ b/tests/unit/net/http/client.test.cpp
@@ -1,0 +1,166 @@
+// Copyright (c) 2024, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "framework.test.h"
+
+#include <atomic>
+#include <boost/asio/error.hpp>
+#include <boost/asio/io_context.hpp>
+#include <string>
+#include "crypto/crypto.h"             // monero/src
+#include "net/http/client.h"
+#include "net/http_server_impl_base.h" // monero/contrib/epee/include
+
+namespace
+{
+  constexpr const std::uint16_t server_port = 10000;
+  constexpr const std::uint16_t invalid_server_port = 10001;
+
+  namespace enet = epee::net_utils;
+  struct context : enet::connection_context_base
+  {
+    context()
+      : enet::connection_context_base()
+    {}
+  };
+
+  struct handler : epee::http_server_impl_base<handler, context>
+  {
+    handler()
+      : epee::http_server_impl_base<handler, context>()
+    {}
+
+    virtual bool
+    handle_http_request(const enet::http::http_request_info& query, enet::http::http_response_info& response, context&)
+    override final
+    {
+      if (query.m_URI == "/")
+        response.m_response_code = 404;
+      else
+        response.m_response_code = 200;
+      response.m_body = query.m_URI;
+      return true;
+    }
+  };
+}
+
+LWS_CASE("net::http::client")
+{
+
+  boost::asio::io_context io;
+  handler server{};
+  server.init(&crypto::generate_random_bytes_thread_safe, std::to_string(server_port));
+  server.run(1, false);
+
+  SETUP("server and client")
+  {  
+    net::http::client client{epee::net_utils::ssl_verification_t::none};
+
+    SECTION("GET 200 OK")
+    {
+      std::atomic<bool> done = false;
+      const auto handler = [&done, &lest_env] (boost::system::error_code error, std::string body)
+      {
+        EXPECT(!error);
+        EXPECT(body == "/some_endpoint");
+        done = true;
+      };
+      client.get_async(
+        io, "http://127.0.0.1:" + std::to_string(server_port) + "/some_endpoint", handler
+      );
+
+      while (!done)
+      {
+        io.run_one();
+        io.restart();
+      }
+    }
+
+    SECTION("GET 200 OK Twice")
+    {
+      std::atomic<unsigned> done = 0;
+      const auto handler = [&done, &lest_env] (boost::system::error_code error, std::string body)
+      {
+        EXPECT(!error);
+        EXPECT(body == "/some_endpoint");
+        ++done;
+      };
+      client.get_async(
+        io, "http://127.0.0.1:" + std::to_string(server_port) + "/some_endpoint", handler
+      );
+      client.get_async(
+        io, "http://127.0.0.1:" + std::to_string(server_port) + "/some_endpoint", handler
+      );
+
+      while (done != 2)
+      {
+        io.run_one();
+        io.restart();
+      }
+    }
+
+    SECTION("GET 404 NOT FOUND")
+    {
+      std::atomic<bool> done = false;
+      const auto handler = [&done, &lest_env] (boost::system::error_code error, std::string body)
+      {
+        EXPECT(error == boost::asio::error::operation_not_supported);
+        EXPECT(body.empty());
+        done = true;
+      };
+      client.get_async(
+        io, "http://127.0.0.1:" + std::to_string(server_port), handler
+      );
+
+      while (!done)
+      {
+        io.run_one();
+        io.restart();
+      }
+    }
+
+    SECTION("GET (Invalid server address)")
+    {
+      std::atomic<bool> done = false;
+      const auto handler = [&done, &lest_env] (boost::system::error_code error, std::string body)
+      {
+        EXPECT(error == boost::asio::error::connection_refused);
+        EXPECT(body.empty());
+        done = true;
+      };
+      client.get_async(
+        io, "http://127.0.0.1:" + std::to_string(invalid_server_port), handler
+      );
+
+      while (!done)
+      {
+        io.run_one();
+        io.restart();
+      }
+    }
+  }
+}

--- a/tests/unit/scanner.test.cpp
+++ b/tests/unit/scanner.test.cpp
@@ -350,7 +350,7 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
       std::vector<epee::byte_slice> messages{};
       messages.push_back(to_json_rpc(1));
 
-      lws::scanner scanner{db.clone()};
+      lws::scanner scanner{db.clone(), epee::net_utils::ssl_verification_t::none};
 
       boost::thread server_thread(&scanner_thread, std::ref(scanner), rpc.zmq_context(), std::cref(messages));
       const join on_scope_exit{server_thread};
@@ -384,7 +384,7 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
 
       lws_test::test_chain(lest_env, MONERO_UNWRAP(db.start_read()), last_block.id, {hashes.data(), 1});
       {
-        lws::scanner scanner{db.clone()};
+        lws::scanner scanner{db.clone(), epee::net_utils::ssl_verification_t::none};
         boost::thread server_thread(&scanner_thread, std::ref(scanner), rpc.zmq_context(), std::cref(messages));
         const join on_scope_exit{server_thread};
         EXPECT(scanner.sync(MONERO_UNWRAP(rpc.connect())));
@@ -408,7 +408,7 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
         message.hashes.resize(1);
         messages.push_back(daemon_response(message));
 
-        lws::scanner scanner{db.clone()};
+        lws::scanner scanner{db.clone(), epee::net_utils::ssl_verification_t::none};
         boost::thread server_thread(&scanner_thread, std::ref(scanner), rpc.zmq_context(), std::cref(messages));
         const join on_scope_exit{server_thread};
         EXPECT(scanner.sync(MONERO_UNWRAP(rpc.connect())));
@@ -516,7 +516,7 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
         messages.push_back(daemon_response(hmessage));
 
         {
-          lws::scanner scanner{db.clone()};
+          lws::scanner scanner{db.clone(), epee::net_utils::ssl_verification_t::none};
           boost::thread server_thread(&scanner_thread, std::ref(scanner), rpc.zmq_context(), std::cref(messages));
           const join on_scope_exit{server_thread};
           EXPECT(scanner.sync(MONERO_UNWRAP(rpc.connect())));
@@ -534,10 +534,8 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
       bmessage.output_indices.resize(1);
       messages.push_back(daemon_response(bmessage));
       {
-        static constexpr const lws::scanner_options opts{
-          epee::net_utils::ssl_verification_t::none, true, false
-        };
-        lws::scanner scanner{db.clone()};
+        static constexpr const lws::scanner_options opts{true, false};
+        lws::scanner scanner{db.clone(), epee::net_utils::ssl_verification_t::none};
         boost::thread server_thread(&scanner_thread, std::ref(scanner), rpc.zmq_context(), std::cref(messages));
         const join on_scope_exit{server_thread};
         scanner.run(std::move(rpc), 1, {}, {}, opts);


### PR DESCRIPTION
As the title suggests, this removes all blocking epee HTTP client code and moves to an async `boost::beast` implementation. The REST endpoint `/login` is now always non-blocking, even with account creation webhooks. The scanner no longer blocks for webhooks, and instead queues up requests. The rate exchange fetch code is also now async.