### PR TITLE
Add support for dynamic fees over ZMQ

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ if (MONERO_BUILD_DIR)
     PROTOLIB_LIBRARY
   )
 
-  if (NOT (monero_monero_SOURCE_DIR MATCHES "${MONERO_SOURCE_DIR}(/src/cryptonote_protocol)"))
+  if (NOT (monero_monero_SOURCE_DIR MATCHES "${MONERO_SOURCE_DIR}"))
     message(FATAL_ERROR "Invalid Monero source dir - does not appear to match source used for build directory")
   endif()
 

--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -1110,6 +1110,7 @@ namespace lws
             rpc->fee_mask,
             rpc::safe_uint64(received),
             std::move(unspent),
+            rpc->fees,
             std::move(req.creds.key)
           }
         );

--- a/src/rpc/light_wallet.cpp
+++ b/src/rpc/light_wallet.cpp
@@ -350,7 +350,8 @@ namespace lws
       WIRE_FIELD_COPY(per_byte_fee),
       WIRE_FIELD_COPY(fee_mask),
       WIRE_FIELD_COPY(amount),
-      wire::optional_field("outputs", wire::array(boost::adaptors::transform(self.outputs, expand)))
+      wire::optional_field("outputs", wire::array(boost::adaptors::transform(self.outputs, expand))),
+      WIRE_FIELD(fees)
     );
   }
 

--- a/src/rpc/light_wallet.h
+++ b/src/rpc/light_wallet.h
@@ -210,6 +210,7 @@ namespace rpc
     std::uint64_t fee_mask;
     safe_uint64 amount;
     std::vector<std::pair<db::output, std::vector<crypto::key_image>>> outputs;
+    std::vector<std::uint64_t> fees;
     crypto::secret_key user_key;
   };
   void write_bytes(wire::json_writer&, const get_unspent_outs_response&);

--- a/tests/unit/rest.test.cpp
+++ b/tests/unit/rest.test.cpp
@@ -73,7 +73,7 @@ namespace
     return epee::byte_slice{
       std::string{
         "{\"jsonrpc\":2.0,\"id\":0,\"result\":{"
-          "\"estimated_base_fee\":10000,\"fee_mask\":1000,\"size_scale\":256,\"hard_fork_version\":16"
+          "\"estimated_base_fee\":10000,\"fee_mask\":1000,\"size_scale\":256,\"hard_fork_version\":16,\"fees\":[40,41]"
         "}}"
       }
     };
@@ -184,7 +184,7 @@ LWS_CASE("rest_server")
 
       message = "{\"address\":\"" + address + "\",\"view_key\":\"" + viewkey + "\",\"amount\":\"0\"}";
       response = invoke(client, "/get_unspent_outs", message);
-      EXPECT(response == "{\"per_byte_fee\":39,\"fee_mask\":1000,\"amount\":\"0\"}");
+      EXPECT(response == "{\"per_byte_fee\":39,\"fee_mask\":1000,\"amount\":\"0\",\"fees\":[40,41]}");
     }
 
     SECTION("One Receive, Zero Spends")
@@ -309,7 +309,7 @@ LWS_CASE("rest_server")
           "\"height\":4000,"
           "\"rct\":\"" + epee::to_hex::string(epee::as_byte_span(ringct_expanded)) + "\","
           "\"recipient\":{\"maj_i\":2,\"min_i\":66}}"
-        "]}"
+        "],\"fees\":[40,41]}"
       );
     }
 
@@ -467,7 +467,7 @@ LWS_CASE("rest_server")
           "\"spend_key_images\":[\"" + epee::to_hex::string(epee::as_byte_span(image)) + "\"],"
           "\"rct\":\"" + epee::to_hex::string(epee::as_byte_span(ringct_expanded)) + "\","
           "\"recipient\":{\"maj_i\":2,\"min_i\":66}}"
-        "]}"
+        "],\"fees\":[40,41]}"
       );
     }
 


### PR DESCRIPTION
As the title says. This requires a corresponding patch in the daemon (on `master`), so the CI should fail. The CI will be re-run once the associated patch gets merged, and then this PR will get merged after.