### PR TITLE
Adjust get_unspent_outs return error according to API standard

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -95,6 +95,8 @@ namespace lws
         return "Max subaddresses exceeded";
       case error::not_enough_mixin:
         return "Not enough outputs to meet requested mixin count";
+      case error::not_enough_amount:
+        return "Not enough outputs to meet requested amount";
       case error::signal_abort_process:
         return "An in-process message was received to abort the process";
       case error::signal_abort_scan:

--- a/src/error.h
+++ b/src/error.h
@@ -61,6 +61,7 @@ namespace lws
     json_rpc,                   //!< Error returned by JSON-RPC server
     max_subaddresses,           //!< Max subaddresses exceeded
     not_enough_mixin,           //!< Not enough outputs to meet mixin count
+    not_enough_amount,          //!< Not enough outputs to meet amount
     signal_abort_process,       //!< In process ZMQ PUB to abort the process was received
     signal_abort_scan,          //!< In process ZMQ PUB to abort the scan was received
     signal_unknown,             //!< An unknown in process ZMQ PUB was received

--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -1057,7 +1057,7 @@ namespace lws
         }
 
         if (received < std::uint64_t(req.amount))
-          return {lws::error::account_not_found};
+          return {lws::error::not_enough_amount};
 
         if (rpc->size_scale == 0 || 1024 < rpc->size_scale || rpc->fee_mask == 0)
           return {lws::error::bad_daemon_response};
@@ -1958,7 +1958,7 @@ namespace lws
       MINFO("REST error: " << error.message() << " from " << sock().remote_endpoint(ec) << " / " << this);
 
       assert(strand_.running_in_this_thread());
-      if (error.category() == wire::error::rapidjson_category() || error == lws::error::invalid_range)
+      if (error.category() == wire::error::rapidjson_category() || error == lws::error::invalid_range || error == lws::error::not_enough_amount)
         return bad_request(boost::beast::http::status::bad_request, std::forward<F>(resume));
       else if (error == lws::error::account_not_found || error == lws::error::duplicate_request)
         return bad_request(boost::beast::http::status::forbidden, std::forward<F>(resume));


### PR DESCRIPTION
This PR includes a small enhancement on the `get_unspent_outs` method, which returned the error `lws::error:account_not_found` when the amount received is not enough to satisfy the requested amount, in turn causing the `HTTP 403 Forbidden` error. A new error `lws::error:not_enough_amount` has been introduced that replaces `lws::error::account_not_found` in this specific case, also the `bad_request` method has been modified to correctly handle this new error and return the `HTTP 400 Bad Request` error according to the official light wallet API [get_unspent_outs specification](https://github.com/monero-project/meta/blob/master/api/lightwallet_rest.md#get_unspent_outs).