### PR TITLE
Update deprecated features removed in Boost ASIO 1.87

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -19,6 +19,7 @@ jobs:
   build-tests:
     runs-on: ${{matrix.os}}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04, ubuntu-22.04, ubuntu-20.04, macos-latest, macos-14, macos-13]
         rmq: [WITH_RMQ=ON, WITH_RMQ=OFF]

--- a/src/rpc/scanner/client.cpp
+++ b/src/rpc/scanner/client.cpp
@@ -121,7 +121,7 @@ namespace lws { namespace rpc { namespace scanner
         for (;;)
         {
           MINFO("Attempting connection to " << self_->server_address_);
-          self_->connect_timer_.expires_from_now(connect_timeout);
+          self_->connect_timer_.expires_after(connect_timeout);
           self_->connect_timer_.async_wait(
             boost::asio::bind_executor(self_->strand_, close{self_})
           );
@@ -139,7 +139,7 @@ namespace lws { namespace rpc { namespace scanner
             break;
 
           MINFO("Retrying connection in " << std::chrono::seconds{reconnect_interval}.count() << " seconds"); 
-          self_->connect_timer_.expires_from_now(reconnect_interval);
+          self_->connect_timer_.expires_after(reconnect_interval);
           BOOST_ASIO_CORO_YIELD self_->connect_timer_.async_wait(
             boost::asio::bind_executor(self_->strand_, *this)
           );

--- a/src/rpc/scanner/server.cpp
+++ b/src/rpc/scanner/server.cpp
@@ -203,7 +203,7 @@ namespace lws { namespace rpc { namespace scanner
         return;
 
       assert(self_->strand_.running_in_this_thread());
-      self_->check_timer_.expires_from_now(account_poll_interval);
+      self_->check_timer_.expires_after(account_poll_interval);
       self_->check_timer_.async_wait(boost::asio::bind_executor(self_->strand_, *this));
 
       std::size_t total_threads = self_->local_.size();
@@ -422,7 +422,7 @@ namespace lws { namespace rpc { namespace scanner
 
     MDEBUG("Stopping rpc::scanner::server async operations");
     boost::system::error_code error{};
-    check_timer_.cancel(error);
+    check_timer_.cancel();
     acceptor_.cancel(error);
     acceptor_.close(error);
 
@@ -454,7 +454,7 @@ namespace lws { namespace rpc { namespace scanner
       }
     }
     return boost::asio::ip::tcp::endpoint{
-      boost::asio::ip::address::from_string(host), boost::lexical_cast<unsigned short>(port)
+      boost::asio::ip::make_address(host), boost::lexical_cast<unsigned short>(port)
     };
   }
 

--- a/src/rpc/scanner/write_commands.h
+++ b/src/rpc/scanner/write_commands.h
@@ -118,7 +118,7 @@ namespace lws { namespace rpc { namespace scanner
       {
         while (!self_->write_bufs_.empty())
         {
-          self_->write_timeout_.expires_from_now(std::chrono::seconds{10});
+          self_->write_timeout_.expires_after(std::chrono::seconds{10});
           self_->write_timeout_.async_wait(boost::asio::bind_executor(self_->strand_, timeout<T>{self_}));
           BOOST_ASIO_CORO_YIELD boost::asio::async_write(
             self_->sock_, self_->write_buffer(), boost::asio::bind_executor(self_->strand_, *this)
@@ -189,6 +189,17 @@ namespace lws { namespace rpc { namespace scanner
       queue_slice(const queue_slice& rhs)
         : self_(rhs.self_), msg_(rhs.msg_.clone())
       {}
+
+      queue_slice& operator=(queue_slice&&) = default;
+      queue_slice& operator=(const queue_slice& rhs)
+      {
+        if (this != std::addressof(rhs))
+        {
+          self_ = rhs.self_;
+          msg_ = rhs.msg_.clone();
+        }
+        return *this;
+      }
 
       void operator()()
       {

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -1337,7 +1337,7 @@ namespace lws
         const expect<void> status = ctx_.retrieve_rates_async(io_);
         if (!status)
           MERROR("Unable to retrieve exchange rates: " << status.error());
-        rate_timer_.expires_from_now(rate_interval_);
+        rate_timer_.expires_after(rate_interval_);
         rate_timer_.async_wait(*this);
       }
 
@@ -1382,7 +1382,7 @@ namespace lws
         MINFO("No active accounts");
 
         boost::asio::steady_timer poll{sync_.io_};
-        poll.expires_from_now(rpc::scanner::account_poll_interval);
+        poll.expires_after(rpc::scanner::account_poll_interval);
         const auto ready = poll.async_wait(boost::asio::use_future);
 
         /* The exchange rates timer could run while waiting, so ensure that


### PR DESCRIPTION
I missed some deprecated things in Boost ASIO so the build fails with Boost 1.87. This _should_ fail the macOS CI as upstream Monero does not have merged features to make Boost 1.87 work.

The relevant monero PR to [make Boost 1.87 work](https://github.com/monero-project/monero/pull/9628)