### PR TITLE
Add support for carrot (legacy, view-incoming, and view-balance keys)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,18 +88,23 @@ set(MONERO_LIBRARIES
   common
   lmdb
   device
-  cncrypto
-  randomx
   epee
   easylogging
   version
   wallet-crypto
+  fcmp_pp
+  wallet
+  carrot_impl
+  carrot_core
+  cncrypto
+  randomx
+  mx25519
 )
 
 set(MONERO_OPTIONAL wallet-crypto)
 
 if (MONERO_BUILD_DIR)
-
+  list(APPEND MONERO_LIBRARIES "fcmp_pp_rust")
   set(MONERO_SEARCH_PATHS
     "/contrib/epee/src"
     "/external/db_drivers/liblmdb"
@@ -108,6 +113,7 @@ if (MONERO_BUILD_DIR)
     "/src/crypto"
     "/src/crypto/wallet"
     "/src/cryptonote_basic"
+    "/src/fcmp_pp/fcmp_pp_rust"
     "/src/lmdb"
     "/src/ringct"
     "/src/rpc"
@@ -168,7 +174,7 @@ if (MONERO_BUILD_DIR)
   endif()
 
   foreach (LIB ${MONERO_LIBRARIES})
-    find_library(LIB_PATH NAMES "${LIB}" PATHS ${MONERO_BUILD_DIR} PATH_SUFFIXES "/src/${LIB}" "external/${LIB}" ${MONERO_SEARCH_PATHS} NO_DEFAULT_PATH)
+    find_library(LIB_PATH NAMES "${LIB}" PATHS ${MONERO_BUILD_DIR} PATH_SUFFIXES "/src/${LIB}" "/lib" "external/${LIB}" ${MONERO_SEARCH_PATHS} NO_DEFAULT_PATH)
 
     list(FIND MONERO_OPTIONAL "${LIB}" LIB_OPTIONAL)
     if (NOT LIB_PATH)
@@ -288,6 +294,7 @@ set_property(TARGET monero::libraries PROPERTY
     "${MONERO_SOURCE_DIR}/external/easylogging++"
     "${MONERO_SOURCE_DIR}/external/rapidjson/include"
     "${MONERO_SOURCE_DIR}/external/supercop/include"
+    "${MONERO_SOURCE_DIR}/external/mx25519/include"
     "${MONERO_SOURCE_DIR}/src"
 )
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
 RUN apt-get install --no-install-recommends -y \
     build-essential \
     ca-certificates \
+    cargo \
     ccache \
     cmake \
     doxygen \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,19 +57,19 @@ endif ()
 configure_file(lws_version.h.in "${CMAKE_BINARY_DIR}/generated_include/lws_version.h")
 include_directories("${CMAKE_BINARY_DIR}/generated_include")
 
-add_subdirectory(lmdb)
-add_subdirectory(wire)
-add_subdirectory(db)
-add_subdirectory(net)
-add_subdirectory(rpc)
-add_subdirectory(util)
-
 # For both the server and admin utility.
 set(monero-lws-common_sources config.cpp error.cpp)
 set(monero-lws-common_headers config.h error.h fwd.h)
 
 add_library(monero-lws-common ${monero-lws-common_sources} ${monero-lws-common_headers})
 target_link_libraries(monero-lws-common monero::libraries)
+
+add_subdirectory(lmdb)
+add_subdirectory(wire)
+add_subdirectory(db)
+add_subdirectory(net)
+add_subdirectory(rpc)
+add_subdirectory(util)
 
 add_library(monero-lws-daemon-common rest_server.cpp scanner.cpp mempool.cpp)
 target_include_directories(monero-lws-daemon-common PUBLIC ${ZMQ_INCLUDE_PATH})

--- a/src/admin_main.cpp
+++ b/src/admin_main.cpp
@@ -70,7 +70,7 @@ namespace
   void write_bytes(wire::json_writer& dest, const admin_display<lws::db::account>& source)
   {
     wire::object(dest,
-      wire::field("address", lws::db::address_string(source.value.address)),
+      wire::field("address", lws::db::address_string(lws::db::account_address{source.value})),
       wire::field("key", std::cref(source.value.key))
     );
   }
@@ -184,8 +184,8 @@ namespace
     admin_display<lws::db::account> account{};
     {
       crypto::secret_key auth{};
-      crypto::generate_keys(account.value.address.view_public, auth);
-      MONERO_UNWRAP(prog.disk.add_account(account.value.address, auth, lws::db::account_flags::admin_account));
+      crypto::generate_keys(account.value.pubs.view_public, auth);
+      MONERO_UNWRAP(prog.disk.add_account(lws::db::account_address{account.value}, auth, lws::db::account_flags::admin_account));
 
       static_assert(sizeof(auth) == sizeof(account.value.key), "bad memcpy");
       std::memcpy(std::addressof(account.value.key), std::addressof(auth), sizeof(auth));

--- a/src/db/CMakeLists.txt
+++ b/src/db/CMakeLists.txt
@@ -26,9 +26,9 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set(monero-lws-db_sources account.cpp data.cpp storage.cpp string.cpp)
-set(monero-lws-db_headers account.h data.h fwd.h storage.h string.h)
+set(monero-lws-db_sources account.cpp carrot.cpp data.cpp storage.cpp string.cpp)
+set(monero-lws-db_headers account.h carrot.h data.h fwd.h storage.h string.h)
 
 add_library(monero-lws-db ${monero-lws-db_sources} ${monero-lws-db_headers})
 target_include_directories(monero-lws-db PUBLIC "${LMDB_INCLUDE}")
-target_link_libraries(monero-lws-db monero::libraries monero-lws-common monero-lws-lmdb monero-lws-wire-msgpack ${LMDB_LIB_PATH})
+target_link_libraries(monero-lws-db monero::libraries monero-lws-common monero-lws-lmdb monero-lws-wire-json monero-lws-wire-msgpack ${LMDB_LIB_PATH})

--- a/src/db/account.cpp
+++ b/src/db/account.cpp
@@ -29,12 +29,17 @@
 #include <algorithm>
 #include <cstring>
 
+#include "carrot_core/account_secrets.h"
 #include "common/error.h"
 #include "common/expect.h"
+#include "db/carrot.h"
 #include "db/data.h"
 #include "db/string.h"
+#include "error.h"
+#include "ringct/rctOps.h"
 #include "wire/adapted/crypto.h"
 #include "wire/adapted/pair.h"
+#include "wire/adapted/tuple.h"
 #include "wire/msgpack.h"
 #include "wire/vector.h"
 #include "wire/wrapper/trusted_array.h"
@@ -52,6 +57,13 @@ namespace lws
       }
     };
 
+    account::key_type get_type(const db::account_flags flags) noexcept
+    {
+      if (flags & db::account_flags::view_balance_key)
+        return account::key_type::balance;
+      return account::key_type::legacy;
+    }
+
     template<typename F, typename T>
     static void map_update(F& format, T& self)
     {
@@ -64,26 +76,47 @@ namespace lws
     }
   }
 
+  WIRE_AS_INTEGER(account::key_type);
+
   struct account::internal
   {
     internal()
-      : address(), id(db::account_id::invalid), pubs{}, view_key{}
+      : address(),
+        id(db::account_id::invalid),
+        pubs{},
+        balance_key{},
+        carrot_secrets{},
+        type(account::key_type::legacy)
     {}
 
     explicit internal(db::account const& source)
-      : address(db::address_string(source.address)), id(source.id), pubs(source.address), view_key()
+      : address(),
+        id(source.id),
+        pubs{},
+        balance_key{},
+        carrot_secrets{},
+        type(get_type(source.flags))
     {
       using inner_type =
-        std::remove_reference<decltype(tools::unwrap(view_key))>::type;
+        std::remove_reference<decltype(tools::unwrap(balance_key))>::type;
+
+      const std::unique_ptr<const carrot::balance_secrets> secrets = source.get_balance_secrets();
+      pubs = db::account_address{source.pubs, secrets.get()};
+      address = db::address_string(pubs);
+
+      crypto::secret_key& target = secrets ? balance_key : carrot_secrets.kv; 
 
       static_assert(std::is_standard_layout<db::view_key>(), "need standard layout source");
       static_assert(std::is_pod<inner_type>(), "need pod target");
-      static_assert(sizeof(view_key) == sizeof(source.key), "different size keys");
+      static_assert(sizeof(target) == sizeof(source.key), "different size keys");
       std::memcpy(
-        std::addressof(tools::unwrap(view_key)),
+        std::addressof(tools::unwrap(target)),
         std::addressof(source.key),
         sizeof(source.key)
       );
+
+      if (secrets)
+        carrot_secrets = *secrets;
     }
 
     void read_bytes(wire::msgpack_reader& source)
@@ -99,19 +132,25 @@ namespace lws
         WIRE_FIELD_ID(0, address),
         WIRE_FIELD_ID(1, id),
         WIRE_FIELD_ID(2, pubs),
-        WIRE_FIELD_ID(3, view_key)
+         // 3 is reserved for historical purposes
+        WIRE_FIELD_ID(4, balance_key),
+        WIRE_FIELD_ID(5, carrot_secrets),
+        WIRE_FIELD_ID(6, type)
       );
     }
 
     std::string address;
     db::account_id id;
     db::account_address pubs;
-    crypto::secret_key view_key;
+    crypto::secret_key balance_key;
+    carrot::balance_secrets carrot_secrets;
+    account::key_type type;
   };
 
-  account::account(std::shared_ptr<const internal> immutable, db::block_id height, std::vector<std::pair<db::output_id, db::address_index>> spendable, std::vector<crypto::public_key> pubs) noexcept
+  account::account(std::shared_ptr<const internal> immutable, db::block_id height, std::vector<spendable_t> spendable, std::vector<balance_t> balance, std::vector<crypto::public_key> pubs) noexcept
     : immutable_(std::move(immutable))
     , spendable_(std::move(spendable))
+    , balance_(std::move(balance))
     , pubs_(std::move(pubs))
     , spends_()
     , outputs_()
@@ -133,7 +172,8 @@ namespace lws
       wire::optional_field<2>("pubs_", wire::trusted_array(std::ref(self.pubs_))),
       wire::optional_field<3>("spends_", wire::trusted_array(std::ref(self.spends_))),
       wire::optional_field<4>("outputs_", wire::trusted_array(std::ref(self.outputs_))),
-      WIRE_FIELD_ID(5, height_)
+      WIRE_FIELD_ID(5, height_),
+      wire::optional_field<6>("balance_", wire::trusted_array(std::ref(self.balance_)))
     );
   }
 
@@ -147,13 +187,14 @@ namespace lws
   { map_update(dest, *this); }
 
   account::account() noexcept
-    : immutable_(nullptr), spendable_(), pubs_(), spends_(), outputs_(), height_(db::block_id(0))
+    : immutable_(nullptr), spendable_(), balance_(), pubs_(), spends_(), outputs_(), height_(db::block_id(0))
   {}
 
-  account::account(db::account const& source, std::vector<std::pair<db::output_id, db::address_index>> spendable, std::vector<crypto::public_key> pubs)
-    : account(std::make_shared<internal>(source), source.scan_height, std::move(spendable), std::move(pubs))
+  account::account(db::account const& source, std::vector<spendable_t> spendable, std::vector<balance_t> balance, std::vector<crypto::public_key> pubs)
+    : account(std::make_shared<internal>(source), source.scan_height, std::move(spendable), std::move(balance), std::move(pubs))
   {
     std::sort(spendable_.begin(), spendable_.end());
+    std::sort(balance_.begin(), balance_.end());
     std::sort(pubs_.begin(), pubs_.end(), sort_pubs{});
   }
 
@@ -166,6 +207,7 @@ namespace lws
     map(source, *this, *immutable);
     immutable_ = std::move(immutable);
     std::sort(spendable_.begin(), spendable_.end());
+    std::sort(balance_.begin(), balance_.end());
     std::sort(pubs_.begin(), pubs_.end(), sort_pubs{});
   }
 
@@ -177,7 +219,7 @@ namespace lws
 
   account account::clone() const
   {
-    account result{immutable_, height_, spendable_, pubs_};
+    account result{immutable_, height_, spendable_, balance_, pubs_};
     result.outputs_ = outputs_;
     result.spends_ = spends_;
     return result;
@@ -199,6 +241,13 @@ namespace lws
     if (immutable_)
       return immutable_->id;
     return db::account_id::invalid;
+  }
+
+  account::key_type account::type() const noexcept
+  {
+    if (immutable_)
+      return immutable_->type;
+    return key_type::legacy;
   }
 
   std::string const& account::address() const
@@ -228,18 +277,41 @@ namespace lws
   crypto::secret_key const& account::view_key() const
   {
     null_check();
-    return immutable_->view_key;
+    return immutable_->carrot_secrets.kv;
   }
 
-  boost::optional<db::address_index> account::get_spendable(db::output_id const& id) const noexcept
+  crypto::secret_key const& account::balance_key() const
+  {
+    null_check();
+    return immutable_->balance_key;
+  }
+
+  crypto::secret_key const& account::generate_image_key() const
+  {
+    null_check();
+    return immutable_->carrot_secrets.kgi;
+  }
+ 
+  std::optional<db::address_index> account::get_spendable(db::output_id const& id) const noexcept
   {
     const auto searchable = 
-      std::make_pair(id, db::address_index{db::major_index::primary, db::minor_index::primary});
+      std::make_pair(id, db::address_index::primary());
     const auto account =
       std::lower_bound(spendable_.begin(), spendable_.end(), searchable);
     if (account == spendable_.end() || account->first != id)
-      return boost::none;
+      return std::nullopt;
     return account->second;
+  }
+
+  std::optional<std::pair<db::output_id, db::address_index>> account::get_spendable(crypto::key_image const& image) const noexcept
+  {
+    const auto searchable =
+      std::make_tuple(image, std::uint64_t(0), db::address_index::primary());
+    const auto account =
+      std::lower_bound(balance_.begin(), balance_.end(), searchable);
+    if (account == balance_.end() || std::get<0>(*account) != image)
+      return std::nullopt;
+    return std::make_pair(db::output_id{0, std::get<1>(*account)}, std::get<2>(*account));
   }
 
   bool account::add_out(db::output const& out)
@@ -249,11 +321,26 @@ namespace lws
       return false;
 
     pubs_.insert(existing_pub, out.pub);
-    auto spendable_value = std::make_pair(out.spend_meta.id, out.recipient);
-    spendable_.insert(
-      std::lower_bound(spendable_.begin(), spendable_.end(), spendable_value),
-      spendable_value
-    );
+
+    if (type() == key_type::balance)
+    {
+      const std::optional<crypto::key_image> image = get_image(out);
+      if (!image)
+        MONERO_THROW(error::crypto_failure, "Failed to generate carrot key image");
+      auto elem = std::make_tuple(*image, out.spend_meta.id.low, out.recipient);
+      balance_.insert(
+        std::lower_bound(balance_.begin(), balance_.end(), elem),
+        elem
+      );
+    }
+    else if (!out.is_carrot())
+    {
+      auto spendable_value = std::make_pair(out.spend_meta.id, out.recipient);
+      spendable_.insert(
+        std::lower_bound(spendable_.begin(), spendable_.end(), spendable_value),
+        spendable_value
+      );
+    }
     outputs_.push_back(out);
     return true;
   }
@@ -262,6 +349,12 @@ namespace lws
   {
     spends_.push_back(spend);
   }
-} // lws
 
+  std::optional<crypto::key_image> account::get_image(db::output const& out) const
+  {
+    if (!immutable_ || type() != key_type::balance)
+      return std::nullopt;
+    return carrot::get_image(out, immutable_->pubs, immutable_->balance_key, immutable_->carrot_secrets);
+  }
+} // lws
 

--- a/src/db/account.h
+++ b/src/db/account.h
@@ -27,10 +27,12 @@
 #pragma once
 
 #include <array>
-#include <boost/optional/optional.hpp>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
+#include <tuple>
+#include <utility>
 #include <vector>
 
 #include "crypto/crypto.h"
@@ -65,20 +67,26 @@ namespace lws
   {
     struct internal;
 
+    using balance_t = std::tuple<crypto::key_image, std::uint64_t, db::address_index>;
+    using spendable_t = std::pair<db::output_id, db::address_index>;
+
     std::shared_ptr<const internal> immutable_;
     std::vector<std::pair<db::output_id, db::address_index>> spendable_;
+    std::vector<balance_t> balance_;
     std::vector<crypto::public_key> pubs_;
     std::vector<db::spend> spends_;
     std::vector<db::output> outputs_;
     db::block_id height_;
 
-    explicit account(std::shared_ptr<const internal> immutable, db::block_id height, std::vector<std::pair<db::output_id, db::address_index>> spendable, std::vector<crypto::public_key> pubs) noexcept;
+    explicit account(std::shared_ptr<const internal> immutable, db::block_id height, std::vector<spendable_t> spendable, std::vector<balance_t> balance, std::vector<crypto::public_key> pubs) noexcept;
     void null_check() const;
 
     template<typename F, typename T, typename U>
     static void map(F& format, T& self, U& immutable);
 
   public:
+    //! `view_key()` can be one of several different "types"
+    enum class key_type : std::uint8_t { balance = 0, incoming, legacy };
 
     //! Sent internally via ZMQ from scanner thread to websocket "push" thread
     struct update
@@ -96,7 +104,7 @@ namespace lws
     account() noexcept;
 
     //! Construct an account from `source` and current `spendable` outputs.
-    explicit account(db::account const& source, std::vector<std::pair<db::output_id, db::address_index>> spendable, std::vector<crypto::public_key> pubs);
+    explicit account(db::account const& source, std::vector<spendable_t> spendable, std::vector<balance_t> balance, std::vector<crypto::public_key> pubs);
 
     /*!
       \return False if this is a "moved-from" account (i.e. the internal memory
@@ -125,6 +133,9 @@ namespace lws
     //! \return Unique ID from the account database, possibly `db::account_id::kInvalid`.
     db::account_id id() const noexcept;
 
+    //! \return Key-type
+    key_type type() const noexcept;
+
     //! \return Monero base58 string for account.
     std::string const& address() const;
 
@@ -137,14 +148,23 @@ namespace lws
     //! \return Extracted spend public key from `address()`.
     crypto::public_key const& spend_public() const;
 
-    //! \return Secret view key for the account.
+    //! \return Secret legacy or carrot incoming key for the account.
     crypto::secret_key const& view_key() const;
+
+    //! \return Secret balance view key, iff `type() == key_type::balance`.
+    crypto::secret_key const& balance_key() const;
+
+    //! \return Secret generate image ley, iff `type() == key_type::balance`.
+    crypto::secret_key const& generate_image_key() const;
 
     //! \return Current scan height of `this`.
     db::block_id scan_height() const noexcept { return height_; }
 
     //! \return Subaddress index iff `id` is spendable by `this`.
-    boost::optional<db::address_index> get_spendable(db::output_id const& id) const noexcept;
+    std::optional<db::address_index> get_spendable(db::output_id const& id) const noexcept;
+
+    //! \return Output index + subaddress index iff `image` is spendable by `this`.
+    std::optional<std::pair<db::output_id, db::address_index>> get_spendable(crypto::key_image const& image) const noexcept;
 
     //! \return Outputs matched during the latest scan.
     std::vector<db::output> const& outputs() const noexcept { return outputs_; }
@@ -157,6 +177,9 @@ namespace lws
 
     //! Track a possible `spend`.
     void add_spend(db::spend const& spend);
+
+    //! \return Key image for `out` iff `type() == key_type::balance`.
+    std::optional<crypto::key_image> get_image(db::output const& out) const;
   };
 
   struct by_height

--- a/src/db/carrot.cpp
+++ b/src/db/carrot.cpp
@@ -1,0 +1,182 @@
+// Copyright (c) 2025, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "carrot.h"
+
+#include "carrot_core/account_secrets.h"     // monero/src
+#include "carrot_core/address_utils.h"       // monero/src
+#include "carrot_core/carrot_enote_types.h"  // monero/src
+#include "carrot_core/device.h"              // monero/src
+#include "carrot_core/device_ram_borrowed.h" // monero/src
+#include "carrot_core/enote_utils.h"         // monero/src
+#include "carrot_impl/address_device_ram_borrowed.h" // monero/src
+#include "carrot_impl/format_utils.h"     // monero/src
+#include "carrot_impl/key_image_device_composed.h"   // monero/src:w
+#include "db/data.h"
+#include "ringct/rctOps.h"               // monero/src
+#include "wire.h"
+#include "wire/adapted/crypto.h"
+
+namespace lws { namespace carrot
+{
+  balance_secrets::balance_secrets(const db::account_pubs& pubs, const crypto::secret_key& svb)
+  {
+    crypto::secret_key preimage{};
+    ::carrot::make_carrot_generateimage_preimage(svb, preimage);
+    ::carrot::make_carrot_generateimage_key(preimage, pubs.flex_public, kgi);
+    ::carrot::make_carrot_generateaddress_secret(svb, sga);
+    ::carrot::make_carrot_viewincoming_key(svb, kv);
+  }
+
+  namespace
+  {
+    template<typename F, typename T>
+    void map_balance_secrets(F& format, T& self)
+    {
+      wire::object(format, WIRE_FIELD_ID(0, kgi), WIRE_FIELD_ID(1, kv), WIRE_FIELD_ID(2, sga));
+    }
+
+    crypto::public_key get_account_view_public(const crypto::public_key& spend_public, const crypto::secret_key& kv)
+    {
+      return rct2pk(scalarmultKey(rct::pk2rct(spend_public), rct::sk2rct(kv)));
+    }
+  }
+  WIRE_DEFINE_OBJECT(balance_secrets, map_balance_secrets);
+
+  account::account(const db::account& source)
+    : account(source, source.get_balance_secrets())
+  {}
+
+  account::account(const db::account& source, balance_secrets const* const secrets) 
+    : view_public{}, spend_public{source.pubs.flex_public}
+  {
+    crypto::secret_key kv;
+    if (secrets)
+    {
+      kv = secrets->kv;
+      spend_public = db::account_address{source.pubs, secrets}.spend_public;
+    }
+    else
+      unwrap(unwrap(kv)) = source.key;
+
+    view_public = get_account_view_public(spend_public, kv);
+  }
+
+  std::optional<crypto::key_image> get_image(const db::output& source, const ::carrot::key_image_device& imager, const ::carrot::view_incoming_key_device& incoming, const crypto::secret_key& balance_key)
+  {
+    try
+    {
+      if (!source.is_carrot())
+        return std::nullopt;
+
+      mx25519_pubkey shared{};
+      ::carrot::view_tag_t tag{};
+      const bool is_coinbase = db::unpack(source.extra).first & db::coinbase_output; 
+      const mx25519_pubkey de = ::carrot::raw_byte_convert<mx25519_pubkey>(source.spend_meta.tx_public);
+      const ::carrot::input_context_t context =
+        is_coinbase ?
+          ::carrot::make_carrot_input_context_coinbase(std::uint64_t(source.link.height)) :
+          ::carrot::make_carrot_input_context(source.first_image);
+
+      if (source.spend_meta.mixin_count == db::carrot_external)
+      {
+        if (!incoming.view_key_scalar_mult_x25519(::carrot::raw_byte_convert<mx25519_pubkey>(source.spend_meta.tx_public), shared))
+          return std::nullopt;
+      }
+      else
+        shared = ::carrot::raw_byte_convert<mx25519_pubkey>(unwrap(unwrap(balance_key)));
+
+      ::carrot::make_carrot_view_tag(shared.data, context, source.pub, tag);
+
+      if (is_coinbase)
+      {
+        return imager.derive_key_image(
+          ::carrot::CarrotCoinbaseOutputOpeningHintV1{
+            ::carrot::CarrotCoinbaseEnoteV1{
+              source.pub,
+              source.spend_meta.amount,
+              source.anchor,
+              tag,
+              de,
+              std::uint64_t(source.link.height)
+            },
+            ::carrot::AddressDeriveType::Carrot
+          }
+        );
+      }
+
+      // else !coinbase
+
+      crypto::hash ctx{}; 
+      ::carrot::make_carrot_contextualized_sender_receiver_secret(shared.data, de, context, ctx);
+
+      return imager.derive_key_image(
+        ::carrot::CarrotOutputOpeningHintV1{
+          ::carrot::CarrotEnoteV1{
+            source.pub,
+            ::carrot::commit_carrot_amount(source.spend_meta.amount, rct2sk(source.ringct_mask)),
+            ::carrot::encrypt_carrot_amount(source.spend_meta.amount, ctx, source.pub),
+            source.anchor,
+            tag,
+            de,
+            source.first_image
+          },
+          std::nullopt,
+          ::carrot::subaddress_index_extended{
+            {std::uint32_t(source.recipient.maj_i), std::uint32_t(source.recipient.min_i)},
+            ::carrot::AddressDeriveType::Carrot
+          }
+        }
+      );
+    }
+    catch (const ::carrot::device_error& e)
+    {
+      MWARNING("Failed to compute key image: " << e.what());
+    }
+
+    return std::nullopt;
+  }
+
+  std::optional<crypto::key_image> get_image(const db::output& source, const db::account_address& primary, const crypto::secret_key& balance_key, const balance_secrets& secrets)
+  {
+    const auto incoming_device = std::make_shared<::carrot::view_incoming_key_ram_borrowed_device>(secrets.kv);
+    const auto image_device = std::make_shared<::carrot::generate_image_key_ram_borrowed_device>(secrets.kgi);
+    const auto generate_device = std::make_shared<::carrot::generate_address_secret_ram_borrowed_device>(secrets.sga);
+    const auto carrot_device = std::make_shared<::carrot::carrot_hierarchy_address_device>(
+      generate_device, primary.spend_public, get_account_view_public(primary.spend_public, secrets.kv)
+    );
+    const auto hybrid_device = std::make_shared<::carrot::hybrid_hierarchy_address_device>(
+      carrot_device, nullptr
+    );
+    const auto balance_device = std::make_shared<::carrot::view_balance_secret_ram_borrowed_device>(balance_key);
+    const ::carrot::key_image_device_composed final_device{
+      image_device, hybrid_device, balance_device, incoming_device
+    };
+    return get_image(source, final_device, *incoming_device, balance_key);
+  }
+}} // lws // carrot
+

--- a/src/db/carrot.h
+++ b/src/db/carrot.h
@@ -1,0 +1,78 @@
+// Copyright (c) 2025, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <memory>
+#include <optional>
+#include "db/fwd.h"
+#include "crypto/crypto.h" // monero/src
+#include "wire/fwd.h"
+
+namespace carrot
+{
+  struct janus_anchor_t;
+  using encrypted_janus_anchor_t = janus_anchor_t;
+  class key_image_device;
+  class view_incoming_key_device;
+}
+namespace lws { namespace carrot
+{
+  //! From the carrot hierarchy
+  struct balance_secrets
+  {
+    crypto::secret_key kgi; //!< generate-image key
+    crypto::secret_key kv;  //!< incoming view key
+    crypto::secret_key sga; //!< generate-address secret
+
+    balance_secrets(const db::account_pubs& pubs, const crypto::secret_key& svb);
+    balance_secrets()
+      : kgi{}, kv{}, sga{}
+    {}
+  };
+  WIRE_DECLARE_OBJECT(balance_secrets);
+
+  //! View public differs from "address" account - see carrot docs
+  struct account 
+  {
+    crypto::public_key view_public;
+    crypto::public_key spend_public;
+
+    explicit account(const db::account& source);
+    explicit account(const db::account& source, const balance_secrets* secrets);
+
+    explicit account(const db::account& source, std::unique_ptr<const balance_secrets> secrets)
+      : account(source, secrets.get())
+    {}
+
+    account() noexcept
+      : view_public{}, spend_public{}
+    {}
+  };
+
+  std::optional<crypto::key_image> get_image(const db::output& source, const ::carrot::key_image_device& imager, const ::carrot::view_incoming_key_device& incoming, const crypto::secret_key& balance_key);
+  std::optional<crypto::key_image> get_image(const db::output& source, const db::account_address& primary, const crypto::secret_key& balance_key, const carrot::balance_secrets& secrets);
+}} // lws // carrot

--- a/src/db/data.cpp
+++ b/src/db/data.cpp
@@ -28,14 +28,20 @@
 
 #include <cstring>
 #include <memory>
+#include <optional>
 
+#include "carrot_core/account_secrets.h"     // monero/src
+#include "carrot_core/destination.h"         // monero/src
+#include "carrot_core/device_ram_borrowed.h" // monero/src
 #include "cryptonote_config.h" // monero/src
+#include "db/carrot.h"
 #include "db/string.h"
 #include "int-util.h"          // monero/contribe/epee/include
 #include "ringct/rctOps.h"     // monero/src
 #include "ringct/rctTypes.h"   // monero/src
 #include "wire.h"
 #include "wire/adapted/array.h"
+#include "wire/adapted/carrot.h"
 #include "wire/adapted/crypto.h"
 #include "wire/json/write.h"
 #include "wire/msgpack.h"
@@ -74,9 +80,35 @@ namespace db
     {
       wire::object(format, WIRE_FIELD_ID(0, spend_public), WIRE_FIELD_ID(1, view_public));
     }
+
+    template<typename F, typename T>
+    void map_account_pubs(F& format, T& self)
+    {
+      wire::object(format, WIRE_FIELD_ID(0, view_public), WIRE_FIELD_ID(1, flex_public));
+    }
   }
   WIRE_DEFINE_OBJECT(account_address, map_account_address);
+  WIRE_DEFINE_OBJECT(account_pubs, map_account_pubs);
 
+  account_address::account_address(const account& acct)
+    : account_address(acct.pubs, acct.get_balance_secrets())
+  {}
+
+  account_address::account_address(const request_info& info)
+    : account_address(info.pubs, info.get_balance_secrets())
+  {}
+
+  account_address::account_address(const account_pubs& pubs, carrot::balance_secrets const* const secrets)
+    : account_address(pubs, secrets ? &secrets->kgi : nullptr)
+  {}
+
+  account_address::account_address(const account_pubs& pubs, crypto::secret_key const* const kgi)
+    : view_public(pubs.view_public), spend_public(pubs.flex_public)
+  {
+    if (kgi)
+      spend_public = rct2pk(addKeys(scalarmultBase(rct::sk2rct(*kgi)), rct::pk2rct(spend_public)));
+  }
+  
   namespace
   {
     template<typename F, typename T>
@@ -163,6 +195,19 @@ namespace db
     return rct::rct2pk(rct::addKeys(rct::pk2rct(base.spend_public), rct::pk2rct(M)));
   }
 
+  crypto::public_key address_index::get_spend_public(carrot::account const& base, crypto::secret_key const& sga) const
+  {
+    if (is_zero())
+      return base.spend_public;
+
+    ::carrot::CarrotDestinationV1 out{};
+    const ::carrot::generate_address_secret_ram_borrowed_device address_device{sga};
+    ::carrot::make_carrot_subaddress_v1(
+      base.spend_public, base.view_public, address_device, std::uint32_t(maj_i), std::uint32_t(min_i), out
+    );
+    return out.address_spend_pubkey; 
+  }
+
   namespace
   {
     template<typename F, typename T>
@@ -170,8 +215,23 @@ namespace db
     {
       wire::object(format, WIRE_FIELD_ID(0, subaddress), WIRE_FIELD_ID(1, index));
     }
+
+    std::unique_ptr<carrot::balance_secrets> compute_secrets(const account_flags flags, const account_pubs& pubs, const db::view_key& key)
+    {
+      if (!(flags & db::view_balance_key))
+        return nullptr;
+
+      crypto::secret_key balance;
+      unwrap(unwrap(balance)) = key;
+      return std::make_unique<carrot::balance_secrets>(pubs, balance);
+    }
   }
   WIRE_DEFINE_OBJECT(subaddress_map, map_subaddress_map);
+
+  std::unique_ptr<carrot::balance_secrets> account::get_balance_secrets() const
+  {
+    return compute_secrets(flags, pubs, key);    
+  }
 
   void write_bytes(wire::writer& dest, const account& self, const bool show_key)
   {
@@ -183,7 +243,7 @@ namespace db
     wire::object(dest,
       WIRE_FIELD(id),
       wire::field("access_time", self.access),
-      WIRE_FIELD(address),
+      WIRE_FIELD(pubs),
       wire::optional_field("view_key", key),
       WIRE_FIELD(scan_height),
       WIRE_FIELD(start_height),
@@ -255,8 +315,10 @@ namespace db
   void read_bytes(wire::reader& source, output& self)
   {
     bool coinbase = false;
-    boost::optional<rct::key> rct;
-    boost::optional<std::vector<std::uint8_t>> payment_id;
+    std::optional<rct::key> rct;
+    std::optional<std::vector<std::uint8_t>> payment_id;
+    std::optional<crypto::key_image> first_image;
+    std::optional<::carrot::encrypted_janus_anchor_t> anchor;
 
     wire::object(source,
       wire::optional_field<0>("id", wire::defaulted(std::ref(self.spend_meta.id), output_id::txpool())),
@@ -274,7 +336,9 @@ namespace db
       wire::field<12>("coinbase", std::ref(coinbase)),
       wire::field<13>("fee", std::ref(self.fee)),
       wire::field<14>("recipient", std::ref(self.recipient)),
-      wire::field<15>("pub", std::ref(self.pub))
+      wire::field<15>("pub", std::ref(self.pub)),
+      wire::optional_field<16>("first_image", std::ref(first_image)),
+      wire::optional_field<17>("janus_enc", std::ref(anchor))
     );
 
     std::uint8_t pay_length = 0;
@@ -299,6 +363,14 @@ namespace db
     if (rct)
       flags = extra(lws::db::ringct_output | flags);
     self.extra = db::pack(flags, pay_length);
+
+    if (self.spend_meta.is_carrot())
+    {
+      if (!first_image || !anchor)
+        WIRE_DLOG_THROW(wire::error::schema::binary, "expected first_image and anchor");
+      self.first_image = *first_image;
+      self.anchor = *anchor;
+    }
   }
 
   void write_bytes(wire::writer& dest, const output& self)
@@ -320,6 +392,14 @@ namespace db
     const auto payment_id = payment_bytes.empty() ?
       nullptr : std::addressof(payment_bytes);
 
+    crypto::key_image const* first = nullptr;
+    ::carrot::encrypted_janus_anchor_t const* anchor = nullptr;
+    if (self.spend_meta.is_carrot())
+    {
+      first = std::addressof(self.first_image);
+      anchor = std::addressof(self.anchor);
+    }
+
     // defaulted will omit "id" and "block" when the output is in the
     // txpool with no valid values.
     wire::object(dest,
@@ -338,7 +418,9 @@ namespace db
       wire::field<12>("coinbase", coinbase),
       wire::field<13>("fee", self.fee),
       wire::field<14>("recipient", self.recipient),
-      wire::field<15>("pub", std::cref(self.pub))
+      wire::field<15>("pub", std::cref(self.pub)),
+      wire::optional_field<16>("first_image", first),
+      wire::optional_field<17>("janus_enc", anchor)
     );
   }
 
@@ -395,6 +477,11 @@ namespace db
   }
   WIRE_DEFINE_OBJECT(key_image, map_key_image);
 
+  std::unique_ptr<carrot::balance_secrets> request_info::get_balance_secrets() const
+  {
+    return compute_secrets(creation_flags, pubs, key);    
+  } 
+
   void write_bytes(wire::writer& dest, const request_info& self, const bool show_key)
   {
     db::view_key const* const key =
@@ -402,7 +489,7 @@ namespace db
     const bool generated = (self.creation_flags & lws::db::account_generated_locally);
 
     wire::object(dest,
-      WIRE_FIELD(address),
+      WIRE_FIELD(pubs),
       wire::optional_field("view_key", key),
       WIRE_FIELD(start_height),
       wire::field("generated_locally", generated),

--- a/src/db/data.h
+++ b/src/db/data.h
@@ -33,11 +33,14 @@
 #include <cstdint>
 #include <iosfwd>
 #include <limits>
+#include <memory>
 #include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
+#include "db/fwd.h"
+#include "carrot_core/core_types.h"
 #include "crypto/crypto.h"
 #include "lmdb/util.h"
 #include "ringct/rctTypes.h" //! \TODO brings in lots of includes, try to remove
@@ -46,6 +49,8 @@
 #include "wire/msgpack/fwd.h"
 #include "wire/traits.h"
 #include "wire/wrapper/array.h"
+
+namespace carrot { class key_image_device; }
 
 namespace lws
 {
@@ -78,12 +83,30 @@ namespace db
   inline constexpr std::uint64_t to_uint(const block_id src) noexcept
   { return std::uint64_t(src); }
 
+  inline constexpr block_id add(const block_id src, const std::uint64_t value) noexcept
+  { return block_id(std::uint64_t(src) + value); }
+
+  inline constexpr block_id increment(const block_id src) noexcept
+  { return add(src, 1); }
+
   //! References a global output number, as determined by the public chain
   struct output_id
   {
     //! \return Special ID for outputs not yet in a block.
     static constexpr output_id txpool() noexcept
     { return {0, std::numeric_limits<std::uint64_t>::max()}; }
+
+    //! \return Special ID for unknown spent output
+    static constexpr output_id unknown_spend() noexcept
+    { return {0, std::numeric_limits<std::uint64_t>::max() - 1}; }
+
+    // New output ids, post fcmp++/carrot are called `global`
+
+    static constexpr output_id unified(const std::uint64_t id) noexcept
+    { return {std::numeric_limits<std::uint64_t>::max(), id}; }
+
+    constexpr bool is_unified() const noexcept
+    { return high == std::numeric_limits<std::uint64_t>::max(); }
 
     std::uint64_t high; //!< Amount on public chain; rct outputs are `0`
     std::uint64_t low;  //!< Offset within `amount` on the public chain
@@ -102,7 +125,8 @@ namespace db
   {
     default_account = 0,
     admin_account   = 1,          //!< Indicates `key` can be used for admin requests
-    account_generated_locally = 2 //!< Flag sent by client on initial login request
+    account_generated_locally = 2,//!< Flag sent by client on initial login request
+    view_balance_key = 4,         //!< Indicates `key` is carrot v1 view-balance
   };
 
   enum class request : std::uint8_t
@@ -121,15 +145,50 @@ namespace db
   struct view_key : crypto::ec_scalar {};
   // wire::is_blob trait below
 
-  //! The public keys of a monero address
+  //! Format stored in the DB in account and creation request
+  struct account_pubs
+  {
+    crypto::public_key view_public;//!< In address format; see `carrot::account`. Must be first.
+    crypto::public_key flex_public;//!< Partial spend pubkey when carrot view-balance, otherwise full spend-public
+  };
+  static_assert(sizeof(account_pubs) == 64, "padding in account pubs");
+  WIRE_DECLARE_OBJECT(account_pubs);
+
+
+  //! The public keys of a monero address (as encoded in base58)
   struct account_address
   {
+    explicit account_address(const account& acct);
+    explicit account_address(const request_info& info);
+    explicit account_address(const account_pubs& pubs, const carrot::balance_secrets* secrets);
+    explicit account_address(const account_pubs& pubs, const crypto::secret_key* kgi);
+
+    //! This constructor assumes `pubs` is NOT for a balance key 
+    explicit account_address(const account_pubs& pubs)
+      : account_address(pubs, static_cast<crypto::secret_key*>(nullptr))
+    {}
+
+    explicit account_address(const account_pubs& pubs, const std::unique_ptr<const carrot::balance_secrets> secrets)
+      : account_address(pubs, secrets.get())
+    {}
+
+    account_address(const crypto::public_key& view, const crypto::public_key& spend) noexcept
+      : view_public(view), spend_public(spend)
+    {}
+
+    account_address() noexcept
+      : account_address(crypto::public_key{}, crypto::public_key{})
+    {}
+
+    account_address(const account_address&) = default;
+    account_address& operator=(const account_address&) = default;
+
     crypto::public_key view_public; //!< Must be first for LMDB optimizations.
     crypto::public_key spend_public;
   };
   static_assert(sizeof(account_address) == 64, "padding in account_address");
   WIRE_DECLARE_OBJECT(account_address);
-
+  
   //! Major index of a subaddress
   enum class major_index : std::uint32_t { primary = 0 };
   WIRE_AS_INTEGER(major_index);
@@ -163,10 +222,15 @@ namespace db
     minor_index min_i;
 
     crypto::public_key get_spend_public(account_address const& base, crypto::secret_key const& view) const;
+    crypto::public_key get_spend_public(carrot::account const& base, crypto::secret_key const& address) const;
     constexpr bool is_zero() const noexcept
     {
       return maj_i == major_index::primary && min_i == minor_index::primary;
-    } 
+    }
+    static constexpr address_index primary() noexcept
+    {
+      return {major_index::primary, minor_index::primary};
+    }
   };
   static_assert(sizeof(address_index) == 4 * 2, "padding in address_index");
   WIRE_DECLARE_OBJECT(address_index);
@@ -184,7 +248,7 @@ namespace db
   {
     account_id id;          //!< Must be first for LMDB optimizations
     account_time access;    //!< Last time `get_address_info` was called.
-    account_address address;
+    account_pubs pubs;
     view_key key;           //!< Doubles as authorization handle for REST API.
     block_id scan_height;   //!< Last block scanned; check-ins are always by block
     block_id start_height;  //!< Account started scanning at this block height
@@ -193,6 +257,8 @@ namespace db
     char reserved[3];
     address_index lookahead;
     block_id lookahead_fail;
+
+    std::unique_ptr<carrot::balance_secrets> get_balance_secrets() const;
   };
   static_assert(sizeof(account) == (4 * 2) + 64 + 32 + (8 * 2) + (4 * 2) + (4 * 2) + 8, "padding in account");
   void write_bytes(wire::writer&, const account&, bool show_key = false);
@@ -267,6 +333,10 @@ namespace db
     return {extra(real_val >> 6), std::uint8_t(real_val & 0x3f)};
   }
 
+  // `output.spend_meta.mixin` is set to one of two below values when carrot
+  constexpr const std::uint32_t carrot_external = std::numeric_limits<std::uint32_t>::max();
+  constexpr const std::uint32_t carrot_internal = carrot_external - 1;
+
   //! Information for an output that has been received by an `account`.
   struct output
   {
@@ -278,9 +348,25 @@ namespace db
       output_id id;             //!< Unique id for output within monero
       // `link` and `id` must be in this order for LMDB optimizations
       std::uint64_t amount;
-      std::uint32_t mixin_count;//!< Ring-size of TX
+      std::uint32_t mixin_count;//!< Ring-size of TX or `carrot_output`
       std::uint32_t index;      //!< Offset within a tx
       crypto::public_key tx_public;
+
+      constexpr bool is_carrot() const noexcept
+      { return carrot_internal <= mixin_count; }
+
+      //! \return `mixin` value as used by LWS-RPC.
+      constexpr std::uint32_t rpc_mixin() const noexcept
+      { return is_carrot() ? std::numeric_limits<std::uint32_t>::max() : mixin_count; }
+
+      //! \return metadata when an external receive triggered an unknown spend
+      static constexpr spend_meta_ unknown() noexcept
+      {
+        return spend_meta_{
+          .id = output_id::unknown_spend(),
+          .mixin_count = carrot_external
+        }; 
+      }
     } spend_meta;
 
     std::uint64_t timestamp;
@@ -297,9 +383,13 @@ namespace db
     } payment_id;
     std::uint64_t fee;       //!< Total fee for transaction
     address_index recipient;
+    crypto::key_image first_image; //!< First in tx
+    ::carrot::encrypted_janus_anchor_t anchor; //!< Useful for carrot spending
+
+    constexpr bool is_carrot() const noexcept { return spend_meta.is_carrot(); }
   };
   static_assert(
-    sizeof(output) == 8 + 32 + (8 * 3) + (4 * 2) + 32 + (8 * 2) + (32 * 3) + 7 + 1 + 32 + 8 + 2 * 4,
+    sizeof(output) == 8 + 32 + (8 * 3) + (4 * 2) + 32 + (8 * 2) + (32 * 3) + 7 + 1 + 32 + 8 + 2 * 4 + 32 + 16,
     "padding in output"
   );
   WIRE_DECLARE_OBJECT(output);
@@ -313,7 +403,7 @@ namespace db
     // `link`, `image`, and `source` must in this order for LMDB optimizations
     std::uint64_t timestamp;  //!< Timestamp of spend
     std::uint64_t unlock_time;//!< Unlock time of spend
-    std::uint32_t mixin_count;//!< Ring-size of TX output
+    std::uint32_t mixin_count;//!< Ring-size of TX output or carrot_output
     char reserved[3];
     std::uint8_t length;      //!< Length of `payment_id` field (0..32).
     crypto::hash payment_id;  //!< Unencrypted only, can't decrypt spend
@@ -333,13 +423,15 @@ namespace db
 
   struct request_info
   {
-    account_address address;//!< Must be first for LMDB optimizations
+    account_pubs pubs;//!< Must be first for LMDB optimizations
     view_key key;
     block_id start_height;
     account_time creation;        //!< Time the request was created.
     account_flags creation_flags; //!< Generated locally?
     char reserved[3];
     address_index lookahead;      //!< Desired subaddress lookahead
+
+    std::unique_ptr<carrot::balance_secrets> get_balance_secrets() const;
   };
   static_assert(sizeof(request_info) == 64 + 32 + 8 + (4 * 2) + (4*2), "padding in request_info");
   void write_bytes(wire::writer& dest, const request_info& self, bool show_key = false);

--- a/src/db/fwd.h
+++ b/src/db/fwd.h
@@ -34,6 +34,12 @@ namespace lws
   class account;
   class mempool_receive;
 
+namespace carrot
+{
+  struct account;
+  struct balance_secrets;
+}
+
 namespace db
 {
   enum account_flags : std::uint8_t;
@@ -49,6 +55,7 @@ namespace db
 
   struct account;
   struct account_address;
+  struct account_pubs;
   struct address_index;
   struct block_info;
   struct key_image;

--- a/src/db/storage.cpp
+++ b/src/db/storage.cpp
@@ -39,12 +39,14 @@
 #include <string>
 #include <utility>
 
+#include "carrot_core/account_secrets.h" // monero/src
 #include "checkpoints/checkpoints.h"
 #include "config.h"
 #include "crypto/crypto.h"
 #include "cryptonote_basic/cryptonote_basic.h"
 #include "cryptonote_core/cryptonote_tx_utils.h"
 #include "db/account.h"
+#include "db/carrot.h"
 #include "db/string.h"
 #include "error.h"
 #include "hex.h"
@@ -59,6 +61,7 @@
 #include "lmdb/value_stream.h"
 #include "net/net_parse_helpers.h" // monero/contrib/epee/include
 #include "span.h"
+#include "util/transactions.h"
 #include "wire/adapted/array.h"
 #include "wire/filters.h"
 #include "wire/json.h"
@@ -194,6 +197,55 @@ namespace db
       sizeof(output) == 8 + 32 + (8 * 3) + (4 * 2) + 32 + (8 * 2) + (32 * 3) + 7 + 1 + 32 + 8,
       "padding in output"
     );
+
+    struct request_info
+    {
+      account_address address;//!< Must be first for LMDB optimizations
+      view_key key;
+      block_id start_height;
+      account_time creation;        //!< Time the request was created.
+      account_flags creation_flags; //!< Generated locally?
+      char reserved[3];
+      address_index lookahead;      //!< Desired subaddress lookahead
+
+      std::unique_ptr<carrot::balance_secrets> get_balance_secrets() const;
+    };
+    static_assert(sizeof(request_info) == 64 + 32 + 8 + (4 * 2) + (4*2), "padding in request_info");
+  }
+
+  namespace v2
+  {
+    //! Third DB value, with no carrot/fcmp++ data
+    struct output
+    {
+      transaction_link link;        //! Orders and links `output` to `spend`s.
+
+      //! Data that a linked `spend` needs in some REST endpoints.
+      struct spend_meta_
+      {
+        output_id id;             //!< Unique id for output within monero
+        // `link` and `id` must be in this order for LMDB optimizations
+        std::uint64_t amount;
+        std::uint32_t mixin_count;//!< Ring-size of TX
+        std::uint32_t index;      //!< Offset within a tx
+        crypto::public_key tx_public;
+      } spend_meta;
+
+      std::uint64_t timestamp;
+      std::uint64_t unlock_time; //!< Not always a timestamp; mirrors chain value.
+      crypto::hash tx_prefix_hash;
+      crypto::public_key pub;    //!< One-time spendable public key.
+      rct::key ringct_mask;      //!< Unencrypted CT mask
+      char reserved[7];
+      extra_and_length extra;    //!< Extra info + length of payment id
+      union payment_id_
+      {
+        crypto::hash8 short_;  //!< Decrypted short payment id
+        crypto::hash long_;    //!< Long version of payment id (always decrypted)
+      } payment_id;
+      std::uint64_t fee;       //!< Total fee for transaction
+      address_index recipient;
+    };
   }
 
 
@@ -346,8 +398,11 @@ namespace db
     constexpr const lmdb::basic_table<account_id, v1::output> outputs_v1{
       "outputs_v1_by_account_id,block_id,tx_hash,output_id", MDB_DUPSORT, &output_compare
     };
+    constexpr const lmdb::basic_table<account_id, v2::output> outputs_v2{
+      "outputs_v2_by_account_id,block_id,tx_hash,output_id", MDB_DUPSORT, &output_compare
+    };
     constexpr const lmdb::basic_table<account_id, output> outputs{
-      "outputs_v2_by_account_id,block_id,tx_hash,output_id", (MDB_CREATE | MDB_DUPSORT), &output_compare
+      "outputs_v3_by_account_id,block_id,tx_hash,output_id", (MDB_CREATE | MDB_DUPSORT), &output_compare
     };
     constexpr const lmdb::basic_table<account_id, v0::spend> spends_v0{
       "spends_by_account_id,block_id,tx_hash,image", MDB_DUPSORT, &spend_compare
@@ -361,8 +416,11 @@ namespace db
     constexpr const lmdb::basic_table<request, v0::request_info> requests_v0{
       "requests_by_type,address", MDB_DUPSORT, MONERO_COMPARE(v0::request_info, address.spend_public)
     };
+    constexpr const lmdb::basic_table<request, v1::request_info> requests_v1{
+      "requests_v1_by_type,address", MDB_DUPSORT, MONERO_COMPARE(v1::request_info, address.spend_public)
+    };
     constexpr const lmdb::basic_table<request, request_info> requests{
-      "requests_v1_by_type,address", (MDB_CREATE | MDB_DUPSORT), MONERO_COMPARE(request_info, address.spend_public)
+      "requests_v2_by_type,address", (MDB_CREATE | MDB_DUPSORT), MONERO_COMPARE(request_info, pubs.view_public)
     };
     constexpr const lmdb::msgpack_table<webhook_key, webhook_dupsort, webhook_data> webhooks{
       "webhooks_by_account_id,payment_id", (MDB_CREATE | MDB_DUPSORT), &lmdb::less<db::webhook_dupsort>
@@ -755,6 +813,12 @@ namespace db
       else if (v1_outputs != lmdb::error(MDB_NOTFOUND))
         MONERO_THROW(v1_outputs.error(), "Error opening old outputs table");
 
+      const auto v2_outputs = outputs_v2.open(*txn);
+      if (v2_outputs)
+        MONERO_UNWRAP(convert_table<v2::output, output>(*txn, *v2_outputs, tables.outputs));
+      else if (v2_outputs != lmdb::error(MDB_NOTFOUND))
+        MONERO_THROW(v2_outputs.error(), "Error opening old outputs table");
+
       const auto v0_spends = spends_v0.open(*txn);
       if (v0_spends)
         MONERO_UNWRAP(convert_table<v0::spend, spend>(*txn, *v0_spends, tables.spends));
@@ -772,6 +836,12 @@ namespace db
         MONERO_UNWRAP(convert_table<v0::request_info, request_info>(*txn, *v0_requests, tables.requests));
       else if (v0_requests != lmdb::error(MDB_NOTFOUND))
         MONERO_THROW(v0_requests.error(), "Error open old requests table");
+
+      const auto v1_requests = requests_v1.open(*txn);
+      if (v1_requests)
+        MONERO_UNWRAP(convert_table<v1::request_info, request_info>(*txn, *v1_requests, tables.requests));
+      else if (v1_requests != lmdb::error(MDB_NOTFOUND))
+        MONERO_THROW(v1_requests.error(), "Error opening old requests table");
 
       check_blockchain(*txn, tables.blocks);
       check_pow(*txn, tables.pows);
@@ -997,25 +1067,46 @@ namespace db
 
   expect<lws::account> storage_reader::get_full_account(const account& user)
   {
+    account_address address{};
+    crypto::secret_key balance_key{};
     std::vector<std::pair<db::output_id, db::address_index>> receives{};
+    std::vector<std::tuple<crypto::key_image, std::uint64_t, db::address_index>> balance{};
     std::vector<crypto::public_key> pubs{};
     auto receive_list = get_outputs(user.id);
     if (!receive_list)
       return receive_list.error();
 
+    const std::unique_ptr<carrot::balance_secrets> secrets = user.get_balance_secrets();
     const std::size_t elems = receive_list->count();
-    receives.reserve(elems);
+    if (secrets)
+    {
+      balance.reserve(elems);
+      unwrap(unwrap(balance_key)) = user.key;
+      address = account_address{user.pubs, secrets.get()};
+    }
+    else
+      receives.reserve(elems);
+
     pubs.reserve(elems);
 
     for (auto output = receive_list->make_iterator(); !output.is_end(); ++output)
     {
-      auto id = output.get_value<MONERO_FIELD(db::output, spend_meta.id)>();
+      auto meta = output.get_value<MONERO_FIELD(db::output, spend_meta)>();
       auto subaddr = output.get_value<MONERO_FIELD(db::output, recipient)>();
-      receives.emplace_back(std::move(id), std::move(subaddr));
       pubs.emplace_back(output.get_value<MONERO_FIELD(db::output, pub)>());
+      if (secrets)
+      {
+        std::optional<crypto::key_image> image =
+          carrot::get_image(output.get_value<db::output>(), address, balance_key, *secrets);
+        if (!image)
+          MONERO_THROW(error::crypto_failure, "Failed to calculate carrot key image");
+        balance.emplace_back(std::move(*image), std::move(meta.id.low), std::move(subaddr));
+      }
+      else if (!meta.is_carrot())
+        receives.emplace_back(std::move(meta.id), std::move(subaddr));
     }
 
-    return lws::account{user, std::move(receives), std::move(pubs)};
+    return lws::account{user, std::move(receives), std::move(balance), std::move(pubs)};
   }
 
   expect<std::pair<account_status, account>>
@@ -2076,17 +2167,21 @@ namespace db
           std::addressof(unwrap(copy)), std::addressof(user.key), sizeof(copy)
         );
 
-        if (!crypto::secret_key_to_public_key(copy, verify))
-          return {lws::error::bad_view_key};
+        if (user.flags & account_flags::view_balance_key)
+        {
+          crypto::secret_key incoming_key{};
+          ::carrot::make_carrot_viewincoming_key(copy, incoming_key);
+          copy = incoming_key;
+        }
 
-        if (verify != user.address.view_public)
+        if (!crypto::secret_key_to_public_key(copy, verify) || verify != user.pubs.view_public)
           return {lws::error::bad_view_key};
       }
 
       const account_status status =
         user.flags == account_flags::admin_account ?
           account_status::hidden : account_status::active;
-      const account_by_address by_address{user.address, {user.id, status}};
+      const account_by_address by_address{account_address{user}, {user.id, status}};
 
       MDB_val key = lmdb::to_val(by_address_version);
       MDB_val value = lmdb::to_val(by_address);
@@ -2112,10 +2207,11 @@ namespace db
     }
   } // anonymous
 
-  expect<void> storage::add_account(account_address const& address, crypto::secret_key const& key, const account_flags flags) noexcept
+
+  expect<void> storage::add_account(account_pubs const& pubs, crypto::secret_key const& key, account_flags flags) noexcept
   {
     MONERO_PRECOND(db != nullptr);
-    return db->try_write([this, &address, &key, flags] (MDB_txn& txn) -> expect<void>
+    return db->try_write([this, &pubs, &key, flags] (MDB_txn& txn) -> expect<void>
     {
       const expect<db::account_time> current_time = get_account_time();
       if (!current_time)
@@ -2149,7 +2245,7 @@ namespace db
       const account_id next_id = account_id(lmdb::to_native(*last_id) + 1);
       account user{};
       user.id = next_id;
-      user.address = address;
+      user.pubs = pubs;
       static_assert(sizeof(user.key) == sizeof(key), "bad memcpy");
       std::memcpy(std::addressof(user.key), std::addressof(key), sizeof(key));
       user.start_height = *height;
@@ -2164,9 +2260,18 @@ namespace db
     });
   }
 
+  expect<void> storage::add_account(account_address const& address, crypto::secret_key const& key, const account_flags flags) noexcept
+  {
+    return add_account(
+      account_pubs{address.view_public, address.spend_public},
+      key,
+      account_flags(flags & ~account_flags::view_balance_key)
+    );
+  }
+
   namespace
   {
-    expect<std::vector<subaddress_dict>> do_upsert(MDB_cursor& ranges_cur, MDB_cursor& indexes_cur, const account_id id, const account_address& address, const crypto::secret_key& view_key, std::vector<subaddress_dict> subaddrs, const std::uint32_t max_subaddr)
+    expect<std::vector<subaddress_dict>> do_upsert(MDB_cursor& ranges_cur, MDB_cursor& indexes_cur, const account& user, std::optional<crypto::secret_key> generate_address, std::vector<subaddress_dict> subaddrs, const std::uint32_t max_subaddr)
     {
       std::size_t subaddr_count = 0;
       std::vector<subaddress_dict> out{};
@@ -2197,8 +2302,23 @@ namespace db
         return true;
       };
 
-      MDB_val key = lmdb::to_val(id);
+      
+      if (user.flags & account_flags::view_balance_key)
+      {
+        crypto::secret_key balance_key;
+        unwrap(unwrap(balance_key)) = user.key;
+        ::carrot::make_carrot_generateaddress_secret(balance_key, generate_address.emplace());
+      }
+
+      crypto::secret_key view_key{};
+      std::optional<carrot::account> carrot_user;
+      if (generate_address)
+        carrot_user.emplace(user);
+      else
+        unwrap(unwrap(view_key)) = user.key;
+
       MDB_val value{};
+      MDB_val key = lmdb::to_val(user.id);
       int err = mdb_cursor_get(&indexes_cur, &key, &value, MDB_SET);
       if (err)
       {
@@ -2302,9 +2422,12 @@ namespace db
           {
             subaddress_map new_value{};
             new_value.index = address_index{major_entry.first, minor_index(minor)};
-            new_value.subaddress = new_value.index.get_spend_public(address, view_key);
+            if (carrot_user && generate_address)
+              new_value.subaddress = new_value.index.get_spend_public(*carrot_user, *generate_address);
+            else
+              new_value.subaddress = new_value.index.get_spend_public(account_address{user}, view_key);
 
-            key = lmdb::to_val(id);
+            key = lmdb::to_val(user.id);
             value = lmdb::to_val(new_value);
             const int err = mdb_cursor_put(&indexes_cur, &key, &value, MDB_NODUPDATA);
             if (err && err != MDB_KEYEXIST)
@@ -2316,7 +2439,7 @@ namespace db
           subaddress_ranges.make_value(major_entry.first, new_dict);
         if (!value_bytes)
           return value_bytes.error();
-        key = lmdb::to_val(id);
+        key = lmdb::to_val(user.id);
         value = MDB_val{value_bytes->size(), const_cast<void*>(static_cast<const void*>(value_bytes->data()))};
         MLWS_LMDB_CHECK(mdb_cursor_put(&ranges_cur, &key, &value, MDB_NODUPDATA));
       }
@@ -2324,7 +2447,7 @@ namespace db
       return {std::move(out)};
     }
 
-    expect<void> do_lookahead(MDB_cursor& outputs_cur, MDB_cursor& ranges_cur, MDB_cursor& indexes_cur, const account_id id, const account_address& address, const crypto::secret_key& view_key, const address_index& lookahead, const std::uint32_t max_subaddresses)
+    expect<void> do_lookahead(MDB_cursor& outputs_cur, MDB_cursor& ranges_cur, MDB_cursor& indexes_cur, const account& user, const address_index& lookahead, const std::uint32_t max_subaddresses)
     {
       const auto major = to_uint(lookahead.maj_i);
       const auto minor = to_uint(lookahead.min_i);
@@ -2337,7 +2460,7 @@ namespace db
       if (max_subaddresses < major * minor)
         return {error::max_subaddresses};
 
-      MDB_val key = lmdb::to_val(id);
+      MDB_val key = lmdb::to_val(user.id);
       MDB_val value{};
 
       std::vector<subaddress_dict> initial{};
@@ -2421,7 +2544,7 @@ namespace db
         }
       }
 
-      const auto upserted = do_upsert(ranges_cur, indexes_cur, id, address, view_key, std::move(initial), max_subaddresses);
+      const auto upserted = do_upsert(ranges_cur, indexes_cur, user, std::nullopt, std::move(initial), max_subaddresses);
       if (!upserted)
         return upserted.error();
       return success();
@@ -2429,11 +2552,8 @@ namespace db
 
     expect<void> do_lookahead(account& user, MDB_cursor& outputs_cur, MDB_cursor& ranges_cur, MDB_cursor& indexes_cur, const address_index& lookahead, const std::uint32_t max_subaddresses)
     {
-      crypto::secret_key key;
-      static_assert(sizeof(key) == sizeof(user.key));
-      std::memcpy(std::addressof(unwrap(unwrap(key))), std::addressof(user.key), sizeof(key));
       const expect<void> attempt =
-        do_lookahead(outputs_cur, ranges_cur, indexes_cur, user.id, user.address, key, lookahead, max_subaddresses);
+        do_lookahead(outputs_cur, ranges_cur, indexes_cur, user, lookahead, max_subaddresses);
       if (attempt == error::max_subaddresses)
       {
         user.lookahead = lookahead;
@@ -2575,14 +2695,13 @@ namespace db
     });
   }
 
-  expect<std::vector<webhook_new_account>> storage::creation_request(account_address const& address, crypto::secret_key const& key, account_flags flags, address_index lookahead) noexcept
+  expect<std::vector<webhook_new_account>> storage::creation_request(account_pubs const& pubs, crypto::secret_key const& key, account_flags flags, address_index lookahead) noexcept
   {
     MONERO_PRECOND(db != nullptr);
-
     if (!db->create_queue_max)
       return {lws::error::create_queue_max};
 
-    return db->try_write([this, &address, &key, flags, lookahead] (MDB_txn& txn) -> expect<std::vector<webhook_new_account>>
+    return db->try_write([this, &pubs, &key, flags, lookahead] (MDB_txn& txn) -> expect<std::vector<webhook_new_account>>
     {
       const expect<db::account_time> current_time = get_account_time();
       if (!current_time)
@@ -2599,7 +2718,7 @@ namespace db
       MONERO_CHECK(check_cursor(txn, this->db->tables.webhooks, webhooks_cur));
 
       MDB_val keyv = lmdb::to_val(by_address_version);
-      MDB_val value = lmdb::to_val(address);
+      MDB_val value = lmdb::to_val(pubs);
 
       int err = mdb_cursor_get(accounts_ba_cur.get(), &keyv, &value, MDB_GET_BOTH);
       if (err != MDB_NOTFOUND)
@@ -2635,7 +2754,7 @@ namespace db
         return height.error();
 
       request_info info{};
-      info.address = address;
+      info.pubs = pubs;
       static_assert(sizeof(info.key) == sizeof(key), "bad memcpy");
       std::memcpy(std::addressof(info.key), std::addressof(key), sizeof(key));
       info.creation = *current_time;
@@ -2665,7 +2784,7 @@ namespace db
           return log_lmdb_error(err, __LINE__, __FILE__);
         }
 
-        hooks.push_back(webhook_new_account{MONERO_UNWRAP(webhooks.get_value(value)), address});
+        hooks.push_back(webhook_new_account{MONERO_UNWRAP(webhooks.get_value(value)), account_address{info}});
         err = mdb_cursor_get(webhooks_cur.get(), &keyv, &value, MDB_NEXT_DUP);
       }
 
@@ -2698,7 +2817,7 @@ namespace db
         return log_lmdb_error(err, __LINE__, __FILE__);
 
       request_info info{};
-      info.address = address;
+      info.pubs = {address.view_public, address.spend_public};
       info.start_height = height;
       info.lookahead = lookahead;
 
@@ -2821,7 +2940,7 @@ namespace db
 
         account user{};
         user.id = next_id;
-        user.address = address;
+        user.pubs = info->pubs;
         user.key = info->key;
         user.start_height = info->start_height;
         user.scan_height = info->start_height;
@@ -2997,9 +3116,8 @@ namespace db
         MDB_val key = lmdb::to_val(hook_key);
         MDB_val value = lmdb::to_val(sorter);
         int err = mdb_cursor_get(&webhooks_cur, &key, &value, MDB_GET_BOTH_RANGE);
-
         for (; /* all user/payment_id==x entries */ ;)
-        {
+        {      
           if (err)
           {
             if (err != MDB_NOTFOUND)
@@ -3342,20 +3460,30 @@ namespace db
   }
 
   expect<std::vector<subaddress_dict>>
-  storage::upsert_subaddresses(const account_id id, const account_address& address, const crypto::secret_key& view_key, std::vector<subaddress_dict> subaddrs, const std::uint32_t max_subaddr)
+  storage::upsert_subaddresses(const account_id id, std::optional<crypto::secret_key> generate_address, std::vector<subaddress_dict> subaddrs, const std::uint32_t max_subaddr)
   {
     MONERO_PRECOND(db != nullptr);
     std::sort(subaddrs.begin(), subaddrs.end());
 
-    return db->try_write([this, id, &address, &view_key, &subaddrs, max_subaddr] (MDB_txn& txn) -> expect<std::vector<subaddress_dict>>
+    return db->try_write([this, id, &generate_address, &subaddrs, max_subaddr] (MDB_txn& txn) -> expect<std::vector<subaddress_dict>>
     {
+      cursor::accounts            accounts_cur;
       cursor::subaddress_ranges   ranges_cur;
       cursor::subaddress_indexes  indexes_cur;
 
+      MONERO_CHECK(check_cursor(txn, this->db->tables.accounts,          accounts_cur));
       MONERO_CHECK(check_cursor(txn, this->db->tables.subaddress_ranges, ranges_cur));
       MONERO_CHECK(check_cursor(txn, this->db->tables.subaddress_indexes, indexes_cur));
 
-      return do_upsert(*ranges_cur, *indexes_cur, id, address, view_key, subaddrs, max_subaddr);
+      const account_status status_key = account_status::active;
+      MDB_val key = lmdb::to_val(status_key);
+      MDB_val value = lmdb::to_val(id);
+      MLWS_LMDB_CHECK(mdb_cursor_get(accounts_cur.get(), &key, &value, MDB_GET_BOTH));
+
+      const expect<lws::db::account> user = accounts.get_value<account>(value);
+      if (!user)
+        return user.error();
+      return do_upsert(*ranges_cur, *indexes_cur, *user, generate_address, subaddrs, max_subaddr);
     });
   }
 
@@ -3436,11 +3564,8 @@ namespace db
             }
           }
 
-          crypto::secret_key viewkey;
-          static_assert(sizeof(viewkey) == sizeof(user->key));
-          std::memcpy(std::addressof(unwrap(unwrap(viewkey))), std::addressof(user->key), sizeof(viewkey));
           upserted =
-            do_upsert(*ranges_cur, *indexes_cur, user->id, address, viewkey, std::move(upsertions), max_subaddresses);
+            do_upsert(*ranges_cur, *indexes_cur, *user, std::nullopt, std::move(upsertions), max_subaddresses);
         }
       }
 

--- a/src/db/storage.h
+++ b/src/db/storage.h
@@ -246,6 +246,8 @@ namespace db
     expect<std::vector<account_address>>
       change_status(account_status status, epee::span<const account_address> addresses);
 
+    //! Add an account, for immediate inclusion in the active list.
+    expect<void> add_account(account_pubs const& pubs, crypto::secret_key const& key, account_flags flags = account_flags::default_account) noexcept;
 
     //! Add an account, for immediate inclusion in the active list.
     expect<void> add_account(account_address const& address, crypto::secret_key const& key, account_flags flags = account_flags::default_account) noexcept;
@@ -255,7 +257,7 @@ namespace db
       rescan(block_id height, epee::span<const account_address> addresses);
 
     //! Add an account for later approval. For use with the login endpoint.
-    expect<std::vector<webhook_new_account>> creation_request(account_address const& address, crypto::secret_key const& key, account_flags flags, address_index lookahead) noexcept;
+    expect<std::vector<webhook_new_account>> creation_request(account_pubs const& pubs, crypto::secret_key const& key, account_flags flags, address_index lookahead) noexcept;
 
     /*!
       Request lock height of an existing account. No effect if the `start_height`
@@ -312,7 +314,7 @@ namespace db
         (whereas `subaddrs` may overlap with existing indexes).
       */
     expect<std::vector<subaddress_dict>>
-      upsert_subaddresses(account_id id, const account_address& address, const crypto::secret_key& view_key, std::vector<subaddress_dict> subaddrs, std::uint32_t max_subaddresses);
+      upsert_subaddresses(account_id id, std::optional<crypto::secret_key> address_key, std::vector<subaddress_dict> subaddrs, std::uint32_t max_subaddresses);
 
     /*! Update lookahead where `match` was a matching subaddress on-chain.
       \return The number of new subaddresses added via lookahead, or -1 if

--- a/src/lws_version.h.in
+++ b/src/lws_version.h.in
@@ -33,7 +33,7 @@ namespace lws { namespace version
   constexpr const char branch[] = "@MLWS_COMMIT_BRANCH@";
   constexpr const char commit[] = "@MLWS_COMMIT_HASH@";
   constexpr const char date[] = "@MLWS_COMMIT_DATE@";
-  constexpr const char id[] = "1.1-alpha";
+  constexpr const char id[] = "2.0-alpha";
   constexpr const char name[] = "monero-lws";
 
   // openmonero is currently on 1.6 and we have multiple additions since then

--- a/src/mempool.cpp
+++ b/src/mempool.cpp
@@ -148,7 +148,8 @@ namespace lws
           boost::numeric_cast<std::uint64_t>(std::chrono::system_clock::to_time_t(pair.second->timestamp)),
           std::addressof(pair.first),
           pair.second->tx,
-          fake_outs
+          fake_outs,
+          false
         );
       if (found.empty() || found.back().hash != pair.first)
         skipped.push_back(pair.first);

--- a/src/net/CMakeLists.txt
+++ b/src/net/CMakeLists.txt
@@ -32,4 +32,4 @@ set(monero-lws-net_sources zmq_async.cpp)
 set(monero-lws-net_headers zmq_async.h)
 
 add_library(monero-lws-net ${monero-lws-net_sources} ${monero-lws-net_headers})
-target_link_libraries(monero-lws-net monero-lws-net-http monero::libraries)
+target_link_libraries(monero-lws-net monero-lws-common monero-lws-net-http monero::libraries)

--- a/src/net/http/CMakeLists.txt
+++ b/src/net/http/CMakeLists.txt
@@ -30,4 +30,4 @@ set(monero-lws-net-http_sources client.cpp)
 set(monero-lws-net-http_headers client.h slice_body.h)
 
 add_library(monero-lws-net-http ${monero-lws-net-http_sources} ${monero-lws-net-http_headers})
-target_link_libraries(monero-lws-net-http ${Boost_SYSTEM_LIBRARY} monero::libraries)
+target_link_libraries(monero-lws-net-http monero-lws-common ${Boost_SYSTEM_LIBRARY} monero::libraries)

--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -226,7 +226,6 @@ namespace lws
       return to_uint(tx_height) + CRYPTONOTE_DEFAULT_TX_SPENDABLE_AGE > to_uint(last);
     }
 
-     
     bool check_lookahead(connection_data& data, const db::address_index lookahead)
     {
       const auto minor = to_uint(lookahead.min_i);
@@ -524,16 +523,20 @@ namespace lws
         resp.spent_outputs.reserve(spends->count());
         for (auto const& spend : spends->make_range())
         {
-          const auto meta = rpc::get_address_txs_response::find_metadata(metas, spend.source);
-          if (meta == metas.end() || meta->id != spend.source)
+          if (spend.source != db::output_id::unknown_spend())
           {
-            throw std::logic_error{
-              "Serious database error, no receive for spend"
-            };
+            const auto meta = rpc::get_address_txs_response::find_metadata(metas, spend.source);
+            if (meta == metas.end() || meta->id != spend.source)
+            {
+              throw std::logic_error{
+                "Serious database error, no receive for spend"
+              };
+            }
+            resp.spent_outputs.push_back({*meta, spend});
+            resp.total_sent = rpc::safe_uint64(std::uint64_t(resp.total_sent) + meta->amount);
           }
-
-          resp.spent_outputs.push_back({*meta, spend});
-          resp.total_sent = rpc::safe_uint64(std::uint64_t(resp.total_sent) + meta->amount);
+          else // carrot output with legacy or view-incoming key
+            resp.spent_outputs.push_back({db::output::spend_meta_::unknown(), spend}); 
         }
 
         // `get_rates()` nevers does I/O, so handler can remain synchronous
@@ -1304,7 +1307,7 @@ namespace lws
 
       static expect<response> handle(request req, connection_data& data, std::function<async_complete>&&)
       {
-        if (!lws::rpc::key_check(req.creds))
+        if (!lws::rpc::key_check(req.creds, req.balance_key))
           return {lws::error::bad_view_key};
 
         auto disk = data.global->disk.clone();
@@ -1332,8 +1335,13 @@ namespace lws
         if (!check_lookahead(data, req.lookahead))
           return {lws::error::max_subaddresses};
 
-        const auto flags = req.generated_locally ? db::account_generated_locally : db::default_account;
-        const auto hooks = disk.creation_request(req.creds.address, req.creds.key, flags, req.lookahead);
+        db::account_flags flags = req.generated_locally ? db::account_generated_locally : db::default_account;
+        if (req.balance_key)
+          flags = db::account_flags(flags | db::view_balance_key);
+
+        const auto hooks = disk.creation_request(
+          {req.creds.address.view_public, req.creds.address.spend_public}, req.creds.key, flags, req.lookahead
+        );
         if (!hooks)
           return hooks.error();
 
@@ -1407,7 +1415,7 @@ namespace lws
               db::major_index(elem), db::index_ranges{{db::index_range{db::minor_index(minor_i), db::minor_index(minor_i + n_minor - 1)}}}
             );
           }
-          auto upserted = data.global->disk.clone().upsert_subaddresses(id, req.creds.address, req.creds.key, ranges, data.global->options.max_subaddresses);
+          auto upserted = data.global->disk.clone().upsert_subaddresses(id, req.generate_address, ranges, data.global->options.max_subaddresses);
           if (!upserted)
             return upserted.error();
           new_ranges = std::move(*upserted);
@@ -1667,7 +1675,7 @@ namespace lws
         std::vector<db::subaddress_dict> all_ranges;
         auto disk = data.global->disk.clone();
         auto new_ranges =
-          disk.upsert_subaddresses(id, req.creds.address, req.creds.key, req.subaddrs, data.global->options.max_subaddresses);
+          disk.upsert_subaddresses(id, req.generate_address, req.subaddrs, data.global->options.max_subaddresses);
         if (!new_ranges)
           return new_ranges.error();
 

--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -26,11 +26,11 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-add_subdirectory(scanner)
-
 set(monero-lws-rpc_sources admin.cpp client.cpp daemon_pub.cpp daemon_zmq.cpp feed_ssl.cpp feed_tcp.cpp light_wallet.cpp login.cpp lws_pub.cpp rates.cpp)
 set(monero-lws-rpc_headers admin.h client.h daemon_pub.h daemon_zmq.h feed.h fwd.h json.h light_wallet.h login.h lws_pub.h rates.h)
 
 add_library(monero-lws-rpc ${monero-lws-rpc_sources} ${monero-lws-rpc_headers})
 target_include_directories(monero-lws-rpc PRIVATE ${RMQ_INCLUDE_DIR})
-target_link_libraries(monero-lws-rpc monero::libraries monero-lws-db monero-lws-util monero-lws-wire-json monero-lws-wire-wrapper ${RMQ_LIBRARY})
+target_link_libraries(monero-lws-rpc monero::libraries monero-lws-db monero-lws-net monero-lws-util monero-lws-wire-json monero-lws-wire-wrapper ${RMQ_LIBRARY})
+
+add_subdirectory(scanner)

--- a/src/rpc/admin.cpp
+++ b/src/rpc/admin.cpp
@@ -79,7 +79,7 @@ namespace
   void write_bytes(wire::writer& dest, const truncated<lws::db::account>& self)
   {
     wire::object(dest,
-      wire::field("address", lws::db::address_string(self.value.address)),
+      wire::field("address", lws::db::address_string(lws::db::account_address{self.value})),
       wire::field("scan_height", self.value.scan_height),
       wire::field("access_time", self.value.access)
     );
@@ -88,7 +88,7 @@ namespace
   void write_bytes(wire::writer& dest, const truncated<lws::db::request_info>& self)
   {
     wire::object(dest,
-      wire::field("address", lws::db::address_string(self.value.address)),
+      wire::field("address", lws::db::address_string(lws::db::account_address{self.value})),
       wire::field("start_height", self.value.start_height),
       wire::field("lookahead", self.value.lookahead)
     );

--- a/src/rpc/daemon_zmq.cpp
+++ b/src/rpc/daemon_zmq.cpp
@@ -31,6 +31,7 @@
 #include "cryptonote_config.h"        // monero/src
 #include "crypto/crypto.h"            // monero/src
 #include "rpc/message_data_structs.h" // monero/src
+#include "wire/adapted/carrot.h"
 #include "wire/adapted/crypto.h"
 #include "wire/json.h"
 #include "wire/wrapper/array.h"
@@ -56,7 +57,7 @@ namespace
   using max_inputs_per_tx = wire::max_element_count<3000>;
   using max_outputs_per_tx = wire::max_element_count<2000>;
   using max_ring_size = wire::max_element_count<4600>;
-  using max_txpool_size = wire::max_element_count<775>;
+  using max_txpool_size = wire::max_element_count<700>;
 }
 
 namespace rct
@@ -225,9 +226,9 @@ namespace rct
 
 namespace cryptonote
 {
-  static void read_bytes(wire::json_reader& source, txout_to_script& self)
+  static void read_bytes(wire::json_reader& source, txout_to_carrot_v1& self)
   {
-    wire::object(source, WIRE_FIELD(keys), WIRE_FIELD(script));
+    wire::object(source, WIRE_FIELD(key), WIRE_FIELD(view_tag), WIRE_FIELD(encrypted_janus_anchor));
   }
   static void read_bytes(wire::json_reader& source, txout_to_scripthash& self)
   {
@@ -248,7 +249,7 @@ namespace cryptonote
       WIRE_FIELD(amount),
       WIRE_OPTION("to_key", txout_to_key, variant),
       WIRE_OPTION("to_tagged_key", txout_to_tagged_key, variant),
-      WIRE_OPTION("to_script", txout_to_script, variant),
+      WIRE_OPTION("to_carrot_v1", txout_to_carrot_v1, variant),
       WIRE_OPTION("to_scripthash", txout_to_scripthash, variant)
     );
   }
@@ -263,7 +264,7 @@ namespace cryptonote
   }
   static void read_bytes(wire::json_reader& source, txin_to_scripthash& self)
   {
-    wire::object(source, WIRE_FIELD(prev), WIRE_FIELD(prevout), WIRE_FIELD(script), WIRE_FIELD(sigset));
+    wire::object(source);
   }
   static void read_bytes(wire::json_reader& source, txin_to_key& self)
   {
@@ -302,6 +303,8 @@ namespace cryptonote
 
   static void read_bytes(wire::json_reader& source, block& self)
   {
+    std::optional<std::uint8_t> n_tree_layers;
+    std::optional<crypto::ec_point> tree_root;
     using min_hash_size = wire::min_element_sizeof<crypto::hash>;
     self.tx_hashes.reserve(default_transaction_count);
     wire::object(source,
@@ -311,8 +314,17 @@ namespace cryptonote
       WIRE_FIELD(miner_tx),
       WIRE_FIELD_ARRAY(tx_hashes, min_hash_size),
       WIRE_FIELD(prev_id),
-      WIRE_FIELD(nonce)
+      WIRE_FIELD(nonce),
+      wire::optional_field("fcmp_pp_n_tree_layers", std::ref(n_tree_layers)),
+      wire::optional_field("fcmp_pp_tree_root", std::ref(tree_root))
     );
+    if (self.major_version >= HF_VERSION_FCMP_PLUS_PLUS)
+    {
+      if (!n_tree_layers || !tree_root)
+        WIRE_DLOG_THROW(wire::error::schema::binary, "Expected fcmp++ elements");
+      self.fcmp_pp_n_tree_layers = *n_tree_layers;
+      self.fcmp_pp_tree_root = *tree_root;
+    }
   }
 
   static void read_bytes(wire::json_reader& source, std::vector<transaction>& self)
@@ -352,7 +364,8 @@ void lws::rpc::read_bytes(wire::json_reader& source, get_blocks_fast_response& s
   self.output_indices.reserve(default_blocks_fetched);
   wire::object(source,
     WIRE_FIELD(blocks),
-    wire::field("output_indices", wire::array<max_blocks_per_fetch>(wire::array<max_txes_per_block>(wire::array<max_outputs_per_tx>(std::ref(self.output_indices))))),
+    wire::optional_field("output_indices", wire::array<max_blocks_per_fetch>(wire::array<max_txes_per_block>(wire::array<max_outputs_per_tx>(std::ref(self.output_indices))))),
+    wire::optional_field("unified_indices", wire::array<max_blocks_per_fetch>(wire::array<max_txes_per_block>(wire::array<max_outputs_per_tx>(std::ref(self.unified_indices))))),
     WIRE_FIELD(start_height),
     WIRE_FIELD(current_height)
   );

--- a/src/rpc/daemon_zmq.h
+++ b/src/rpc/daemon_zmq.h
@@ -66,6 +66,7 @@ namespace rpc
     get_blocks_fast_response() = delete;
     std::vector<cryptonote::rpc::block_with_transactions> blocks;
     std::vector<std::vector<std::vector<std::uint64_t>>> output_indices;
+    std::vector<std::vector<std::vector<std::uint64_t>>> unified_indices;
     std::uint64_t start_height;
     std::uint64_t current_height;
   };

--- a/src/rpc/light_wallet.cpp
+++ b/src/rpc/light_wallet.cpp
@@ -31,11 +31,13 @@
 #include <boost/range/adaptor/transformed.hpp>
 #include <ctime>
 #include <limits>
+#include <optional>
 #include <stdexcept>
 #include <type_traits>
 #include <unordered_set>
 
 #include "config.h"
+#include "db/carrot.h"
 #include "db/storage.h"
 #include "db/string.h"
 #include "error.h"
@@ -44,10 +46,12 @@
 #include "time_helper.h"       // monero/contrib/epee/include
 #include "ringct/rctOps.h"     // monero/src
 #include "rpc/feed.h"
+#include "rpc/message_data_structs.h" // monero/src
 #include "span.h"              // monero/contrib/epee/include
 #include "util/random_outputs.h"
 #include "version.h"           // monero/src
 #include "wire.h"
+#include "wire/adapted/carrot.h"
 #include "wire/adapted/crypto.h"
 #include "wire/error.h"
 #include "wire/json.h"
@@ -56,6 +60,7 @@
 #include "wire/vector.h"
 #include "wire/wrapper/array.h"
 #include "wire/wrapper/defaulted.h"
+#include "wire/wrapper/variant.h"
 #include "wire/wrappers_impl.h"
 
 namespace
@@ -86,6 +91,31 @@ namespace wire
     : std::true_type
   {};
 }
+
+namespace fcmp_pp
+{
+  WIRE_AS_INTEGER(OutputPairType);
+
+  static void write_bytes(wire::json_writer& dest, const UnifiedOutputs& self)
+  {
+    wire::object(dest,
+      WIRE_FIELD(unified_ids),
+      WIRE_FIELD(output_types),
+      WIRE_FIELD(output_pubkeys),
+      WIRE_FIELD(commitments)
+    );
+  }
+ 
+  static void write_bytes(wire::json_writer& dest, const CompressedChunk& self)
+  {
+    wire::object(dest, WIRE_FIELD(elems));
+  }
+
+  static void write_bytes(wire::json_writer& dest, const CompressedPath& self)
+  {
+    wire::object(dest, WIRE_FIELD(leaves), WIRE_FIELD(layer_chunks));
+  } 
+} // fcmp_pp
 
 namespace
 {
@@ -140,6 +170,15 @@ namespace
       optional_rct = std::addressof(rct);
     }
 
+    carrot::encrypted_janus_anchor_t const* anchor = nullptr;
+    crypto::key_image const* first = nullptr;
+    if (self.data.first.is_carrot())
+    {
+      anchor = std::addressof(self.data.first.anchor);
+      if (!(unpack(self.data.first.extra).second & lws::db::coinbase_output))
+        first = std::addressof(self.data.first.first_image);
+    }
+
     wire::object(dest,
       wire::field("amount", lws::rpc::safe_uint64(self.data.first.spend_meta.amount)),
       wire::field("public_key", self.data.first.pub),
@@ -153,7 +192,10 @@ namespace
       wire::field("height", self.data.first.link.height),
       wire::field("spend_key_images", std::cref(self.data.second)),
       wire::optional_field("rct", optional_rct),
-      wire::field("recipient", std::cref(self.data.first.recipient))
+      wire::field("recipient", std::cref(self.data.first.recipient)),
+      wire::field("unified", self.data.first.spend_meta.id.is_unified()),
+      wire::optional_field("first_key_image", first),
+      wire::optional_field("janus_enc", anchor)
     );
   }
 
@@ -466,7 +508,7 @@ namespace lws
       wire::field("key_image", std::cref(self.possible_spend.image)),
       wire::field("tx_pub_key", std::cref(self.meta.tx_public)),
       wire::field("out_index", self.meta.index),
-      wire::field("mixin", self.possible_spend.mixin_count),
+      wire::field("mixin", self.meta.rpc_mixin()),
       wire::field("sender", std::cref(self.possible_spend.sender))
     );
   }
@@ -524,7 +566,7 @@ namespace lws
         wire::optional_field("payment_id", payment_id),
         wire::field("coinbase", is_coinbase),
         wire::field("mempool", mempool),
-        wire::field("mixin", self.value().info.spend_meta.mixin_count),
+        wire::field("mixin", self.value().info.spend_meta.rpc_mixin()),
         wire::field("recipient", self.value().info.recipient),
         wire::field("spent_outputs", std::cref(self.value().spends))
       );
@@ -594,16 +636,26 @@ namespace lws
 
       const bool has_pool = (user && pool);
       std::uint64_t total = 0;
+      crypto::secret_key balance_key{};
+      db::account_address user_address{};
+      std::unique_ptr<carrot::balance_secrets> balance_secrets;
       std::vector<rpc::get_transaction> out{};
       std::vector<db::output::spend_meta_> metas{};
       std::vector<std::pair<db::output_id, db::address_index>> receives{};
+      std::vector<std::tuple<crypto::key_image, std::uint64_t, db::address_index>> balance{};
       std::unordered_set<crypto::hash> txes_processed{};
 
       out.reserve(reserve);
       metas.reserve(reserve);
-      if (has_pool)
+      if (user && pool)
       {
-        receives.reserve(reserve);
+        balance_secrets = user->get_balance_secrets();
+        user_address = db::account_address{user->pubs, balance_secrets.get()};
+        std::memcpy(&unwrap(unwrap(balance_key)), &user->key, sizeof(balance_key));
+        if (balance_secrets)
+          balance.reserve(reserve);
+        else
+          receives.reserve(reserve);
         txes_processed.reserve(reserve);
       }
 
@@ -645,7 +697,15 @@ namespace lws
           {
             auto id = output.template get_value<MONERO_FIELD(db::output, spend_meta.id)>();
             auto subaddr = output.template get_value<MONERO_FIELD(db::output, recipient)>();
-            receives.emplace_back(std::move(id), std::move(subaddr));
+
+            if (balance_secrets)
+            {
+              auto image = get_image(*output, user_address, balance_key, *balance_secrets);
+              if (image)
+                balance.emplace_back(std::move(*image), std::move(id.low), std::move(subaddr));
+            }
+            else
+              receives.emplace_back(std::move(id), std::move(subaddr));
           }
 
           if (all_outputs)
@@ -669,13 +729,19 @@ namespace lws
           LWS_VERIFY(!spend.is_end());
 
           const db::output_id source_id = spend.template get_value<MONERO_FIELD(db::spend, source)>();
-          const auto meta = rpc::get_address_txs_response::find_metadata(metas, source_id);
-          LWS_VERIFY(skip_spend_meta || (meta != metas.end() && meta->id == source_id));
+          auto meta = db::output::spend_meta_::unknown();
+          if (source_id != db::output_id::unknown_spend())
+          {
+            const auto spend_meta = rpc::get_address_txs_response::find_metadata(metas, source_id);
+            LWS_VERIFY(skip_spend_meta || (spend_meta != metas.end() && spend_meta->id == source_id));
+            if (spend_meta != metas.end())
+              meta = *spend_meta;
+          }
 
           if (out.empty() || out.back().info.link.tx_hash != next_spend.tx_hash)
           {
             out.push_back({});
-            out.back().spends.push_back({skip_spend_meta ? meta_type{} : *meta, *spend});
+            out.back().spends.push_back({skip_spend_meta ? meta_type{} : meta, *spend});
             out.back().info.link.height = out.back().spends.back().possible_spend.link.height;
             out.back().info.link.tx_hash = out.back().spends.back().possible_spend.link.tx_hash;
             out.back().info.spend_meta.mixin_count =
@@ -686,10 +752,10 @@ namespace lws
               txes_processed.emplace(out.back().info.link.tx_hash);
           }
           else
-            out.back().spends.push_back({skip_spend_meta ? meta_type{} : *meta, *spend});
+            out.back().spends.push_back({skip_spend_meta ? meta_type{} : meta, *spend});
 
           if (!skip_spend_meta)
-            out.back().spent += meta->amount;
+            out.back().spent += meta.amount;
 
           ++spend;
           if (!spend.is_end())
@@ -701,7 +767,7 @@ namespace lws
       {
         // Add mempool transactions. Order is not important, since
         // mempool txs cannot depend on each other.
-        lws::account full_user{*user, std::move(receives), {}};
+        lws::account full_user{*user, std::move(receives), std::move(balance), {}};
         const auto pool_txs = pool->scan_account(full_user);
         for (const auto& row: pool_txs)
         {
@@ -832,6 +898,73 @@ namespace lws
     wire::object(dest, WIRE_FIELD(all_subaddrs));
   }
 
+  namespace rpc
+  {
+    namespace
+    {
+      template<typename F, typename T>
+      void map_legacy(F& format, T& self)
+      {
+        wire::object(format, WIRE_FIELD(amount), WIRE_FIELD(index));
+      }
+    }
+
+    static void read_bytes(wire::json_reader& source, legacy_id& self)
+    {
+      map_legacy(source, self);
+    }
+
+    static void write_bytes(wire::json_writer& dest, const legacy_id& self)
+    {
+      map_legacy(dest, self);
+    }
+
+    namespace
+    {
+      template<typename F, typename T>
+      void map_unified(F& format, T& self)
+      {
+        auto id = wire::variant(std::ref(self));
+        wire::object(format,
+          WIRE_OPTION("legacy", rpc::legacy_id, id),
+          WIRE_OPTION("unified", std::uint64_t, id)
+        ); 
+      }
+    }
+
+    static void read_bytes(wire::json_reader& source, unified_id& self)
+    {
+      map_unified(source, self);
+    }
+
+    static void write_bytes(wire::json_writer& dest, const unified_id& self)
+    {
+      map_unified(dest, self);
+    }
+
+    static void write_bytes(wire::json_writer& dest, const path_response& self)
+    {
+      wire::object(dest, WIRE_FIELD(output_id), WIRE_FIELD(leaf_idx), WIRE_FIELD(path));
+    }
+  } // rpc
+
+  void rpc::read_bytes(wire::json_reader& source, get_tree_paths_request& self)
+  {
+    using max_outputs = wire::max_element_count<21845>;
+    wire::object(source, WIRE_FIELD_ARRAY(output_ids, max_outputs));
+  }
+
+  void rpc::write_bytes(wire::json_writer& dest, const get_tree_paths_response& self)
+  {
+    wire::object(dest,
+      WIRE_FIELD(top_block_height),
+      WIRE_FIELD(n_leaf_tuples),
+      WIRE_FIELD(paths),
+      WIRE_FIELD(last_path),
+      WIRE_FIELD(top_block_hash)
+    );
+  }
+
   void rpc::read_bytes(wire::json_reader& source, get_unspent_outs_request& self)
   {
     std::string address;
@@ -917,14 +1050,39 @@ namespace lws
   void rpc::read_bytes(wire::json_reader& source, login_request& self)
   {
     std::string address;
+    std::optional<db::view_key> view_key;
+    std::optional<db::view_key> balance_key;
+    std::optional<crypto::public_key> partial_spend;
     wire::object(source,
       wire::field("address", std::ref(address)),
-      wire::field("view_key", std::ref(unwrap(unwrap(self.creds.key)))),
+      wire::optional_field("view_key", std::ref(view_key)),
+      wire::optional_field("balance_key", std::ref(balance_key)),
+      wire::optional_field("partial_spend", std::ref(partial_spend)),
       WIRE_FIELD_DEFAULTED(lookahead, db::address_index{}),
       WIRE_FIELD(create_account),
       WIRE_FIELD(generated_locally)
     );
+
+    if (unsigned(bool(view_key)) + unsigned(bool(balance_key)) != 1)
+      WIRE_DLOG_THROW(wire::error::schema::fixed_binary, "one of: view_key, balance_key");
+    if (!view_key && unsigned(bool(balance_key)) + unsigned(bool(partial_spend)) != 2)
+      WIRE_DLOG_THROW(wire::error::schema::fixed_binary, "both: balance_key and partial_spend");
+
+    self.balance_key = bool(balance_key);
     convert_address(address, self.creds.address);
+    if (balance_key && partial_spend)
+    {
+      std::memcpy(std::addressof(unwrap(unwrap(self.creds.key))), std::addressof(*balance_key), sizeof(*balance_key));
+
+      const db::account_pubs pubs{self.creds.address.view_public, *partial_spend};
+      const carrot::balance_secrets secrets{pubs, self.creds.key};
+      if (db::account_address{pubs, &secrets}.spend_public != self.creds.address.spend_public)
+        WIRE_DLOG_THROW(wire::error::schema::fixed_binary, "invalid partial spend pubkey");
+
+      self.creds.address.spend_public = *partial_spend;
+    }
+    else if (view_key)
+      std::memcpy(std::addressof(unwrap(unwrap(self.creds.key))), std::addressof(*view_key), sizeof(*view_key)); 
   }
   void rpc::write_bytes(wire::json_writer& dest, const login_response self)
   {
@@ -938,9 +1096,11 @@ namespace lws
   void rpc::read_bytes(wire::json_reader& source, provision_subaddrs_request& self)
   {
     std::string address;
+    std::optional<crypto::ec_scalar> generate_address;
     wire::object(source,
       wire::field("address", std::ref(address)),
       wire::field("view_key", std::ref(unwrap(unwrap(self.creds.key)))),
+      wire::optional_field("generate_address_key", std::ref(generate_address)),
       WIRE_OPTIONAL_FIELD(maj_i),
       WIRE_OPTIONAL_FIELD(min_i),
       WIRE_OPTIONAL_FIELD(n_maj),
@@ -948,6 +1108,8 @@ namespace lws
       WIRE_OPTIONAL_FIELD(get_all)
     );
     convert_address(address, self.creds.address);
+    if (generate_address)
+      unwrap(unwrap(self.generate_address.emplace())) = *generate_address;
   }
  
   void rpc::read_bytes(wire::json_reader& source, submit_raw_tx_request& self)
@@ -962,12 +1124,16 @@ namespace lws
   void rpc::read_bytes(wire::json_reader& source, upsert_subaddrs_request& self)
   {
     std::string address;
+    std::optional<crypto::ec_scalar> generate_address;
     wire::object(source,
       wire::field("address", std::ref(address)),
       wire::field("view_key", std::ref(unwrap(unwrap(self.creds.key)))),
+      wire::optional_field("generate_address_key", std::ref(generate_address)),
       WIRE_FIELD_ARRAY(subaddrs, max_subaddrs),
       WIRE_OPTIONAL_FIELD(get_all)
     );
     convert_address(address, self.creds.address);
+    if (generate_address)
+      unwrap(unwrap(self.generate_address.emplace())) = *generate_address;
   }
 } // lws

--- a/src/rpc/light_wallet.h
+++ b/src/rpc/light_wallet.h
@@ -29,7 +29,7 @@
 
 #include <boost/optional/optional.hpp>
 #include <cstdint>
-
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -40,11 +40,18 @@
 #include "crypto/crypto.h"     // monero/src
 #include "db/data.h"
 #include "db/fwd.h"
+#include "fcmp_pp/curve_trees.h" // monero/src
 #include "rpc/fwd.h"
 #include "rpc/rates.h"
 #include "util/fwd.h"
 #include "wire/json/fwd.h"
 #include "wire/msgpack/fwd.h"
+
+namespace cryptonote { namespace rpc
+{
+  struct path_request;
+  struct path_response;
+}}
 
 namespace lws
 {
@@ -317,6 +324,45 @@ namespace rpc
   void write_bytes(wire::json_writer&, const get_subaddrs_response&);
 
 
+  struct legacy_id
+  {
+    legacy_id(std::uint64_t amount = 0, std::uint64_t index = 0) noexcept
+      : amount(amount), index(index)
+    {}
+
+    std::uint64_t amount;
+    std::uint64_t index;
+  };
+
+  using unified_id = std::variant<std::uint64_t, legacy_id>;
+
+  struct get_tree_paths_request
+  {
+    get_tree_paths_request() = delete;
+    std::vector<unified_id> output_ids;
+  };
+  void read_bytes(wire::json_reader&, get_tree_paths_request&);
+
+  struct path_response
+  {
+    path_response() = delete;
+    fcmp_pp::CompressedPath path;
+    unified_id output_id;
+    std::uint64_t leaf_idx; 
+  };
+
+  struct get_tree_paths_response
+  {
+    get_tree_paths_response() = delete;
+    std::uint64_t top_block_height;
+    std::uint64_t n_leaf_tuples;
+    std::vector<path_response> paths;
+    fcmp_pp::CompressedPath last_path;
+    crypto::hash top_block_hash;
+  };
+  void write_bytes(wire::json_writer&, const get_tree_paths_response&);
+
+
   struct get_version_request
   {
     get_version_request() = delete;
@@ -374,6 +420,7 @@ namespace rpc
     db::address_index lookahead;
     bool create_account;
     bool generated_locally;
+    bool balance_key;
   };
   void read_bytes(wire::json_reader&, login_request&);
 
@@ -391,6 +438,7 @@ namespace rpc
   {
     provision_subaddrs_request() = delete;
     account_credentials creds;
+    std::optional<crypto::secret_key> generate_address;
     boost::optional<std::uint32_t> maj_i;
     boost::optional<std::uint32_t> min_i;
     boost::optional<std::uint32_t> n_maj;
@@ -420,6 +468,7 @@ namespace rpc
     upsert_subaddrs_request() = delete;
     account_credentials creds;
     std::vector<db::subaddress_dict> subaddrs;
+    std::optional<crypto::secret_key> generate_address;
     boost::optional<bool> get_all;
   };
   void read_bytes(wire::json_reader&, upsert_subaddrs_request&);

--- a/src/rpc/login.cpp
+++ b/src/rpc/login.cpp
@@ -27,11 +27,19 @@
 
 #include "login.h"
 
-#include "crypto/crypto.h" // monero/src
+#include "carrot_core/account_secrets.h" // monero/src
 #include "db/data.h"
 #include "db/storage.h"
 #include "error.h"
 #include "rpc/light_wallet.h"
+
+namespace
+{
+  bool key_check(const lws::rpc::account_credentials& creds)
+  {
+    return ::lws::rpc::key_check(creds.address.view_public, creds.key);
+  }
+}
 
 namespace lws { namespace rpc
 {
@@ -49,20 +57,28 @@ namespace lws { namespace rpc
     return true;
   }
 
-  bool key_check(const rpc::account_credentials& creds)
+  bool key_check(const crypto::public_key& view_public, const crypto::secret_key& key)
   {
     crypto::public_key verify{};
-    if (!crypto::secret_key_to_public_key(creds.key, verify))
+    if (!crypto::secret_key_to_public_key(key, verify))
       return false;
-    if (verify != creds.address.view_public)
-      return false;
-    return true;
+    return verify == view_public;
+  }
+
+  bool key_check(const rpc::account_credentials& creds, const bool balance_key)
+  {
+    if (!balance_key)
+      return ::key_check(creds);
+
+    crypto::secret_key view_key{};
+    ::carrot::make_carrot_viewincoming_key(creds.key, view_key);
+    return key_check(creds.address.view_public, view_key);
   }
 
   //! \return Account info from the DB, iff key matches address AND address is NOT hidden.
   expect<std::pair<db::account, db::storage_reader>> open_account(const account_credentials& creds, const db::storage& disk)
   {
-    if (!key_check(creds))
+    if (!::key_check(creds))
       return {lws::error::bad_view_key};
 
     auto reader = disk.start_read();

--- a/src/rpc/login.h
+++ b/src/rpc/login.h
@@ -30,6 +30,7 @@
 #include <utility>
 
 #include "common/expect.h" // monero/src
+#include "crypto/crypto.h"
 #include "db/fwd.h"
 #include "rpc/fwd.h"
 
@@ -38,8 +39,11 @@ namespace lws { namespace rpc
   bool is_hidden(db::account_status status) noexcept;
 
   //! Verify that view pub matches view secret.
-  bool key_check(const rpc::account_credentials& creds);
+  bool key_check(const crypto::public_key& view_public, const crypto::secret_key& key);
 
+  //! Verify that view pub matches view secret.
+  bool key_check(const rpc::account_credentials& creds, const bool balance_key);
+  
   //! \return Account info from the DB, iff key matches address AND address is NOT hidden.
   expect<std::pair<db::account, db::storage_reader>> open_account(const account_credentials& creds, const db::storage& disk);
 }} // lws // rpc

--- a/src/rpc/scanner/CMakeLists.txt
+++ b/src/rpc/scanner/CMakeLists.txt
@@ -34,4 +34,4 @@ set(monero-lws-rpc-scanner_headers
 )
 
 add_library(monero-lws-rpc-scanner ${monero-lws-rpc-scanner_sources} ${monero-lws-rpc-scanner_headers})
-target_link_libraries(monero-lws-rpc-scanner monero::libraries monero-lws-wire-msgpack)
+target_link_libraries(monero-lws-rpc-scanner monero-lws-common monero-lws-db  monero-lws-rpc monero::libraries monero-lws-wire-msgpack)

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -46,7 +46,6 @@
 #include "common/error.h"                             // monero/src
 #include "config.h"
 #include "crypto/crypto.h"                            // monero/src
-#include "crypto/wallet/crypto.h"                     // monero/src
 #include "cryptonote_basic/cryptonote_basic.h"        // monero/src
 #include "cryptonote_basic/cryptonote_format_utils.h" // monero/src
 #include "db/account.h"
@@ -274,7 +273,7 @@ namespace lws
       if (opts.max_subaddresses > 0)
         scan_transaction.enable_subaddresses(disk, opts.max_subaddresses);
       for (const auto& tx : parsed->txes)
-        scan_transaction(users, db::block_id::txpool, time, nullptr, tx, fake_outs);
+        scan_transaction(users, db::block_id::txpool, time, nullptr, tx, fake_outs, false /* not unified*/);
     }
 
     void do_scan_loop(scanner_sync& self, std::shared_ptr<thread_data> data, const size_t thread_n) noexcept
@@ -506,15 +505,17 @@ namespace lws
           if (!send(client, block_request.clone()))
             return false;
 
-          if (fetched->blocks.size() != fetched->output_indices.size())
+          if (fetched->blocks.size() != fetched->output_indices.size() && fetched->blocks.size() != fetched->unified_indices.size())
             throw std::runtime_error{"Bad daemon response - need same number of blocks and indices"};
 
           blockchain.push_back(cryptonote::get_block_hash(fetched->blocks.front().block));
           if (opts.untrusted_daemon)
             new_pow.push_back(db::pow_sync{fetched->blocks.front().block.timestamp});
 
+          const bool is_unified = !fetched->unified_indices.empty();
           auto blocks = epee::to_mut_span(fetched->blocks);
-          auto indices = epee::to_span(fetched->output_indices);
+          auto indices = is_unified ?
+            epee::to_span(fetched->unified_indices) : epee::to_span(fetched->output_indices);
 
           if (fetched->start_height != 1)
           {
@@ -557,7 +558,8 @@ namespace lws
               block.timestamp,
               nullptr,
               block.miner_tx,
-              *(indices.begin())
+              *(indices.begin()),
+              is_unified
             );
 
             if (opts.untrusted_daemon)
@@ -606,9 +608,10 @@ namespace lws
                 epee::to_mut_span(users),
                 db::block_id(fetched->start_height),
                 block.timestamp,
-                std::addressof(boost::get<0>(tx_data)), // tx_hashes
-                boost::get<1>(tx_data), // txes
-                boost::get<2>(tx_data) // indices
+                std::addressof(boost::get<0>(tx_data)),
+                boost::get<1>(tx_data),
+                boost::get<2>(tx_data),
+                is_unified
               );
             }
 

--- a/src/util/fwd.h
+++ b/src/util/fwd.h
@@ -29,6 +29,7 @@
 
 namespace lws
 {
+  struct carrot_account;
   class gamma_picker;
   struct random_output;
   struct random_ring;

--- a/src/util/ownership_test.cpp
+++ b/src/util/ownership_test.cpp
@@ -30,9 +30,13 @@
 #include <boost/optional/optional.hpp>
 #include <boost/range/combine.hpp>
 
+#include "carrot_core/device_ram_borrowed.h"          // monero/src
+#include "carrot_core/enote_utils.h"                  // monero/src
+#include "carrot_core/scan.h"                         // monero/src
+#include "carrot_impl/format_utils.h"                 // monero/src 
 #include "common/error.h"
-#include "crypto/wallet/crypto.h"
-#include "cryptonote_basic/cryptonote_format_utils.h"
+#include "crypto/wallet/crypto.h"                     // monero/src
+#include "cryptonote_basic/cryptonote_format_utils.h" // monero/src
 #include "cryptonote_basic/tx_extra.h"
 #include "db/account.h"
 #include "db/data.h"
@@ -44,6 +48,30 @@
 
 namespace lws
 {
+  namespace
+  {
+    std::optional<db::address_index> is_match(const crypto::public_key& derived_pub, const account& user, boost::optional<subaddress_reader>& subaddress, const db::block_id height)
+    {
+      if (user.spend_public() == derived_pub)
+        return db::address_index::primary(); // no need to update lookahead
+
+      if (!subaddress)
+        return std::nullopt;
+
+      const expect<db::address_index> match =
+        subaddress->find_subaddress(user, derived_pub);
+      if (!match)
+      {
+        if (match != lmdb::error(MDB_NOTFOUND))
+          MERROR("Failure when doing subaddress search: " << match.error().message());
+        return std::nullopt;
+      }
+
+      subaddress->update_lookahead(user, *match, height);
+      return *match;
+    }
+  }
+
   ownership_test::ownership_test(spend_action on_spend, output_action on_output)
     : on_spend(std::move(on_spend))
     , on_output(std::move(on_output))
@@ -65,10 +93,21 @@ namespace lws
     std::uint64_t timestamp,
     crypto::hash const* tx_hash,
     const cryptonote::transaction& tx,
-    const std::vector<std::uint64_t>& out_ids)
+    const std::vector<std::uint64_t>& out_ids,
+    const bool is_unified)
   {
     if (2 < tx.version)
       throw std::runtime_error{"Unsupported tx version"};
+
+    struct carrot_secrets
+    {
+      crypto::secret_key gout;
+      crypto::secret_key tout;
+      crypto::secret_key blinding;
+    };
+    std::optional<carrot_secrets> is_carrot;
+    if (::carrot::is_carrot_transaction_v1(tx))
+      is_carrot.emplace();
 
     crypto::hash tx_hash_lazy;
     cryptonote::tx_extra_pub_key key;
@@ -76,7 +115,7 @@ namespace lws
     boost::optional<cryptonote::tx_extra_nonce> extra_nonce;
     std::pair<std::uint8_t, db::output::payment_id_> payment_id;
     cryptonote::tx_extra_additional_pub_keys additional_tx_pub_keys;
-    std::vector<crypto::key_derivation> additional_derivations;
+    std::vector<mx25519_pubkey> additional_derivations;
 
     const auto get_tx_hash = [&] () -> const crypto::hash&
     {
@@ -91,7 +130,7 @@ namespace lws
     {
       std::vector<cryptonote::tx_extra_field> extra;
       cryptonote::parse_tx_extra(tx.extra, extra);
-      if (!cryptonote::find_tx_extra_field_by_type(extra, key))
+      if (!cryptonote::find_tx_extra_field_by_type(extra, key) && !is_carrot)
         return;
 
       extra_nonce.emplace();
@@ -103,7 +142,7 @@ namespace lws
       else
         extra_nonce = boost::none;
 
-      if (subaddress)
+      if (subaddress || is_carrot)
         cryptonote::find_tx_extra_field_by_type(extra, additional_tx_pub_keys);
     }
 
@@ -112,16 +151,36 @@ namespace lws
       if (height <= user.scan_height())
         continue;
 
-      crypto::key_derivation derived;
-      if (!crypto::wallet::generate_key_derivation(key.pub_key, user.view_key(), derived))
+      if (payment_id.first == sizeof(crypto::hash8))
+        payment_id = {};
+
+      const account::key_type account_type = user.type();
+      const crypto::secret_key& view_key = user.view_key();
+
+      mx25519_pubkey derived;
+      crypto::key_derivation ed25519_derived;
+      if (is_carrot && ::carrot::try_make_carrot_shared_key_receiver(view_key, ::carrot::raw_byte_convert<mx25519_pubkey>(key.pub_key), derived))
+      {}
+      else if (!is_carrot && crypto::wallet::generate_key_derivation(key.pub_key, view_key, ed25519_derived))
+      {
+        derived = ::carrot::raw_byte_convert<mx25519_pubkey>(ed25519_derived);
+      }
+      else // failed derivation
         continue;
 
       if (subaddress && additional_tx_pub_keys.data.size() == tx.vout.size())
+      if ((is_carrot || subaddress) && additional_tx_pub_keys.data.size() == tx.vout.size())
       {
         additional_derivations.resize(tx.vout.size());
         for (std::size_t index = 0; index < tx.vout.size(); ++index)
         {
-          if (!crypto::wallet::generate_key_derivation(additional_tx_pub_keys.data[index], user.view_key(), additional_derivations[index]))
+          if (is_carrot && ::carrot::try_make_carrot_shared_key_receiver(view_key, ::carrot::raw_byte_convert<mx25519_pubkey>(additional_tx_pub_keys.data[index]), additional_derivations[index]))
+          {}
+          else if (!is_carrot && crypto::wallet::generate_key_derivation(additional_tx_pub_keys.data[index], view_key, ed25519_derived))
+          {
+            additional_derivations[index] = ::carrot::raw_byte_convert<mx25519_pubkey>(ed25519_derived);
+          }
+          else // failed derivation
           {
             additional_derivations.clear();
             break;
@@ -131,20 +190,52 @@ namespace lws
 
       db::extra ext{};
       std::uint32_t mixin = 0;
+      std::size_t index = -1;
+      crypto::key_image first_key_image{};
+      cryptonote::txin_gen const* coinbase = nullptr;
       for (auto const& in : tx.vin)
       {
+        ++index;
+
         if (const auto in_data = boost::get<cryptonote::txin_to_key>(std::addressof(in)))
         {
           mixin = boost::numeric_cast<std::uint32_t>(std::max<std::size_t>(1, in_data->key_offsets.size()) - 1);
 
+          if (index == 0 && is_carrot)
+            first_key_image = in_data->k_image;
+
+          const auto carrot_subaccount =
+            account_type == account::key_type::balance ?
+              user.get_spendable(in_data->k_image) : std::nullopt;
+          if (carrot_subaccount)
+          {
+            // ::carrot balance-key case: output key image was observed
+            on_spend(
+              user,
+              db::spend{
+                db::transaction_link{height, get_tx_hash()},
+                in_data->k_image,
+                carrot_subaccount->first,
+                timestamp,
+                tx.unlock_time,
+                db::carrot_internal,
+                {0, 0, 0}, // reserved
+                0,
+                crypto::hash{},
+                carrot_subaccount->second
+              }
+            );
+          }
+
           std::uint64_t goffset = 0;
           for (std::uint64_t offset : in_data->key_offsets)
-          {
+          {  
             goffset += offset;
             const auto address_index = user.get_spendable(db::output_id{in_data->amount, goffset});
             if (!address_index)
               continue;
 
+            // original spend case: output listed in ring
             on_spend(
               user,
               db::spend{
@@ -162,7 +253,7 @@ namespace lws
             );
           }
         }
-        else if (boost::get<cryptonote::txin_gen>(std::addressof(in)))
+        else if ((coinbase = boost::get<cryptonote::txin_gen>(std::addressof(in))))
           ext = db::extra(ext | db::coinbase_output);
       }
 
@@ -174,16 +265,20 @@ namespace lws
 
         const auto view_tag = cryptonote::get_output_view_tag(tx.vout[index]);
         const bool matched =
-          (!additional_derivations.empty() && cryptonote::out_can_be_to_acc(view_tag, additional_derivations.at(index), index)) ||
-          cryptonote::out_can_be_to_acc(view_tag, derived, index);
+            is_carrot ||
+            (!additional_derivations.empty() && cryptonote::out_can_be_to_acc(view_tag, ::carrot::raw_byte_convert<crypto::key_derivation>(additional_derivations.at(index)), index)) ||
+            cryptonote::out_can_be_to_acc(view_tag, ::carrot::raw_byte_convert<crypto::key_derivation>(derived), index);
 
         if (!matched)
           continue;
 
-        bool found_pub = false;
-        db::address_index account_index{db::major_index::primary, db::minor_index::primary};
-        crypto::key_derivation active_derivation{};
+        std::uint64_t amount = tx.vout.at(index).amount;
+        ::carrot::CarrotEnoteType enote_type = ::carrot::CarrotEnoteType::PAYMENT;
+        std::optional<db::address_index> account_index;
+        mx25519_pubkey active_derivation{};
         crypto::public_key active_pub{};
+        rct::key mask = rct::identity();
+        ::carrot::encrypted_janus_anchor_t anchor{};
 
         for (std::size_t attempt = 0; attempt < 2; ++attempt)
         {
@@ -200,39 +295,141 @@ namespace lws
           else
             break;
 
-          crypto::public_key derived_pub;
-          if (!crypto::wallet::derive_subaddress_public_key(out_pub_key, active_derivation, index, derived_pub))
-            continue;
-
-          if (user.spend_public() != derived_pub)
+          crypto::public_key derived_pub{};
+          cryptonote::txout_to_carrot_v1 const* const carrot_info =
+            boost::get<cryptonote::txout_to_carrot_v1>(std::addressof(tx.vout.at(index).target));
+          if (is_carrot && carrot_info)
           {
-            if (!subaddress)
-              continue;
+            payment_id = {};
+            mixin = db::carrot_external;
+            anchor = carrot_info->encrypted_janus_anchor;
 
-            const expect<db::address_index> match = subaddress->find_subaddress(user, derived_pub);
-            if (!match)
+            if (coinbase)
             {
-              if (match != lmdb::error(MDB_NOTFOUND))
-                MERROR("Failure when doing subaddress search: " << match.error().message());
-              continue;
+              if (::carrot::try_scan_carrot_coinbase_enote_receiver(
+                ::carrot::CarrotCoinbaseEnoteV1{
+                  out_pub_key,
+                  tx.vout.at(index).amount,
+                  anchor,
+                  carrot_info->view_tag,
+                  ::carrot::raw_byte_convert<mx25519_pubkey>(active_pub),
+                  coinbase->height
+                },
+                active_derivation,
+                {std::addressof(user.spend_public()), 1},
+                is_carrot->gout,
+                is_carrot->tout,
+                derived_pub
+              ))
+              { account_index = is_match(derived_pub, user, subaddress, height); }
             }
+            else if (index < tx.rct_signatures.outPk.size())
+            {
+              crypto::hash8 temp{};
+              ::carrot::payment_id_t decrypted_id{};
+              ::carrot::janus_anchor_t janus;
+              std::optional<::carrot::encrypted_payment_id_t> cpayment_id;
 
-            auto result = subaddress->update_lookahead(user, *match, height);
-            if (!result)
-              MWARNING("Failed to update lookahead for " << user.address() << ": " << result.error());
-            found_pub = true;
-            account_index = *match;
-            break;
+              ::carrot::CarrotEnoteV1 enote{
+                out_pub_key,
+                ::carrot::raw_byte_convert<::carrot::amount_commitment_t>(tx.rct_signatures.outPk.at(index).mask),
+                ::carrot::encrypted_amount_t{},
+                anchor,
+                carrot_info->view_tag,
+                ::carrot::raw_byte_convert<mx25519_pubkey>(active_pub),
+                first_key_image
+              };
+
+              static_assert(sizeof(enote.amount_enc) <= sizeof(tx.rct_signatures.ecdhInfo.at(index).amount));
+              if (index < tx.rct_signatures.ecdhInfo.size())
+                std::memcpy(std::addressof(enote.amount_enc), std::addressof(tx.rct_signatures.ecdhInfo.at(index).amount), sizeof(enote.amount_enc));
+
+              if (extra_nonce && cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce->nonce, temp))
+                cpayment_id = ::carrot::raw_byte_convert<::carrot::encrypted_payment_id_t>(temp);
+
+              const ::carrot::view_incoming_key_ram_borrowed_device incoming_device{view_key};
+              const ::carrot::view_balance_secret_ram_borrowed_device balance_device{user.balance_key()};
+
+              if (::carrot::try_scan_carrot_enote_external_receiver(
+                enote,
+                cpayment_id,
+                active_derivation,
+                {std::addressof(user.spend_public()), 1},
+                incoming_device,
+                is_carrot->gout,
+                is_carrot->tout,
+                derived_pub,
+                amount,
+                is_carrot->blinding,
+                decrypted_id,
+                enote_type
+                ) && (account_index = is_match(derived_pub, user, subaddress, height)))
+              {
+                payment_id.first = sizeof(crypto::hash8);
+                payment_id.second.short_ = ::carrot::raw_byte_convert<crypto::hash8>(decrypted_id);
+              }
+              else if (account_type == account::key_type::balance && ::carrot::try_scan_carrot_enote_internal_receiver(
+                enote,
+                balance_device,
+                is_carrot->gout,
+                is_carrot->tout,
+                derived_pub,
+                amount,
+                is_carrot->blinding,
+                enote_type,
+                janus
+                ) && (account_index = is_match(derived_pub, user, subaddress, height)))
+              {
+                mixin = db::carrot_internal;
+              }
+              else
+                continue; // to next available active_derivation
+                mask = ::carrot::raw_byte_convert<rct::key>(tools::unwrap(is_carrot->blinding));
+            }
+            else
+            {
+              MWARNING("Invalid tx format detected: " << tx_hash);
+              continue; // to next active_derivation
+            }
           }
-          else
+          else // !is_carrot
           {
-            found_pub = true;
-            break;
+            if (crypto::wallet::derive_subaddress_public_key(out_pub_key, ::carrot::raw_byte_convert<crypto::key_derivation>(active_derivation), index, derived_pub))
+              account_index = is_match(derived_pub, user, subaddress, height);
           }
         }
 
-        if (!found_pub)
+        // check for `!is_carrot` or `is_carrot && coinbase`
+        if (!account_index)
           continue;
+
+        if (enote_type == ::carrot::CarrotEnoteType::CHANGE && account_type != account::key_type::balance)
+        {
+          // Detected spend via ::carrot protocol (change received)
+          for (auto const& in : tx.vin)
+          {
+            cryptonote::txin_to_key const* const in_data =
+              boost::get<cryptonote::txin_to_key>(std::addressof(in));
+            if (in_data && in_data->key_offsets.empty())
+            {
+              on_spend(
+                user,
+                db::spend{
+                  db::transaction_link{height, get_tx_hash()},
+                  in_data->k_image,
+                  db::output_id::unknown_spend(), // no clue which output was spent
+                  timestamp,
+                  tx.unlock_time,
+                  db::carrot_external,
+                  {0, 0, 0}, // reserved
+                  0,
+                  crypto::hash{},
+                  db::address_index{account_index->maj_i, db::minor_index::primary}, // best guess
+                }
+              );
+            }
+          }
+        }
 
         if (!prefix_hash)
         {
@@ -240,15 +437,13 @@ namespace lws
           cryptonote::get_transaction_prefix_hash(tx, *prefix_hash);
         }
 
-        std::uint64_t amount = tx.vout[index].amount;
-        rct::key mask = rct::identity();
-        if (!amount && !(ext & db::coinbase_output) && 1 < tx.version)
+        if (!amount && !is_carrot && !(ext & db::coinbase_output) && 1 < tx.version)
         {
           const bool bulletproof2 = (rct::RCTTypeBulletproof2 <= tx.rct_signatures.type);
           const auto decrypted = lws::decode_amount(
             tx.rct_signatures.outPk.at(index).mask,
             tx.rct_signatures.ecdhInfo.at(index),
-            active_derivation,
+            ::carrot::raw_byte_convert<crypto::key_derivation>(active_derivation),
             index,
             bulletproof2
           );
@@ -264,18 +459,19 @@ namespace lws
         else if (1 < tx.version)
           ext = db::extra(ext | db::ringct_output);
 
-        if (extra_nonce && !payment_id.first && cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce->nonce, payment_id.second.short_))
+        if (!is_carrot && extra_nonce && !payment_id.first && cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce->nonce, payment_id.second.short_))
         {
           payment_id.first = sizeof(crypto::hash8);
-          lws::decrypt_payment_id(payment_id.second.short_, active_derivation);
+          lws::decrypt_payment_id(payment_id.second.short_, ::carrot::raw_byte_convert<crypto::key_derivation>(active_derivation));
         }
 
+        const std::uint64_t id = out_ids.at(index);
         on_output(
           user,
           db::output{
             db::transaction_link{height, get_tx_hash()},
             db::output::spend_meta_{
-              db::output_id{tx.version < 2 ? tx.vout[index].amount : 0, out_ids.at(index)},
+              is_unified ? db::output_id::unified(id) : db::output_id{tx.version < 2 ? tx.vout[index].amount : 0, id},
               amount,
               mixin,
               boost::numeric_cast<std::uint32_t>(index),
@@ -290,7 +486,9 @@ namespace lws
             db::pack(ext, payment_id.first),
             payment_id.second,
             cryptonote::get_tx_fee(tx),
-            account_index
+            *account_index,
+            first_key_image,
+            anchor
           }
         );
       }

--- a/src/util/ownership_test.h
+++ b/src/util/ownership_test.h
@@ -79,7 +79,8 @@ namespace lws
       std::uint64_t timestamp,
       crypto::hash const* tx_hash,
       const cryptonote::transaction& tx,
-      const std::vector<std::uint64_t>& out_ids
+      const std::vector<std::uint64_t>& out_ids,
+      bool unified
     );
 
     void enable_subaddresses(const db::storage& disk, const std::uint32_t max_subaddresses);

--- a/src/util/transactions.cpp
+++ b/src/util/transactions.cpp
@@ -27,10 +27,12 @@
 
 #include "transactions.h"
 
-#include "cryptonote_config.h"
-#include "crypto/crypto.h"
-#include "crypto/hash.h"
-#include "ringct/rctOps.h"
+#include "cryptonote_config.h"            // monero/src
+#include "crypto/crypto.h"                // monero/src
+#include "crypto/hash.h"                  // monero/src
+#include "db/data.h"
+#include "misc_log_ex.h"                  // monero/contrib/include
+#include "ringct/rctOps.h"                // monero/src
 
 void lws::decrypt_payment_id(crypto::hash8& out, const crypto::key_derivation& key)
 {
@@ -45,7 +47,7 @@ void lws::decrypt_payment_id(crypto::hash8& out, const crypto::key_derivation& k
     out.data[b] ^= hash.data[b];
 }
 
-boost::optional<std::pair<std::uint64_t, rct::key>> lws::decode_amount(const rct::key& commitment, const rct::ecdhTuple& info, const crypto::key_derivation& sk, std::size_t index, const bool bulletproof2)
+std::optional<std::pair<std::uint64_t, rct::key>> lws::decode_amount(const rct::key& commitment, const rct::ecdhTuple& info, const crypto::key_derivation& sk, std::size_t index, const bool bulletproof2)
 {
   crypto::secret_key scalar{};
   crypto::derivation_to_scalar(sk, index, scalar);
@@ -60,6 +62,8 @@ boost::optional<std::pair<std::uint64_t, rct::key>> lws::decode_amount(const rct
     rct::xmr_amount out = 0;
     if (rct::h2d(out, copy.amount))
       return {{out, copy.mask}};
+    //return {{rct::h2d(copy.amount), copy.mask}};
   }
-  return boost::none;
+  return std::nullopt;
 }
+

--- a/src/util/transactions.h
+++ b/src/util/transactions.h
@@ -25,21 +25,16 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include <boost/optional/optional.hpp>
 #include <cstdint>
+#include <optional>
 #include <utility>
 
-#include "common/pod-class.h"
-#include "ringct/rctTypes.h"
-
-namespace crypto
-{
-  POD_CLASS hash8;
-  POD_CLASS key_derivation;
-}
+#include "common/pod-class.h" // monero/src
+#include "crypto/crypto.h"    // monero/src
+#include "ringct/rctTypes.h"  // moneor/src 
 
 namespace lws
 {
   void decrypt_payment_id(crypto::hash8& out, const crypto::key_derivation& key);
-  boost::optional<std::pair<std::uint64_t, rct::key>> decode_amount(const rct::key& commitment, const rct::ecdhTuple& info, const crypto::key_derivation& sk, std::size_t index, const bool bulletproof2);
+  std::optional<std::pair<std::uint64_t, rct::key>> decode_amount(const rct::key& commitment, const rct::ecdhTuple& info, const crypto::key_derivation& sk, std::size_t index, const bool bulletproof2);
 }

--- a/src/wire/adapted/carrot.h
+++ b/src/wire/adapted/carrot.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, The Monero Project
+// Copyright (c) 2025, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are
@@ -27,20 +27,13 @@
 
 #pragma once
 
-#include <boost/filesystem/path.hpp>
-#include "crypto/crypto.h" // monero/src/
-#include "db/account.h"
-#include "db/data.h"
-#include "db/storage.h"
+#include <type_traits>
 
-namespace lws { namespace db { namespace test
+#include "carrot_core/core_types.h" // monero/src
+#include "wire/traits.h"
+
+namespace wire
 {
-  struct cleanup_db
-  {
-    ~cleanup_db();
-  };
-
-  lws::db::storage get_fresh_db();
-  lws::db::account make_db_account(const lws::db::account_pubs& pubs, const crypto::secret_key& key);
-  lws::account make_account(const lws::db::account_pubs& pubs, const crypto::secret_key& key);
-}}} // lws // db // test
+  WIRE_DECLARE_BLOB(carrot::encrypted_janus_anchor_t);
+  WIRE_DECLARE_BLOB(carrot::view_tag_t);
+}

--- a/src/wire/adapted/crypto.h
+++ b/src/wire/adapted/crypto.h
@@ -52,6 +52,7 @@ namespace crypto
 namespace wire
 {
   WIRE_DECLARE_BLOB(crypto::ec_scalar);
+  WIRE_DECLARE_BLOB(crypto::ec_point);
   WIRE_DECLARE_BLOB(crypto::hash);
   WIRE_DECLARE_BLOB(crypto::hash8);
   WIRE_DECLARE_BLOB(crypto::key_derivation);

--- a/src/wire/adapted/tuple.h
+++ b/src/wire/adapted/tuple.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023, The Monero Project
+// Copyright (c) 2025, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are
@@ -27,20 +27,31 @@
 
 #pragma once
 
-#include <boost/filesystem/path.hpp>
-#include "crypto/crypto.h" // monero/src/
-#include "db/account.h"
-#include "db/data.h"
-#include "db/storage.h"
+#include <array>
+#include <tuple>
+#include <utility>
 
-namespace lws { namespace db { namespace test
+#include "wire/field.h"
+#include "wire/read.h"
+#include "wire/write.h"
+
+namespace wire
 {
-  struct cleanup_db
+  template<typename F, typename T, std::size_t... I>
+  void map_tuple(F& format, T& self, std::index_sequence<I...>)
   {
-    ~cleanup_db();
-  };
+    const std::array<std::string, sizeof...(I)> names = {
+      std::to_string(I)...
+    };
+    wire::object(format, wire::field<I>(std::get<I>(names).c_str(), std::get<I>(self))...);
+  }
 
-  lws::db::storage get_fresh_db();
-  lws::db::account make_db_account(const lws::db::account_pubs& pubs, const crypto::secret_key& key);
-  lws::account make_account(const lws::db::account_pubs& pubs, const crypto::secret_key& key);
-}}} // lws // db // test
+  template<typename R, typename... T>
+  void read_bytes(R& source, std::tuple<T...>& dest)
+  { map_tuple(source, dest, std::index_sequence_for<T...>()); }
+
+  template<typename W, typename... T>
+  void write_bytes(W& dest, const std::tuple<T...>& source)
+  { map_tuple(dest, source, std::index_sequence_for<T...>()); }
+}
+

--- a/src/wire/read.h
+++ b/src/wire/read.h
@@ -443,6 +443,13 @@ namespace wire_read
     expand_tracker_map(head.set_mapping(index, map), map, tail...);
   }
 
+  template<typename R>
+  inline void object(R& source)
+  {
+    source.start_object();
+    source.end_object();
+  }
+
   template<typename R, typename... T>
   inline void object(R& source, tracker<T>... fields)
   {

--- a/src/wire/wrapper/CMakeLists.txt
+++ b/src/wire/wrapper/CMakeLists.txt
@@ -31,5 +31,5 @@ set(monero-lws-wire_headers variant.h)
 
 add_library(monero-lws-wire-wrapper ${monero-lws-wire_sources} ${monero-lws-wire_headers})
 target_include_directories(monero-lws-wire-wrapper PUBLIC "${LMDB_INCLUDE}")
-target_link_libraries(monero-lws-wire-wrapper PRIVATE monero::libraries)
+target_link_libraries(monero-lws-wire-wrapper PRIVATE monero-lws-wire monero::libraries)
 

--- a/src/wire/wrapper/variant.h
+++ b/src/wire/wrapper/variant.h
@@ -31,6 +31,7 @@
 #include <boost/variant/variant_fwd.hpp>
 #include <functional>
 #include <utility>
+#include <variant>
 
 #include "wire/error.h"
 #include "wire/fwd.h"
@@ -114,6 +115,10 @@ namespace wire
     // other variant overloads can be added here as needed
 
     template<typename U, typename... T>
+    inline const U* get_if(const std::variant<T...>& value)
+    { return std::get_if<U>(std::addressof(value)); }
+
+    template<typename U, typename... T>
     inline const U* get_if(const boost::variant<T...>& value)
     { return boost::get<U>(std::addressof(value)); }
 
@@ -177,6 +182,14 @@ namespace wire
   namespace adapt
   {
     // other variant overloads can be added here as needed
+
+    template<typename U, typename... T>
+    inline U& get(std::variant<T...>& value)
+    { return std::get<U>(value); }
+
+    template<typename U, typename... T>
+    inline const U& get(const std::variant<T...>& value)
+    { return std::get<U>(value); }
 
     template<typename U, typename... T>
     inline U& get(boost::variant<T...>& value)

--- a/tests/unit/db/account.test.cpp
+++ b/tests/unit/db/account.test.cpp
@@ -41,7 +41,7 @@ LWS_CASE("lws::account serialization")
   lws::db::account db_account{
     lws::db::account_id(44),
     lws::db::account_time(500000),
-    lws::db::account_address{
+    lws::db::account_pubs{
       keys.m_account_address.m_view_public_key,
       keys.m_account_address.m_spend_public_key
     },
@@ -64,7 +64,7 @@ LWS_CASE("lws::account serialization")
   };
   const std::vector<crypto::public_key> pubs{crypto::rand<crypto::public_key>()};
 
-  lws::account account{db_account, spendable, pubs};
+  lws::account account{db_account, spendable, {}, pubs};
   EXPECT(account);
 
   const lws::db::transaction_link link{
@@ -119,8 +119,8 @@ LWS_CASE("lws::account serialization")
 
   const std::string account_address = account.address();
   EXPECT(account.id() == db_account.id);
-  EXPECT(account.view_public() == db_account.address.view_public);
-  EXPECT(account.spend_public() == db_account.address.spend_public);
+  EXPECT(account.view_public() == db_account.pubs.view_public);
+  EXPECT(account.spend_public() == db_account.pubs.flex_public);
   EXPECT(account.view_key() == keys.m_view_secret_key);
   EXPECT(account.scan_height() == db_account.scan_height);
   {
@@ -175,8 +175,8 @@ LWS_CASE("lws::account serialization")
   EXPECT(copy);
   EXPECT(copy.address() == account_address);
   EXPECT(copy.id() == db_account.id);
-  EXPECT(copy.view_public() == db_account.address.view_public);
-  EXPECT(copy.spend_public() == db_account.address.spend_public);
+  EXPECT(copy.view_public() == db_account.pubs.view_public);
+  EXPECT(copy.spend_public() == db_account.pubs.flex_public);
   EXPECT(copy.view_key() == keys.m_view_secret_key);
   EXPECT(copy.scan_height() == db_account.scan_height);
   {

--- a/tests/unit/db/chain.test.cpp
+++ b/tests/unit/db/chain.test.cpp
@@ -94,7 +94,7 @@ LWS_CASE("db::storage::sync_chain")
     EXPECT(db.sync_chain(last_block.id, chain, false));
 
     {
-      const lws::account accounts[1] = {lws::account{get_account(), {}, {}}};
+      const lws::account accounts[1] = {lws::account{get_account(), {}, {}, {}}};
       EXPECT(accounts[0].scan_height() == last_block.id);
       const auto updated = db.update(last_block.id, chain, accounts, nullptr);
       EXPECT(updated);
@@ -158,7 +158,7 @@ LWS_CASE("db::storage::sync_chain")
 
     SECTION("Old Blocks dont rollback height")
     {
-      lws::account accounts[1] {lws::account{get_account(), {}, {}}};
+      lws::account accounts[1] {lws::account{get_account(), {}, {}, {}}};
       const auto old_block = lws::db::block_id(lmdb::to_native(last_block.id) - 5);
       const auto new_block = lws::db::block_id(lmdb::to_native(last_block.id) + 4);
       EXPECT(accounts[0].scan_height() == new_block);

--- a/tests/unit/db/storage.test.cpp
+++ b/tests/unit/db/storage.test.cpp
@@ -57,7 +57,7 @@ namespace lws { namespace db { namespace test
     return storage::open(location.c_str(), 5);
   }
 
-  db::account make_db_account(const account_address& pubs, const crypto::secret_key& key)
+  db::account make_db_account(const account_pubs& pubs, const crypto::secret_key& key)
   {
     view_key converted_key{};
     std::memcpy(std::addressof(converted_key), std::addressof(unwrap(unwrap(key))), sizeof(key));
@@ -66,9 +66,9 @@ namespace lws { namespace db { namespace test
     };
   }
 
-  lws::account make_account(const account_address& pubs, const crypto::secret_key& key)
+  lws::account make_account(const account_pubs& pubs, const crypto::secret_key& key)
   {
-    return lws::account{make_db_account(pubs, key), {}, {}};
+    return lws::account{make_db_account(pubs, key), {}, {}, {}};
   }
 }}} // lws // db // test
 
@@ -150,7 +150,7 @@ LWS_CASE("lws::db::storage")
       const auto payment_id_ = crypto::rand<lws::db::output::payment_id_>();
       const crypto::key_image image = crypto::rand<crypto::key_image>();
 
-      lws::account real_account{account, {}, {}};
+      lws::account real_account{account, {}, {}, {}};
       real_account.add_out(
         lws::db::output{
           link,

--- a/tests/unit/db/subaddress.test.cpp
+++ b/tests/unit/db/subaddress.test.cpp
@@ -30,7 +30,9 @@
 #include <boost/range/counting_range.hpp>
 #include <boost/uuid/random_generator.hpp>
 #include <cstdint>
+#include "carrot_core/account_secrets.h"
 #include "crypto/crypto.h" // monero/src
+#include "db/carrot.h"
 #include "db/data.h"
 #include "db/storage.h"
 #include "db/storage.test.h"
@@ -49,22 +51,49 @@ namespace
     {}
   };
 
+  struct carrot_account
+  {
+    lws::carrot::account account;
+    crypto::secret_key generate_address;
+
+    carrot_account()
+      : account{}, generate_address{}
+    {}
+  };
+
   void check_address_map(lest::env& lest_env, lws::db::storage_reader& reader, const user_account& user, const std::vector<lws::db::subaddress_dict>& source)
   {
-    SETUP("check_address_map")
+    const lest::ctx ctx{lest_env, "check_address_map"};
+    lws::db::cursor::subaddress_indexes cur = nullptr;
+    for (const auto& major_entry : source)
     {
-      lws::db::cursor::subaddress_indexes cur = nullptr;
-      for (const auto& major_entry : source)
+      for (const auto& minor_entry : major_entry.second.get_container())
       {
-        for (const auto& minor_entry : major_entry.second.get_container())
+        for (std::uint64_t elem : boost::counting_range(std::uint64_t(minor_entry[0]), std::uint64_t(minor_entry[1]) + 1))
         {
-          for (std::uint64_t elem : boost::counting_range(std::uint64_t(minor_entry[0]), std::uint64_t(minor_entry[1]) + 1))
-          {
-            const lws::db::address_index index{major_entry.first, lws::db::minor_index(elem)};
-            auto result = reader.find_subaddress(lws::db::account_id(1), index.get_spend_public(user.account, user.view), cur);
-            EXPECT(result.has_value());
-            EXPECT(result == index);
-          }
+          const lws::db::address_index index{major_entry.first, lws::db::minor_index(elem)};
+          auto result = reader.find_subaddress(lws::db::account_id(1), index.get_spend_public(user.account, user.view), cur);
+          EXPECT(result.has_value());
+          EXPECT(result == index);
+        }
+      }
+    }
+  }
+
+  void check_address_map(lest::env& lest_env, lws::db::storage_reader& reader, const carrot_account& user, const std::vector<lws::db::subaddress_dict>& source)
+  {
+    const lest::ctx ctx{lest_env, "check_address_map"};
+    lws::db::cursor::subaddress_indexes cur = nullptr;
+    for (const auto& major_entry : source)
+    {
+      for (const auto& minor_entry : major_entry.second.get_container())
+      {
+        for (std::uint64_t elem : boost::counting_range(std::uint64_t(minor_entry[0]), std::uint64_t(minor_entry[1]) + 1))
+        {
+          const lws::db::address_index index{major_entry.first, lws::db::minor_index(elem)};
+          auto result = reader.find_subaddress(lws::db::account_id(1), index.get_spend_public(user.account, user.generate_address), cur);
+          EXPECT(result.has_value());
+          EXPECT(result == index);
         }
       }
     }
@@ -98,7 +127,7 @@ LWS_CASE("db::storage::upsert_subaddresses")
         lws::db::major_index(0),
         lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}}
       );
-      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 100);
       {
         lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
 
@@ -112,7 +141,7 @@ LWS_CASE("db::storage::upsert_subaddresses")
         check_address_map(lest_env, reader, user, subs);
       }
       subs.back().first = lws::db::major_index(1);
-      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 199);
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 199);
       EXPECT(result.has_error());
       EXPECT(result == lws::error::max_subaddresses);
 
@@ -133,7 +162,7 @@ LWS_CASE("db::storage::upsert_subaddresses")
         lws::db::major_index(0),
         lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}}
       );
-      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 100);
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
@@ -148,7 +177,7 @@ LWS_CASE("db::storage::upsert_subaddresses")
 
       subs.back().second =
         lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}};
-      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 200);
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 200);
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
@@ -163,7 +192,7 @@ LWS_CASE("db::storage::upsert_subaddresses")
 
       subs.back().second =
         lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(201), lws::db::minor_index(201)}}};
-      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 200);
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 200);
       EXPECT(result.has_error());
       EXPECT(result == lws::error::max_subaddresses);
 
@@ -184,7 +213,7 @@ LWS_CASE("db::storage::upsert_subaddresses")
         lws::db::major_index(0),
         lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}}
       );
-      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 100);
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
@@ -200,11 +229,11 @@ LWS_CASE("db::storage::upsert_subaddresses")
       subs.back().second =
         lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}};
 
-      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 199);
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 199);
       EXPECT(result.has_error());
       EXPECT(result == lws::error::max_subaddresses);
 
-      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 200);
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 200);
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
@@ -231,7 +260,7 @@ LWS_CASE("db::storage::upsert_subaddresses")
         lws::db::major_index(0),
         lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}}
       );
-      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 100);
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
@@ -246,12 +275,12 @@ LWS_CASE("db::storage::upsert_subaddresses")
 
       subs.back().second =
         lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(300)}}};
-      
-      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 299);
+
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 299);
       EXPECT(result.has_error());
       EXPECT(result == lws::error::max_subaddresses);
 
-      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 300);
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 300);
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
@@ -279,7 +308,7 @@ LWS_CASE("db::storage::upsert_subaddresses")
         lws::db::major_index(0),
         lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}}
       );
-      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 100);
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
@@ -294,11 +323,11 @@ LWS_CASE("db::storage::upsert_subaddresses")
 
       subs.back().second =
         lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(102), lws::db::minor_index(200)}}};
-      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 198);
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 198);
       EXPECT(result.has_error());
       EXPECT(result == lws::error::max_subaddresses);
 
-      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 199);
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 199);
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
@@ -326,7 +355,7 @@ LWS_CASE("db::storage::upsert_subaddresses")
         lws::db::major_index(0),
         lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}}
       );
-      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 100);
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
@@ -341,11 +370,11 @@ LWS_CASE("db::storage::upsert_subaddresses")
 
       subs.back().second =
         lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(99)}}};
-      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 198);
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 198);
       EXPECT(result.has_error());
       EXPECT(result == lws::error::max_subaddresses);
 
-      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 199);
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 199);
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
@@ -373,7 +402,7 @@ LWS_CASE("db::storage::upsert_subaddresses")
         lws::db::major_index(0),
         lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(200)}}}
       );
-      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 200);
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 200);
       EXPECT(result.has_value());
       EXPECT(result->size() == 1);
       EXPECT(result->at(0).first == lws::db::major_index(0));
@@ -388,7 +417,7 @@ LWS_CASE("db::storage::upsert_subaddresses")
 
       subs.back().second =
         lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(5), lws::db::minor_index(99)}}};
-      result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 300);
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 300);
       EXPECT(result.has_value());
       EXPECT(result->size() == 0);
 
@@ -414,7 +443,749 @@ LWS_CASE("db::storage::upsert_subaddresses")
       subs.back().second.get_container().push_back(
         lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}
       );
-      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.account, user.view, subs, 100);
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 100);
+      EXPECT(result.has_error());
+      EXPECT(result == wire::error::schema::array);
+    }
+  }
+}
+
+LWS_CASE("db::storage::upsert_subaddresses incoming-only carrot")
+{
+  carrot_account user{};
+  lws::db::account details{};
+  crypto::secret_key incoming{};
+  {
+    crypto::secret_key master{};
+    crypto::secret_key prove{};
+    crypto::secret_key balance{};
+    crypto::secret_key preimage{};
+    crypto::secret_key image{};
+
+    crypto::generate_keys(details.pubs.flex_public, master);
+    ::carrot::make_carrot_provespend_key(master, prove);
+    ::carrot::make_carrot_viewbalance_secret(master, balance);
+    ::carrot::make_carrot_partial_spend_pubkey(prove, details.pubs.flex_public);
+    ::carrot::make_carrot_generateimage_preimage(balance, preimage);
+    ::carrot::make_carrot_generateimage_key(preimage, details.pubs.flex_public, image);
+    ::carrot::make_carrot_spend_pubkey(image, prove, details.pubs.flex_public);
+    ::carrot::make_carrot_viewincoming_key(balance, incoming);
+    ::carrot::make_carrot_generateaddress_secret(balance, user.generate_address);
+    EXPECT(crypto::secret_key_to_public_key(incoming, details.pubs.view_public));
+    std::memcpy(std::addressof(details.key), std::addressof(unwrap(unwrap(incoming))), sizeof(details.key));
+
+    user.account = lws::carrot::account{details};
+  }
+
+  SETUP("One Account DB")
+  {
+    lws::db::test::cleanup_db on_scope_exit{};
+    lws::db::storage db = lws::db::test::get_fresh_db();
+    const lws::db::block_info last_block =
+      MONERO_UNWRAP(MONERO_UNWRAP(db.start_read()).get_last_block());
+    MONERO_UNWRAP(db.add_account(lws::db::account_address{details}, incoming));
+
+    SECTION("Empty get_subaddresses")
+    {
+      lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
+      EXPECT(MONERO_UNWRAP(reader.get_subaddresses(lws::db::account_id(1))).empty());
+    }
+
+    SECTION("Upsert Basic")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 100);
+      {
+        lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
+
+        EXPECT(result.has_value());
+        EXPECT(result->size() == 1);
+        EXPECT(result->at(0).first == lws::db::major_index(0));
+        EXPECT(result->at(0).second.get_container().size() == 1);
+        EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+        EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
+
+        check_address_map(lest_env, reader, user, subs);
+      }
+      subs.back().first = lws::db::major_index(1);
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 199);
+      EXPECT(result.has_error());
+      EXPECT(result == lws::error::max_subaddresses);
+
+      lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.get_container().size() == 1);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
+    }
+
+    SECTION("Upsert Appended")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 100);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}};
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 200);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(101));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(201), lws::db::minor_index(201)}}};
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 200);
+      EXPECT(result.has_error());
+      EXPECT(result == lws::error::max_subaddresses);
+
+      auto reader = MONERO_UNWRAP(db.start_read());
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.get_container().size() == 1);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
+    }
+
+    SECTION("Upsert Prepended")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 100);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(101));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}};
+
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 199);
+      EXPECT(result.has_error());
+      EXPECT(result == lws::error::max_subaddresses);
+
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 200);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
+
+      lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
+      check_address_map(lest_env, reader, user, subs);
+
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.get_container().size() == 1);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
+    }
+
+    SECTION("Upsert Wrapped")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 100);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(101));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(300)}}};
+
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 299);
+      EXPECT(result.has_error());
+      EXPECT(result == lws::error::max_subaddresses);
+
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 300);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 2);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
+      EXPECT(result->at(0).second.get_container()[1][0] == lws::db::minor_index(201));
+      EXPECT(result->at(0).second.get_container()[1][1] == lws::db::minor_index(300));
+
+      lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
+      check_address_map(lest_env, reader, user, subs);
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.get_container().size() == 1);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(300));
+    }
+
+    SECTION("Upsert After")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 100);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(102), lws::db::minor_index(200)}}};
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 198);
+      EXPECT(result.has_error());
+      EXPECT(result == lws::error::max_subaddresses);
+
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 199);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(102));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
+
+      auto reader = MONERO_UNWRAP(db.start_read());
+      check_address_map(lest_env, reader, user, subs);
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.get_container().size() == 2);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
+      EXPECT(fetched->at(0).second.get_container()[1][0] == lws::db::minor_index(102));
+      EXPECT(fetched->at(0).second.get_container()[1][1] == lws::db::minor_index(200));
+    }
+
+    SECTION("Upsert Before")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 100);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(101));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(99)}}};
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 198);
+      EXPECT(result.has_error());
+      EXPECT(result == lws::error::max_subaddresses);
+
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 199);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(99));
+
+      auto reader = MONERO_UNWRAP(db.start_read());
+      check_address_map(lest_env, reader, user, subs);
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.get_container().size() == 2);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(99));
+      EXPECT(fetched->at(0).second.get_container()[1][0] == lws::db::minor_index(101));
+      EXPECT(fetched->at(0).second.get_container()[1][1] == lws::db::minor_index(200));
+    }
+
+    SECTION("Upsert Encapsulated")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(200)}}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 200);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(5), lws::db::minor_index(99)}}};
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 300);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 0);
+
+      auto reader = MONERO_UNWRAP(db.start_read());
+      check_address_map(lest_env, reader, user, subs);
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.get_container().size() == 1);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
+    }
+
+
+    SECTION("Bad subaddress_dict")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}}
+      );
+      subs.back().second.get_container().push_back(
+        lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 100);
+      EXPECT(result.has_error());
+      EXPECT(result == wire::error::schema::array);
+    }
+  }
+}
+
+LWS_CASE("db::storage::upsert_subaddresses balance-key carrot")
+{
+  carrot_account user{};
+  lws::db::account details{};
+  crypto::secret_key balance{};
+  {
+    crypto::secret_key master{};
+    crypto::secret_key prove{};
+    crypto::secret_key incoming{};
+    crypto::secret_key preimage{};
+    crypto::secret_key image{};
+
+    crypto::generate_keys(details.pubs.flex_public, master);
+    ::carrot::make_carrot_provespend_key(master, prove);
+    ::carrot::make_carrot_viewbalance_secret(master, balance);
+    ::carrot::make_carrot_partial_spend_pubkey(prove, details.pubs.flex_public);
+    ::carrot::make_carrot_generateimage_preimage(balance, preimage);
+    ::carrot::make_carrot_generateimage_key(preimage, details.pubs.flex_public, image);
+    ::carrot::make_carrot_viewincoming_key(balance, incoming);
+    ::carrot::make_carrot_generateaddress_secret(balance, user.generate_address);
+    EXPECT(crypto::secret_key_to_public_key(incoming, details.pubs.view_public));
+    std::memcpy(std::addressof(details.key), std::addressof(unwrap(unwrap(balance))), sizeof(details.key));
+
+    details.flags = lws::db::account_flags::view_balance_key;
+    user.account = lws::carrot::account{details};
+  }
+
+  SETUP("One Account DB")
+  {
+    lws::db::test::cleanup_db on_scope_exit{};
+    lws::db::storage db = lws::db::test::get_fresh_db();
+    const lws::db::block_info last_block =
+      MONERO_UNWRAP(MONERO_UNWRAP(db.start_read()).get_last_block());
+    MONERO_UNWRAP(db.add_account(details.pubs, balance, lws::db::account_flags::view_balance_key));
+
+    SECTION("Empty get_subaddresses")
+    {
+      lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
+      EXPECT(MONERO_UNWRAP(reader.get_subaddresses(lws::db::account_id(1))).empty());
+    }
+
+    SECTION("Upsert Basic")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 100);
+      {
+        lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
+
+        EXPECT(result.has_value());
+        EXPECT(result->size() == 1);
+        EXPECT(result->at(0).first == lws::db::major_index(0));
+        EXPECT(result->at(0).second.get_container().size() == 1);
+        EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+        EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
+
+        check_address_map(lest_env, reader, user, subs);
+      }
+      subs.back().first = lws::db::major_index(1);
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 199);
+      EXPECT(result.has_error());
+      EXPECT(result == lws::error::max_subaddresses);
+
+      lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.get_container().size() == 1);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
+    }
+
+    SECTION("Upsert Appended")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 100);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}};
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 200);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(101));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(201), lws::db::minor_index(201)}}};
+      result = db.upsert_subaddresses(lws::db::account_id(1), user.generate_address, subs, 200);
+      EXPECT(result.has_error());
+      EXPECT(result == lws::error::max_subaddresses);
+
+      auto reader = MONERO_UNWRAP(db.start_read());
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.get_container().size() == 1);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
+    }
+
+    SECTION("Upsert Prepended")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 100);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(101));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}};
+
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 199);
+      EXPECT(result.has_error());
+      EXPECT(result == lws::error::max_subaddresses);
+
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 200);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
+
+      lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
+      check_address_map(lest_env, reader, user, subs);
+
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.get_container().size() == 1);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
+    }
+
+    SECTION("Upsert Wrapped")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 100);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(101));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(300)}}};
+      
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 299);
+      EXPECT(result.has_error());
+      EXPECT(result == lws::error::max_subaddresses);
+
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 300);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 2);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
+      EXPECT(result->at(0).second.get_container()[1][0] == lws::db::minor_index(201));
+      EXPECT(result->at(0).second.get_container()[1][1] == lws::db::minor_index(300));
+
+      lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
+      check_address_map(lest_env, reader, user, subs);
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.get_container().size() == 1);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(300));
+    }
+
+    SECTION("Upsert After")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 100);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(102), lws::db::minor_index(200)}}};
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 198);
+      EXPECT(result.has_error());
+      EXPECT(result == lws::error::max_subaddresses);
+
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 199);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(102));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
+
+      auto reader = MONERO_UNWRAP(db.start_read());
+      check_address_map(lest_env, reader, user, subs);
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.get_container().size() == 2);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(100));
+      EXPECT(fetched->at(0).second.get_container()[1][0] == lws::db::minor_index(102));
+      EXPECT(fetched->at(0).second.get_container()[1][1] == lws::db::minor_index(200));
+    }
+
+    SECTION("Upsert Before")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 100);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(101));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(99)}}};
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 198);
+      EXPECT(result.has_error());
+      EXPECT(result == lws::error::max_subaddresses);
+
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 199);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(99));
+
+      auto reader = MONERO_UNWRAP(db.start_read());
+      check_address_map(lest_env, reader, user, subs);
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.get_container().size() == 2);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(99));
+      EXPECT(fetched->at(0).second.get_container()[1][0] == lws::db::minor_index(101));
+      EXPECT(fetched->at(0).second.get_container()[1][1] == lws::db::minor_index(200));
+    }
+
+    SECTION("Upsert Encapsulated")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(200)}}}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 200);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 1);
+      EXPECT(result->at(0).first == lws::db::major_index(0));
+      EXPECT(result->at(0).second.get_container().size() == 1);
+      EXPECT(result->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(result->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
+
+      {
+        auto reader = MONERO_UNWRAP(db.start_read());
+        check_address_map(lest_env, reader, user, subs);
+      }
+
+      subs.back().second =
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(5), lws::db::minor_index(99)}}};
+      result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 300);
+      EXPECT(result.has_value());
+      EXPECT(result->size() == 0);
+
+      auto reader = MONERO_UNWRAP(db.start_read());
+      check_address_map(lest_env, reader, user, subs);
+      const auto fetched = reader.get_subaddresses(lws::db::account_id(1));
+      EXPECT(fetched.has_value());
+      EXPECT(fetched->size() == 1);
+      EXPECT(fetched->at(0).first == lws::db::major_index(0));
+      EXPECT(fetched->at(0).second.get_container().size() == 1);
+      EXPECT(fetched->at(0).second.get_container()[0][0] == lws::db::minor_index(1));
+      EXPECT(fetched->at(0).second.get_container()[0][1] == lws::db::minor_index(200));
+    }
+
+
+    SECTION("Bad subaddress_dict")
+    {
+      std::vector<lws::db::subaddress_dict> subs{};
+      subs.emplace_back(
+        lws::db::major_index(0),
+        lws::db::index_ranges{{lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(100)}}}
+      );
+      subs.back().second.get_container().push_back(
+        lws::db::index_range{lws::db::minor_index(101), lws::db::minor_index(200)}
+      );
+      auto result = db.upsert_subaddresses(lws::db::account_id(1), std::nullopt, subs, 100);
       EXPECT(result.has_error());
       EXPECT(result == wire::error::schema::array);
     }

--- a/tests/unit/db/webhook.test.cpp
+++ b/tests/unit/db/webhook.test.cpp
@@ -88,9 +88,9 @@ namespace
 
 LWS_CASE("db::storage::*_webhook")
 {
-  lws::db::account_address account{};
+  lws::db::account_pubs account{};
   crypto::secret_key view{};
-  crypto::generate_keys(account.spend_public, view);
+  crypto::generate_keys(account.flex_public, view);
   crypto::generate_keys(account.view_public, view);
 
   SETUP("One Account and one Webhook Database")
@@ -99,7 +99,7 @@ LWS_CASE("db::storage::*_webhook")
     lws::db::storage db = lws::db::test::get_fresh_db();
     const lws::db::block_info last_block =
       MONERO_UNWRAP(MONERO_UNWRAP(db.start_read()).get_last_block());
-    MONERO_UNWRAP(db.add_account(account, view));
+    MONERO_UNWRAP(db.add_account(lws::db::account_address{account}, view));
 
     const auto get_height = [&db] (const lws::db::block_id height) -> std::vector<lws::db::account_id>
     {
@@ -113,7 +113,7 @@ LWS_CASE("db::storage::*_webhook")
         lws::db::webhook_data{"http://the_url", "the_token", 3}
       };
       MONERO_UNWRAP(
-        db.add_webhook(lws::db::webhook_type::tx_confirmation, account, std::move(value))
+        db.add_webhook(lws::db::webhook_type::tx_confirmation, lws::db::account_address{account}, std::move(value))
       );
     }
 
@@ -134,8 +134,9 @@ LWS_CASE("db::storage::*_webhook")
 
     SECTION("storage::clear_webhooks(addresses)")
     {
+      const lws::db::account_address address{account};
       EXPECT(MONERO_UNWRAP(MONERO_UNWRAP(db.start_read()).get_webhooks()).size() == 1);
-      MONERO_UNWRAP(db.clear_webhooks({std::addressof(account), 1}));
+      MONERO_UNWRAP(db.clear_webhooks({std::addressof(address), 1}));
 
       lws::db::storage_reader reader = MONERO_UNWRAP(db.start_read());
       const auto result = MONERO_UNWRAP(reader.get_webhooks());
@@ -166,10 +167,10 @@ LWS_CASE("db::storage::*_webhook")
           lws::db::webhook_data{"http://the_url_spend", "the_token_spend"}
         };
         MONERO_UNWRAP(
-          db.add_webhook(lws::db::webhook_type::tx_spend, account, std::move(value))
+          db.add_webhook(lws::db::webhook_type::tx_spend, lws::db::account_address{account}, std::move(value))
         );
         MONERO_UNWRAP(
-          db.add_webhook(lws::db::webhook_type::tx_confirmation, account, std::move(value2))
+          db.add_webhook(lws::db::webhook_type::tx_confirmation, lws::db::account_address{account}, std::move(value2))
         );
       }
 
@@ -429,7 +430,7 @@ LWS_CASE("db::storage::*_webhook")
           lws::db::webhook_data{"http://the_url_spend", "the_token_spend"}
         };
         MONERO_UNWRAP(
-          db.add_webhook(lws::db::webhook_type::tx_spend, account, std::move(value))
+          db.add_webhook(lws::db::webhook_type::tx_spend, lws::db::account_address{account}, std::move(value))
         );
       }
       SECTION("storage::get_webhooks()")

--- a/tests/unit/mempool.test.cpp
+++ b/tests/unit/mempool.test.cpp
@@ -28,6 +28,7 @@
 #include "framework.test.h"
 
 #include <cstring>
+#include "carrot_core/payment_proposal.h"             // monero/src
 #include "cryptonote_basic/cryptonote_format_utils.h" // monero/src
 #include "cryptonote_core/cryptonote_tx_utils.h"      // monero/src
 #include "db/account.h"
@@ -42,8 +43,8 @@ namespace
   lws::db::account make_account(const cryptonote::account_keys& src)
   {
     lws::db::account out{};
-    std::memcpy(&out.address.spend_public, &src.m_account_address.m_spend_public_key, sizeof(out.address.spend_public));
-    std::memcpy(&out.address.view_public, &src.m_account_address.m_view_public_key, sizeof(out.address.view_public));
+    std::memcpy(&out.pubs.flex_public, &src.m_account_address.m_spend_public_key, sizeof(out.pubs.flex_public));
+    std::memcpy(&out.pubs.view_public, &src.m_account_address.m_view_public_key, sizeof(out.pubs.view_public));
     std::memcpy(&out.key, &unwrap(unwrap(src.m_view_secret_key)), sizeof(out.key));
     return out;
   }
@@ -56,7 +57,7 @@ LWS_CASE("mempool")
   SETUP("mempool")
   {
     lws::mempool pool{};
-    lws::account account{make_account(base), {}, {}};
+    lws::account account{make_account(base), {}, {}, {}};
 
     SECTION("empty")
     {

--- a/tests/unit/rest.test.cpp
+++ b/tests/unit/rest.test.cpp
@@ -33,8 +33,10 @@
 #include <optional>
 #include <time.h>
 
+#include "carrot_core/payment_proposal.h"        // monero/src
 #include "cryptonote_basic/account.h"            // monero/src
 #include "cryptonote_core/cryptonote_tx_utils.h" // monero/src
+#include "db/carrot.h"
 #include "db/data.h"
 #include "db/print.test.h"
 #include "db/storage.test.h"
@@ -83,6 +85,26 @@ namespace
     rct::key commitment;
     rct::key mask;
     rct::key amount;
+  };
+
+  struct user_account
+  {
+    lws::db::account_address account;
+    crypto::secret_key view;
+
+    user_account(const lws::db::account_address& account, const crypto::secret_key& view)
+      : account(account), view(view)
+    {}
+  };
+
+  struct carrot_account
+  {
+    lws::carrot::account account;
+    crypto::secret_key generate_address;
+
+    carrot_account()
+      : account{}, generate_address{}
+    {}
   };
 
   std::pair<std::string, unsigned> invoke_base(enet::http::http_simple_client& client, const boost::string_ref uri, const boost::string_ref body)
@@ -138,6 +160,36 @@ namespace
     return out;
   }
 
+  void check_address_map(lest::env& lest_env, lws::db::storage& db, const user_account& user, const std::pair<std::uint32_t, std::uint32_t> subaddress)
+  {
+    lest::ctx ctx{lest_env, "check_address_map"};
+    auto reader = MONERO_UNWRAP(db.start_read());
+    const lws::db::address_index index{
+      lws::db::major_index(subaddress.first),
+      lws::db::minor_index(subaddress.second)
+    };
+
+    lws::db::cursor::subaddress_indexes cur = nullptr;
+    auto result = reader.find_subaddress(lws::db::account_id(1), index.get_spend_public(user.account, user.view), cur);
+    EXPECT(result.has_value());
+    EXPECT(result == index);
+  }
+
+  void check_address_map(lest::env& lest_env, lws::db::storage& db, const carrot_account& user, const std::pair<std::uint32_t, std::uint32_t> subaddress)
+  {
+    lest::ctx ctx{lest_env, "check_address_map"};
+    auto reader = MONERO_UNWRAP(db.start_read());
+    const lws::db::address_index index{
+      lws::db::major_index(subaddress.first),
+      lws::db::minor_index(subaddress.second)
+    };
+
+    lws::db::cursor::subaddress_indexes cur = nullptr;
+    auto result = reader.find_subaddress(lws::db::account_id(1), index.get_spend_public(user.account, user.generate_address), cur);
+    EXPECT(result.has_value());
+    EXPECT(result == index);
+  }
+
   void verify_json(lest::env& lest_env, std::string name, std::string actual_json, std::string expected_json)
   {
     const lest::ctx ctx{lest_env, std::move(name)};
@@ -166,6 +218,7 @@ LWS_CASE("rest_server")
 {
   const auto now = std::chrono::system_clock::now();
   const auto base = lws_test::make_account();
+  carrot_account account_incoming{};
   lws::db::account_address account_address{
     base.m_account_address.m_view_public_key,
     base.m_account_address.m_spend_public_key
@@ -173,6 +226,16 @@ LWS_CASE("rest_server")
   const crypto::secret_key view = base.m_view_secret_key;
   const std::string address = lws::db::address_string(account_address);
   const std::string viewkey = epee::to_hex::string(epee::as_byte_span(unwrap(unwrap(view))));
+  {
+    lws::db::account temp{};
+    crypto::public_key temp2{};
+    temp.pubs = {account_address.view_public, account_address.spend_public};
+    std::memcpy(std::addressof(temp.key), std::addressof(unwrap(unwrap(view))), sizeof(temp.key));
+    account_incoming.account = lws::carrot::account{temp};
+    crypto::generate_keys(temp2, account_incoming.generate_address);
+  }
+  const std::string generatekey = epee::to_hex::string(epee::as_byte_span(unwrap(unwrap(account_incoming.generate_address))));
+  const user_account account_legacy{account_address, view};
 
   SETUP("Database and login")
   {
@@ -500,7 +563,7 @@ LWS_CASE("rest_server")
       const auto payment_id_ = crypto::rand<lws::db::output::payment_id_>();
       const crypto::key_image image = crypto::rand<crypto::key_image>();
 
-      lws::account real_account{account, {}, {}};
+      lws::account real_account{account, {}, {}, {}};
       real_account.add_out(
         lws::db::output{
           link,
@@ -598,7 +661,8 @@ LWS_CASE("rest_server")
           "\"timestamp\":\"1970-01-01T01:56:40Z\","
           "\"height\":4000,"
           "\"rct\":\"" + epee::to_hex::string(epee::as_byte_span(ringct_expanded)) + "\","
-          "\"recipient\":{\"maj_i\":2,\"min_i\":66}}"
+          "\"recipient\":{\"maj_i\":2,\"min_i\":66},"
+          "\"unified\":false}"
         "],\"fees\":[40,41]}"
       );
     }
@@ -649,7 +713,7 @@ LWS_CASE("rest_server")
       const crypto::hash payment_id = crypto::rand<crypto::hash>();
       const crypto::key_image image = crypto::rand<crypto::key_image>();
 
-      lws::account real_account{account, {}, {}};
+      lws::account real_account{account, {}, {}, {}};
       real_account.add_out(
         lws::db::output{
           link,
@@ -769,7 +833,7 @@ LWS_CASE("rest_server")
                 "key_image":")" + epee::to_hex::string(epee::as_byte_span(tx.images.at(0))) + R"(",
                 "tx_pub_key":")" + epee::to_hex::string(epee::as_byte_span(tx_public)) + R"(",
                 "out_index":2,
-                "mixin":15,
+                "mixin":16,
                 "sender":{"maj_i":2, "min_i": 66}
               }]
             }
@@ -802,10 +866,176 @@ LWS_CASE("rest_server")
           "\"height\":4000,"
           "\"spend_key_images\":[\"" + epee::to_hex::string(epee::as_byte_span(image)) + "\"],"
           "\"rct\":\"" + epee::to_hex::string(epee::as_byte_span(ringct_expanded)) + "\","
-          "\"recipient\":{\"maj_i\":2,\"min_i\":66}}"
+          "\"recipient\":{\"maj_i\":2,\"min_i\":66},"
+          "\"unified\":false}"
         "],\"fees\":[40,41]}"
       );
     }
+
+    SECTION("One Carrot Receive, One Carrot Spend")
+    {
+      const std::string scan_height = std::to_string(std::uint64_t(account.scan_height) + 5);
+      const std::string start_height = std::to_string(std::uint64_t(account.start_height));
+      message = "{\"address\":\"" + address + "\",\"view_key\":\"" + viewkey + "\"}";
+
+      const lws::db::transaction_link link{
+        lws::db::block_id(5000), crypto::rand<crypto::hash>()
+      };
+      const crypto::public_key tx_public = []() {
+        crypto::secret_key secret;
+        crypto::public_key out;
+        crypto::generate_keys(out, secret);
+        return out;
+      }();
+      const crypto::hash tx_prefix = crypto::rand<crypto::hash>();
+      const crypto::public_key pub = crypto::rand<crypto::public_key>();
+      const rct::key ringct = crypto::rand<rct::key>();
+      const auto extra =
+        lws::db::extra(lws::db::extra::ringct_output);
+      const auto payment_id_ = crypto::rand<lws::db::output::payment_id_>();
+      const crypto::hash payment_id = crypto::rand<crypto::hash>();
+      const crypto::key_image image = crypto::rand<crypto::key_image>();
+      const crypto::key_image first_ki = crypto::rand<crypto::key_image>();
+      const auto anchor = crypto::rand<carrot::encrypted_janus_anchor_t>();
+
+      lws::account real_account{account, {}, {}, {}};
+      real_account.add_out(
+        lws::db::output{
+          link,
+          lws::db::output::spend_meta_{
+            lws::db::output_id{350, 0},
+            std::uint64_t(70000),
+            lws::db::carrot_internal,
+            std::uint32_t(1),
+            tx_public
+          },
+          std::uint64_t(9000),
+          std::uint64_t(5670),
+          tx_prefix,
+          pub,
+          ringct,
+          {0, 0, 0, 0, 0, 0, 0},
+          lws::db::pack(extra, sizeof(crypto::hash8)),
+          payment_id_,
+          std::uint64_t(500),
+          lws::db::address_index{lws::db::major_index(0), lws::db::minor_index(0)},
+          first_ki,
+          anchor
+        }
+      );
+      real_account.add_spend(
+        lws::db::spend{
+          link,
+          image,
+          lws::db::output_id::unknown_spend(),
+          std::uint64_t(86),
+          std::uint64_t(9500),
+          lws::db::carrot_external,
+          {0, 0, 0},
+          0,
+          payment_id,
+          lws::db::address_index{lws::db::major_index(0), lws::db::minor_index(0)}
+        }
+      );
+
+      {
+        std::vector<crypto::hash> hashes{
+          last_block.hash,
+          crypto::rand<crypto::hash>(),
+          crypto::rand<crypto::hash>(),
+          crypto::rand<crypto::hash>(),
+          crypto::rand<crypto::hash>(),
+          crypto::rand<crypto::hash>()
+        };
+
+        EXPECT(db.update(last_block.id, epee::to_span(hashes), {std::addressof(real_account), 1}, {}));
+      }
+
+      response = invoke(client, "/get_address_info", message);
+      EXPECT(response ==
+        "{\"locked_funds\":\"0\","
+        "\"total_received\":\"70000\","
+        "\"total_sent\":\"0\","
+        "\"scanned_height\":" + scan_height + "," +
+        "\"scanned_block_height\":" + scan_height + ","
+        "\"start_height\":" + start_height + ","
+        "\"transaction_height\":" + scan_height + ","
+        "\"blockchain_height\":" + scan_height + ","
+        "\"spent_outputs\":[{"
+          "\"amount\":\"0\","
+          "\"key_image\":\"" + epee::to_hex::string(epee::as_byte_span(image)) + "\","
+          "\"tx_pub_key\":\"" + epee::to_hex::string(epee::as_byte_span(crypto::public_key{})) + "\","
+          "\"out_index\":0,"
+          "\"mixin\":4294967295,"
+          "\"sender\":{\"maj_i\":0,\"min_i\":0}"
+        "}]}"
+      );
+
+      response = invoke(client, "/get_address_txs", message);
+      EXPECT(response ==
+        "{\"total_received\":\"70000\","
+        "\"scanned_height\":" + scan_height + "," +
+        "\"scanned_block_height\":" + scan_height + ","
+        "\"start_height\":" + start_height + ","
+        "\"transaction_height\":" + scan_height + ","
+        "\"blockchain_height\":" + scan_height + ","
+        "\"transactions\":["
+          "{\"id\":0,"
+          "\"hash\":\"" + epee::to_hex::string(epee::as_byte_span(link.tx_hash)) + "\","
+          "\"timestamp\":\"1970-01-01T02:30:00Z\","
+          "\"total_received\":\"70000\","
+          "\"total_sent\":\"0\","
+          "\"fee\":\"500\","
+          "\"unlock_time\":5670,"
+          "\"height\":5000,"
+          "\"payment_id\":\"" + epee::to_hex::string(epee::as_byte_span(payment_id_.short_)) + "\","
+          "\"coinbase\":false,"
+          "\"mempool\":false,"
+          "\"mixin\":4294967295,"
+          "\"recipient\":{\"maj_i\":0,\"min_i\":0},"
+          "\"spent_outputs\":[{"
+            "\"amount\":\"0\","
+            "\"key_image\":\"" + epee::to_hex::string(epee::as_byte_span(image)) + "\","
+            "\"tx_pub_key\":\"" + epee::to_hex::string(epee::as_byte_span(crypto::public_key{})) + "\","
+            "\"out_index\":0,"
+            "\"mixin\":4294967295,"
+            "\"sender\":{\"maj_i\":0,\"min_i\":0}"
+          "}]}"
+        "]}"
+      );
+
+      std::vector<epee::byte_slice> messages;
+      messages.emplace_back(get_fee_response());
+      boost::thread server_thread(&lws_test::rpc_thread, context.zmq_context(), std::cref(messages));
+      const join on_scope_exit{server_thread};
+
+      const auto ringct_expanded = get_rct_bytes(view, tx_public, ringct, 70000, 1, false);
+      message = "{\"address\":\"" + address + "\",\"view_key\":\"" + viewkey + "\",\"amount\":\"0\"}";
+      response = invoke(client, "/get_unspent_outs", message);
+      EXPECT(response ==
+        "{\"per_byte_fee\":39,"
+        "\"fee_mask\":1000,"
+        "\"amount\":\"70000\","
+        "\"outputs\":["
+          "{\"amount\":\"70000\","
+          "\"public_key\":\"" + epee::to_hex::string(epee::as_byte_span(pub)) + "\","
+          "\"index\":1,"
+          "\"global_index\":0,"
+          "\"tx_id\":0,"
+          "\"tx_hash\":\"" + epee::to_hex::string(epee::as_byte_span(link.tx_hash)) + "\","
+          "\"tx_prefix_hash\":\"" + epee::to_hex::string(epee::as_byte_span(tx_prefix)) + "\","
+          "\"tx_pub_key\":\"" + epee::to_hex::string(epee::as_byte_span(tx_public)) + "\","
+          "\"timestamp\":\"1970-01-01T02:30:00Z\","
+          "\"height\":5000,"
+          "\"rct\":\"" + epee::to_hex::string(epee::as_byte_span(ringct_expanded)) + "\","
+          "\"recipient\":{\"maj_i\":0,\"min_i\":0},"
+          "\"unified\":false,"
+          "\"first_key_image\":\"" + epee::to_hex::string(epee::as_byte_span(first_ki)) + "\","
+          "\"janus_enc\":\"" + epee::to_hex::string(epee::as_byte_span(anchor)) + "\"}"
+        "],\"fees\":[40,41]}"
+      );
+    }
+
 
     SECTION("provision_subaddrs")
     {
@@ -823,6 +1053,8 @@ LWS_CASE("rest_server")
           "{\"key\":1,\"value\":[[0,4]]}]}"
       );
 
+      check_address_map(lest_env, db, account_legacy, {0, 4});
+
       message = "{\"address\":\"" + address + "\",\"view_key\":\"" + viewkey + "\",\"maj_i\":2,\"min_i\":5,\"n_maj\":2,\"n_min\":5}";
       response = invoke(client, "/provision_subaddrs", message);
       EXPECT(response ==
@@ -835,6 +1067,31 @@ LWS_CASE("rest_server")
           "{\"key\":2,\"value\":[[5,9]]},"
           "{\"key\":3,\"value\":[[5,9]]}]}"
       );
+
+      check_address_map(lest_env, db, account_legacy, {3, 9});
+    }
+
+    SECTION("provision_subaddrs carrot incoming-only")
+    {
+      const std::string scan_height = std::to_string(std::uint64_t(account.scan_height) + 5);
+      const std::string start_height = std::to_string(std::uint64_t(account.start_height));
+      message =
+        "{\"address\":\"" + address + "\","
+        "\"view_key\":\"" + viewkey + "\","
+        "\"generate_address_key\":\"" + generatekey + "\","
+        "\"maj_i\":0,\"min_i\":0,\"n_maj\":2,\"n_min\":5}";
+
+      response = invoke(client, "/provision_subaddrs", message);
+      EXPECT(response ==
+        "{\"new_subaddrs\":["
+          "{\"key\":0,\"value\":[[0,4]]},"
+          "{\"key\":1,\"value\":[[0,4]]}"
+        "],\"all_subaddrs\":["
+          "{\"key\":0,\"value\":[[0,4]]},"
+          "{\"key\":1,\"value\":[[0,4]]}]}"
+      );
+
+      check_address_map(lest_env, db, account_incoming, {0, 4});
     }
 
     SECTION("upsert_subaddrs")
@@ -851,6 +1108,8 @@ LWS_CASE("rest_server")
           "{\"key\":0,\"value\":[[1,10]]}]}"
       );
 
+      check_address_map(lest_env, db, account_legacy, {0, 10});
+
       message = "{\"address\":\"" + address + "\",\"view_key\":\"" + viewkey + "\",\"subaddrs\":[{\"key\":0,\"value\":[[11,20]]}]}";
       response = invoke(client, "/upsert_subaddrs", message);
       EXPECT(response ==
@@ -859,6 +1118,29 @@ LWS_CASE("rest_server")
         "],\"all_subaddrs\":["
           "{\"key\":0,\"value\":[[1,20]]}]}"
       );
+
+      check_address_map(lest_env, db, account_legacy, {0, 20});
+    }
+
+    SECTION("upsert_subaddrs carrot incoming-only")
+    {
+      const std::string scan_height = std::to_string(std::uint64_t(account.scan_height) + 5);
+      const std::string start_height = std::to_string(std::uint64_t(account.start_height));
+      message =
+        "{\"address\":\"" + address + "\","
+        "\"view_key\":\"" + viewkey + "\","
+        "\"generate_address_key\":\"" + generatekey + "\","
+        "\"subaddrs\":[{\"key\":0,\"value\":[[1,10]]}]}";
+
+      response = invoke(client, "/upsert_subaddrs", message);
+      EXPECT(response ==
+        "{\"new_subaddrs\":["
+          "{\"key\":0,\"value\":[[1,10]]}"
+        "],\"all_subaddrs\":["
+          "{\"key\":0,\"value\":[[1,10]]}]}"
+      );
+
+      check_address_map(lest_env, db, account_incoming, {0, 10});
     }
 
     SECTION("feed check")

--- a/tests/unit/scanner.test.cpp
+++ b/tests/unit/scanner.test.cpp
@@ -29,7 +29,19 @@
 #include "framework.test.h"
 
 #include <boost/thread.hpp>
+#include <tuple>
 
+#include "carrot_core/account_secrets.h"
+#include "carrot_core/device_ram_borrowed.h"          // monero/src
+#include "carrot_core/enote_utils.h"                  // monero/src
+#include "carrot_impl/address_device_ram_borrowed.h"  // monero/src
+#include "carrot_impl/format_utils.h"                 // monero/src
+#include "carrot_impl/key_image_device_composed.h"    // monero/src
+#include "carrot_impl/output_opening_types.h"         // monero/src
+#include "carrot_impl/tx_builder_inputs.h"            // monero/src
+#include "carrot_impl/tx_builder_outputs.h"           // monero/src
+#include "carrot_impl/tx_proposal_utils.h"            // monero/src
+#include "common/apply_permutation.h" // monero/src
 #include "cryptonote_basic/account.h" // monero/src
 #include "cryptonote_basic/cryptonote_format_utils.h" // monero/src
 #include "cryptonote_config.h"        // monero/src
@@ -38,17 +50,26 @@
 #include "db/print.test.h"
 #include "db/storage.test.h"
 #include "device/device_default.hpp" // monero/src
+#include "fcmp_pp/curve_trees.h"     // monero/src
+#include "fcmp_pp/prove.h"           // monero/src
+#include "fcmp_pp/tree_cache.h"      // monero/src
+#include "hardforks/hardforks.h"     // monero/src
 #include "net/zmq.h"                 // monero/src
 #include "rpc/client.h"
 #include "rpc/daemon_messages.h"     // monero/src
 #include "scanner.h"
 #include "util/transaction.test.h"
+#include "wallet/tx_builder.h"       // monero/src
 #include "wire/error.h"
 #include "wire/json/write.h"
-
+#include "misc_log_ex.h"
 namespace
 {
+  using tree_cache = fcmp_pp::curve_trees::TreeCacheV1;
+  using curve_tree = fcmp_pp::curve_trees::CurveTreesV1;
+
   constexpr const std::chrono::seconds message_timeout{3};
+  constexpr const std::uint64_t fee_weight = 80000;
 
   template<typename T>
   struct json_rpc_response
@@ -87,7 +108,361 @@ namespace
       boost::thread& thread;
       ~join() { thread.join(); }
   };
+
+  struct get_spend_public
+  {
+    std::vector<crypto::public_key>& pub_keys;
+
+    template<typename T>
+    void operator()(const T&) const noexcept
+    {}
    
+    void operator()(const cryptonote::txout_to_key& val) const
+    { pub_keys.push_back(val.key); }
+
+    void operator()(const cryptonote::txout_to_tagged_key& val) const
+    { pub_keys.push_back(val.key); }
+  };
+
+
+  fcmp_pp::OutputPair make_output_pair(const crypto::public_key& pub, const rct::key& commitment, const bool is_carrot)
+  {
+    if (is_carrot)
+      return {fcmp_pp::CarrotOutputPairV1{{pub, rct2pk(commitment)}}};
+    return {fcmp_pp::LegacyOutputPair{{pub, rct2pk(commitment)}}};
+  }
+
+  fcmp_pp::OutputPair make_output_pair(const lws::db::output& source)
+  {
+    return make_output_pair(
+      source.pub,
+      rct::commit(source.spend_meta.amount, source.ringct_mask),
+      source.is_carrot()
+    );
+  }
+
+  fcmp_pp::OutputPair make_output_pair(const cryptonote::transaction& tx, const std::size_t index)
+  {
+    crypto::public_key pub{};
+    cryptonote::get_output_public_key(tx.vout.at(index), pub);
+    const bool is_carrot = boost::get<cryptonote::txout_to_carrot_v1>(std::addressof(tx.vout.at(index).target));
+    const bool is_miner = tx.vin.at(0).type() == typeid(cryptonote::txin_gen);
+    const std::uint64_t amount = tx.vout.at(index).amount;
+
+    return make_output_pair(
+      pub,
+      is_miner ? rct::commit(amount, rct::identity()) : tx.rct_signatures.outPk.at(index).mask,
+      is_carrot
+    );
+  }
+
+  carrot::CarrotSelectedInput make_carrot_input(const carrot::view_incoming_key_device& incoming, const lws::db::output& source, const carrot::AddressDeriveType type)
+  {
+    if (source.is_carrot())
+    {
+      mx25519_pubkey shared{};
+      carrot::view_tag_t tag{};
+      const bool is_coinbase = lws::db::unpack(source.extra).first & lws::db::coinbase_output; 
+      const mx25519_pubkey de = carrot::raw_byte_convert<mx25519_pubkey>(source.spend_meta.tx_public);
+      const carrot::input_context_t context =
+        is_coinbase ?
+          carrot::make_carrot_input_context_coinbase(std::uint64_t(source.link.height)) :
+          carrot::make_carrot_input_context(source.first_image);
+
+      if (!incoming.view_key_scalar_mult_x25519(carrot::raw_byte_convert<mx25519_pubkey>(source.spend_meta.tx_public), shared))
+        throw std::runtime_error{"Failed to generate x25519"};
+
+      carrot::make_carrot_view_tag(shared.data, context, source.pub, tag);
+
+      std::optional<carrot::encrypted_payment_id_t> epid;
+      if (lws::db::unpack(source.extra).second == 8)
+      {
+        crypto::hash ctx{};
+        carrot::payment_id_t upid{};
+
+        static_assert(sizeof(upid) == sizeof(source.payment_id.short_));
+        std::memcpy(std::addressof(upid), std::addressof(source.payment_id.short_), sizeof(upid));
+        carrot::make_carrot_contextualized_sender_receiver_secret(shared.data, de, context, ctx);
+        epid.emplace(carrot::encrypt_legacy_payment_id(upid, ctx, source.pub));
+      }
+
+      return {
+        source.spend_meta.amount,
+        carrot::CarrotOutputOpeningHintV2{
+          source.pub,
+          ::carrot::commit_carrot_amount(source.spend_meta.amount, rct2sk(source.ringct_mask)),//  ::carrot::raw_byte_convert<::carrot::amount_commitment_t>(source.ringct_mask),
+          source.anchor,
+          tag,
+          carrot::raw_byte_convert<mx25519_pubkey>(source.spend_meta.tx_public),
+          source.first_image,
+          source.spend_meta.amount,
+          epid,
+          carrot::subaddress_index_extended{
+            std::uint32_t(source.recipient.maj_i),
+            std::uint32_t(source.recipient.min_i),
+            type
+          }
+        }
+      };
+    }
+    // else not carrot
+    return {
+      source.spend_meta.amount,
+      carrot::LegacyOutputOpeningHintV1{
+        source.pub,
+        source.spend_meta.tx_public,
+        carrot::subaddress_index{
+          std::uint32_t(source.recipient.maj_i),
+          std::uint32_t(source.recipient.min_i)
+        },
+        source.spend_meta.amount,
+        rct::rct2sk(source.ringct_mask),
+        source.spend_meta.index
+      }
+    };
+  }
+
+  carrot::CarrotDestinationV1 to_carrot_dest(const lws::db::account_address& dest, const carrot::payment_id_t& pid = {})
+  {
+    return {dest.spend_public, dest.view_public, false, pid};
+  }
+
+  carrot::CarrotDestinationV1 to_carrot_dest(const cryptonote::account_keys& dest, const carrot::subaddress_index& sub = {})
+  {
+    crypto::secret_key incoming{};
+    crypto::secret_key address{};
+    carrot::CarrotDestinationV1 out{};
+
+    carrot::make_carrot_generateaddress_secret(dest.m_view_secret_key, address);
+    const carrot::generate_address_secret_ram_borrowed_device address_device{address};
+
+    const auto& account = dest.m_account_address;
+    carrot::make_carrot_subaddress_v1(
+      account.m_spend_public_key, account.m_view_public_key, address_device, sub.major, sub.minor, out
+    );
+
+    return out;
+  }
+
+  lws_test::transaction make_carrot_tx(
+    lest::env& lest_env,
+    const cryptonote::account_keys& keys,
+    const std::vector<carrot::CarrotDestinationV1>& dests,
+    const tree_cache& cache,
+    const curve_tree& tree,
+    const std::vector<lws::db::output>& sources,
+    const carrot::AddressDeriveType type = carrot::AddressDeriveType::PreCarrot
+  )
+  {
+    struct select_inputs
+    {
+      std::vector<carrot::CarrotSelectedInput> sources;
+
+      void operator()(
+        const boost::multiprecision::uint128_t&,
+        const std::map<std::size_t, rct::xmr_amount>&,
+        std::size_t,
+        std::size_t,
+        std::vector<carrot::CarrotSelectedInput>& out)
+      {
+        out = sources;
+      }
+    };
+
+    crypto::secret_key prove_key{};
+    crypto::secret_key image_key{};
+    crypto::secret_key address_key{};
+    crypto::secret_key incoming_key{};
+    crypto::public_key view_address{};
+
+    std::shared_ptr<carrot::generate_address_secret_device> generate_address_device;
+    std::shared_ptr<carrot::generate_image_key_device> generate_image_device;
+    std::shared_ptr<carrot::view_incoming_key_device> incoming_device;
+    std::shared_ptr<carrot::view_balance_secret_device> balance_device;
+    if (type == carrot::AddressDeriveType::Carrot)
+    {
+      crypto::public_key partial{};
+      crypto::secret_key preimage_key{};
+
+      carrot::make_carrot_provespend_key(keys.m_spend_secret_key, prove_key);
+      carrot::make_carrot_generateimage_preimage(keys.m_view_secret_key, preimage_key);
+      carrot::make_carrot_partial_spend_pubkey(prove_key, partial);
+      carrot::make_carrot_generateimage_key(preimage_key, partial, image_key);
+      carrot::make_carrot_generateaddress_secret(keys.m_view_secret_key, address_key);
+      carrot::make_carrot_viewincoming_key(keys.m_view_secret_key, incoming_key);     
+      view_address = rct2pk(scalarmultKey(rct::pk2rct(keys.m_account_address.m_spend_public_key), rct::sk2rct(incoming_key)));
+
+      generate_address_device = std::make_shared<carrot::generate_address_secret_ram_borrowed_device>(address_key);
+      generate_image_device = std::make_shared<::carrot::generate_image_key_ram_borrowed_device>(image_key);
+      incoming_device = std::make_shared<carrot::view_incoming_key_ram_borrowed_device>(incoming_key);
+      balance_device = std::make_shared<::carrot::view_balance_secret_ram_borrowed_device>(keys.m_view_secret_key);
+    }
+
+    std::shared_ptr<carrot::cryptonote_hierarchy_address_device> cryptonote_device;
+    std::shared_ptr<carrot::carrot_hierarchy_address_device> carrot_device;
+    std::shared_ptr<carrot::key_image_device> image_device;
+    if (type == carrot::AddressDeriveType::PreCarrot)
+    {
+      generate_image_device = std::make_shared<::carrot::generate_image_key_ram_borrowed_device>(keys.m_spend_secret_key);
+      const auto view_device = std::make_shared<carrot::cryptonote_view_incoming_key_ram_borrowed_device>(keys.m_view_secret_key);
+      incoming_device = view_device;
+      cryptonote_device = std::make_shared<carrot::cryptonote_hierarchy_address_device>(
+        view_device, keys.m_account_address.m_spend_public_key
+      );
+    }
+    else
+    {
+      carrot_device = std::make_shared<carrot::carrot_hierarchy_address_device>(
+        generate_address_device, keys.m_account_address.m_spend_public_key, view_address
+      );
+    }
+
+    std::vector<bool> biased;
+    std::vector<fcmp_pp::OutputPair> pairs;
+    std::vector<carrot::CarrotSelectedInput> sources_real;
+    for (const auto& source : sources)
+    {
+      biased.push_back(!source.is_carrot());
+      pairs.push_back(make_output_pair(source));
+      sources_real.push_back(make_carrot_input(*incoming_device, source, type));
+    }
+
+    rct::xmr_amount amount = 0;
+    for (const auto& source : sources)
+      amount += source.spend_meta.amount;
+    amount /= (dests.size() + 1);
+
+    std::vector<carrot::CarrotPaymentProposalV1> payments;
+    for (const auto& dest : dests)
+      payments.push_back({dest, amount, carrot::gen_janus_anchor()});
+
+    carrot::CarrotTransactionProposalV1 proposal;
+    carrot::make_carrot_transaction_proposal_v1_transfer(
+      payments,
+      {},
+      fee_weight,
+      {},
+      select_inputs{sources_real},
+      keys.m_account_address.m_spend_public_key,
+      carrot::subaddress_index_extended{{}, type},
+      {},
+      {},
+      proposal
+    );
+
+    crypto::hash tx_hash{};
+    carrot::encrypted_payment_id_t enc_pid{};
+    std::vector<crypto::key_image> images;
+    std::vector<fcmp_pp::FcmpPpSalProof> proofs;
+    std::vector<FcmpRerandomizedOutputCompressed> rerandomized;
+    std::vector<carrot::RCTOutputEnoteProposal> enotes;
+    {
+      const auto hybrid_device = std::make_shared<carrot::hybrid_hierarchy_address_device>(
+        carrot_device, cryptonote_device
+      );
+      const carrot::key_image_device_composed image_composed{
+        generate_image_device, hybrid_device, balance_device, incoming_device
+      };
+
+      EXPECT_NO_THROW(
+        carrot::make_signable_tx_hash_from_proposal_v1(
+          proposal, balance_device.get(), incoming_device.get(), image_composed, tx_hash
+        )
+      );
+ 
+      std::vector<std::size_t> order;
+      EXPECT_NO_THROW(
+        carrot::get_sorted_input_key_images_from_proposal_v1(
+          proposal, image_composed, images, std::addressof(order)
+        )
+      );
+
+      EXPECT_NO_THROW(
+        carrot:get_output_enote_proposals_from_proposal_v1(
+          proposal, balance_device.get(), incoming_device.get(), images.at(0), enotes, enc_pid
+        )
+      );
+
+      rerandomized =
+        carrot::generate_rerandomized_inputs_nonrefundable(
+          epee::to_span(enotes),
+          epee::to_span(proposal.input_proposals),
+          {std::addressof(keys.m_account_address.m_spend_public_key), 1},
+          *incoming_device,
+          balance_device.get()
+        );
+
+      std::size_t i = -1;
+      for (const auto& input : proposal.input_proposals)
+      {
+        ++i;
+        crypto::key_image ignored;
+        const bool is_legacy =
+          std::get_if<carrot::LegacyOutputOpeningHintV1>(std::addressof(input));
+        if (type == carrot::AddressDeriveType::PreCarrot)
+        {
+          EXPECT(cryptonote_device);
+          EXPECT_NO_THROW(
+            carrot::make_sal_proof_any_to_legacy_v1(
+              tx_hash, rerandomized.at(i), input, keys.m_spend_secret_key, *cryptonote_device, proofs.emplace_back(), ignored
+            )
+          );
+        }
+        else
+        {
+          EXPECT(balance_device);
+          EXPECT(incoming_device);
+          EXPECT(generate_address_device);
+          EXPECT_NO_THROW(
+            carrot::make_sal_proof_any_to_carrot_v1(
+              tx_hash,
+              rerandomized.at(i),
+              input,
+              prove_key,
+              image_key,
+              *balance_device,
+              *incoming_device,
+              *generate_address_device,
+              proofs.emplace_back(),
+              ignored
+            )
+          );
+        }
+      }
+
+      tools::apply_permutation(order, pairs);
+      tools::apply_permutation(order, rerandomized);
+      tools::apply_permutation(order, proofs);
+    }
+
+    return lws_test::transaction{
+      .tx = tools::wallet::finalize_fcmps_and_range_proofs(
+        images, rerandomized, pairs, proofs, enotes, enc_pid, proposal.fee, cache, tree
+      ),
+      .carrot = enotes
+    };
+  }
+
+  lws_test::transaction make_carrot_tx(lest::env& lest_env, const cryptonote::account_keys& keys, const tree_cache& cache, const curve_tree& tree, const std::vector<lws::db::output>& sources)
+  { 
+    struct pair
+    {
+      crypto::public_key pub;
+      crypto::secret_key sec;
+
+      pair()
+        : pub{}, sec{}
+      {
+        crypto::generate_keys(pub, sec);
+      }
+    };
+
+    pair spend{};
+    pair view{};
+
+    return make_carrot_tx(lest_env, keys, {to_carrot_dest(lws::db::account_address{spend.pub, view.pub})}, cache, tree, sources);
+  }
+
   void scanner_thread(lws::scanner& scanner, void* ctx, const std::vector<epee::byte_slice>& reply)
   {
     struct stop_
@@ -152,8 +527,10 @@ namespace lws_test
   }
 }
 
-LWS_CASE("lws::scanner::sync and lws::scanner::run")
+LWS_CASE("lws::scanner::sync and lws::scanner::run (legacy keys)")
 {
+  static constexpr const std::uint64_t miner_reward = 35184372088830;
+
   cryptonote::account_keys keys{};
   crypto::generate_keys(keys.m_account_address.m_spend_public_key, keys.m_spend_secret_key);
   crypto::generate_keys(keys.m_account_address.m_view_public_key, keys.m_view_secret_key);
@@ -189,12 +566,45 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
     keys2.m_account_address.m_spend_public_key
   };
 
+  cryptonote::account_keys keys3{};
+  crypto::generate_keys(keys3.m_account_address.m_spend_public_key, keys3.m_spend_secret_key);
+
+  // carrot view-balance account
+  lws::db::account_address account3{};
+  lws::db::account_pubs account3_pubs{};
+  {
+    crypto::public_key partial{};
+    crypto::secret_key incoming_key{};
+    crypto::secret_key prove_key{};
+    crypto::secret_key preimage_key{};
+    crypto::secret_key image_key{};
+    crypto::key_derivation view_public{};
+
+    carrot::make_carrot_provespend_key(keys3.m_spend_secret_key, prove_key);
+    carrot::make_carrot_viewbalance_secret(keys3.m_spend_secret_key, keys3.m_view_secret_key);
+    carrot::make_carrot_partial_spend_pubkey(prove_key, account3_pubs.flex_public);
+    carrot::make_carrot_generateimage_preimage(keys3.m_view_secret_key, preimage_key);
+    carrot::make_carrot_generateimage_key(preimage_key, account3_pubs.flex_public, image_key); 
+    carrot::make_carrot_spend_pubkey(image_key, prove_key, account3.spend_public); 
+
+    carrot::make_carrot_viewincoming_key(keys3.m_view_secret_key, incoming_key);
+    EXPECT(crypto::secret_key_to_public_key(incoming_key, account3.view_public));
+    account3_pubs.view_public = account3.view_public;
+
+    keys3.m_account_address.m_spend_public_key = account3.spend_public;
+
+    EXPECT(crypto::generate_key_derivation(account3.spend_public, incoming_key, view_public));
+    keys3.m_account_address.m_view_public_key = carrot::raw_byte_convert<crypto::public_key>(view_public);
+
+    keys3.m_account_address.m_view_public_key =
+      rct::rct2pk(rct::scalarmultKey(rct::pk2rct(account3.spend_public), rct::sk2rct(incoming_key)));
+  }
+
   SETUP("lws::rpc::context, ZMQ_REP Server, and lws::db::storage")
   {
     std::shared_ptr<lws::mempool> pool{};
     auto rpc = 
       lws::rpc::context::make(lws_test::rpc_rendevous, {}, {}, {}, std::chrono::minutes{0}, false, true);
-
 
     lws::db::test::cleanup_db on_scope_exit{};
     lws::db::storage db = lws::db::test::get_fresh_db();
@@ -283,6 +693,8 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
 
     SECTION("lws::scanner::run (with upsert)")
     {
+      const lws::db::block_id legacy_block_id = add(last_block.id, 2);
+      const lws::db::block_id carrot_block_id = add(legacy_block_id, 2);
       {
         const std::vector<lws::db::subaddress_dict> indexes{
           lws::db::subaddress_dict{
@@ -292,17 +704,12 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
             }
           }
         };
-        const auto result =
-          db.upsert_subaddresses(lws::db::account_id(1), account, keys.m_view_secret_key, indexes, 2);
-        EXPECT(result);
-        EXPECT(result->size() == 1);
-        EXPECT(result->at(0).first == lws::db::major_index::primary);
-        EXPECT(result->at(0).second.get_container().size() == 1);
-        EXPECT(result->at(0).second.get_container().at(0).size() == 2);
-        EXPECT(result->at(0).second.get_container().at(0).at(0) == lws::db::minor_index(1));
-        EXPECT(result->at(0).second.get_container().at(0).at(1) == lws::db::minor_index(2));
       }
 
+      const auto tree = fcmp_pp::curve_trees::curve_trees_v1();
+      tree_cache cache(tree); 
+      cache.init(std::uint64_t(last_block.id), last_block.hash, 0, {}, {});
+ 
       std::vector<cryptonote::tx_destination_entry> destinations;
       destinations.emplace_back();
       destinations.back().amount = 8000;
@@ -313,10 +720,27 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
       EXPECT(tx.pub_keys.size() == 1);
       EXPECT(tx.spend_publics.size() == 1);
 
+      const lws::db::output legacy_output{
+        lws::db::transaction_link{legacy_block_id, cryptonote::get_transaction_hash(tx.tx)},
+        lws::db::output::spend_meta_{
+          lws::db::output_id{0, 100}, miner_reward, 0, 0, tx.pub_keys.at(0)
+        },
+        0,
+        0,
+        cryptonote::get_transaction_prefix_hash(tx.tx),
+        tx.spend_publics.at(0),
+        rct::identity(), //rct::commit(miner_reward, rct::identity()),
+        {},
+        lws::db::pack(lws::db::extra(lws::db::ringct_output | lws::db::coinbase_output), 0),
+        {},
+        0, // fee
+        lws::db::address_index{}
+      };
+
       lws_test::transaction tx2 = lws_test::make_tx(lest_env, keys, destinations, 20, true);
       EXPECT(tx2.pub_keys.size() == 1);
       EXPECT(tx2.spend_publics.size() == 1);
-
+ 
       lws_test::transaction tx3 = lws_test::make_tx(lest_env, keys, destinations, 86, false);
       EXPECT(tx3.pub_keys.size() == 1);
       EXPECT(tx3.spend_publics.size() == 1);
@@ -330,18 +754,9 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
       EXPECT(tx4.pub_keys.size() == 1);
       EXPECT(tx4.spend_publics.size() == 2);
 
-      //destinations.emplace_back();
-      //destinations.back().amount = 1000;
-      //destinations.back().addr = keys_subaddr2.m_account_address;
-      //destinations.back().is_subaddress = true;
-
-      //transaction tx5 = lws_test::make_tx(lest_env, keys, destinations, 100, true);
-      //EXPECT(tx5.pub_keys.size() == 3);
-      //EXPECT(tx5.spend_publics.size() == 3);
-
       cryptonote::rpc::GetBlocksFast::Response bmessage{};
       bmessage.start_height = std::uint64_t(last_block.id) + 1;
-      bmessage.current_height = bmessage.start_height + 1;
+      bmessage.current_height = bmessage.start_height + 7;
       bmessage.blocks.emplace_back();
       bmessage.blocks.back().block.miner_tx = tx.tx;
       bmessage.blocks.back().block.tx_hashes.push_back(cryptonote::get_transaction_hash(tx2.tx));
@@ -362,10 +777,208 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
       bmessage.output_indices.back().back().push_back(201);
       bmessage.blocks.push_back(bmessage.blocks.back());
       bmessage.output_indices.push_back(bmessage.output_indices.back());
+      /*bmessage.blocks.back().block.miner_tx =
+        make_miner_tx(lest_env, lws::db::block_id(std::uint64_t(last_block.id) + 1), {}, false).tx; */
 
+      EXPECT(cache.register_output(make_output_pair(tx.tx, 0)));
+      EXPECT_NO_THROW(
+        cache.sync_block(
+          bmessage.start_height,
+          get_block_hash(bmessage.blocks.at(0).block),
+          last_block.hash,
+          {{bmessage.start_height + 1, {{100, make_output_pair(tx.tx, 0)}}}}
+        )
+      ); 
+      EXPECT_NO_THROW(
+        cache.sync_block(
+          bmessage.start_height + 1,
+          get_block_hash(bmessage.blocks.at(1).block),
+          get_block_hash(bmessage.blocks.at(0).block),
+          {{bmessage.start_height + 2, {{250, make_output_pair(bmessage.blocks.back().block.miner_tx, 0)}}}}
+        )
+      );
+
+      // third block
+      lws_test::transaction tx5 = make_carrot_tx(lest_env, keys, {to_carrot_dest(account3)}, cache, *tree, {legacy_output});
+
+      static constexpr const std::uint64_t carrot1_payment = miner_reward / 2;
+      const auto carrot1_block_id = increment(legacy_block_id);
+      const bool carrot1_index = tx5.carrot.at(0).amount != carrot1_payment;
+      const std::uint64_t carrot1_change = tx5.carrot.at(!carrot1_index).amount;
+
+      const lws::db::output carrot1_output{
+        lws::db::transaction_link{carrot1_block_id, cryptonote::get_transaction_hash(tx5.tx)},
+        lws::db::output::spend_meta_{
+          lws::db::output_id{0, std::uint64_t(301 + carrot1_index)},
+          carrot1_payment,
+          lws::db::carrot_external,
+          std::uint32_t(carrot1_index),
+          carrot::raw_byte_convert<crypto::public_key>(
+            tx5.carrot.at(carrot1_index).enote.enote_ephemeral_pubkey
+          )
+        },
+        0,
+        0,
+        cryptonote::get_transaction_prefix_hash(tx5.tx),
+        tx5.carrot.at(carrot1_index).enote.onetime_address,
+        ::rct::sk2rct(tx5.carrot.at(carrot1_index).amount_blinding_factor),
+        {},
+        lws::db::pack(lws::db::extra::ringct_output, 8),
+        {},
+        612000000, // fee
+        lws::db::address_index{},
+        tx5.carrot.at(carrot1_index).enote.tx_first_key_image,
+        tx5.carrot.at(carrot1_index).enote.anchor_enc
+      };
+ 
+      bmessage.blocks.emplace_back();
+      bmessage.blocks.back().block.miner_tx = lws_test::make_miner_tx(lest_env, last_block.id, {}, true).tx;
+      bmessage.blocks.back().block.tx_hashes.push_back(cryptonote::get_transaction_hash(tx5.tx));
+      bmessage.blocks.back().transactions.push_back(tx5.tx);
+      bmessage.output_indices.emplace_back();
+      bmessage.output_indices.back().emplace_back();
+      bmessage.output_indices.back().back().push_back(300);
+      bmessage.output_indices.back().emplace_back();
+      bmessage.output_indices.back().back().push_back(301);
+      bmessage.output_indices.back().back().push_back(302);
+
+      bmessage.blocks.push_back(bmessage.blocks.back());
+      bmessage.output_indices.push_back(bmessage.output_indices.back());
+
+      EXPECT(cache.register_output(make_output_pair(carrot1_output)));
+      EXPECT_NO_THROW(
+        cache.sync_block(
+          bmessage.start_height + 2,
+          get_block_hash(bmessage.blocks.at(2).block),
+          get_block_hash(bmessage.blocks.at(1).block),
+          {{bmessage.start_height + 3, {{std::uint64_t(301 + carrot1_index), make_output_pair(tx5.tx, carrot1_index)}}}}
+        )
+      );
+      EXPECT_NO_THROW(
+        cache.sync_block(
+          bmessage.start_height + 3,
+          get_block_hash(bmessage.blocks.at(3).block),
+          get_block_hash(bmessage.blocks.at(2).block),
+          {{bmessage.start_height + 4, {{350, make_output_pair(bmessage.blocks.back().block.miner_tx, 0)}}}}
+        )
+      );
+
+      // fifth block
+      lws_test::transaction tx6 = make_carrot_tx(
+        lest_env, keys3, {to_carrot_dest(account, carrot::payment_id_t{{5}})}, cache, *tree, {carrot1_output}, carrot::AddressDeriveType::Carrot
+      );
+
+      static constexpr const std::uint64_t carrot2_payment = carrot1_payment / 2;
+      const auto carrot2_block_id = add(legacy_block_id, 3);
+      const bool carrot2_index = tx6.carrot.at(0).amount != carrot2_payment;
+      const std::uint64_t carrot2_change = tx6.carrot.at(!carrot2_index).amount;
+
+      const lws::db::output carrot2_output{
+        lws::db::transaction_link{carrot2_block_id, cryptonote::get_transaction_hash(tx6.tx)},
+        lws::db::output::spend_meta_{
+          lws::db::output_id{0, std::uint64_t(401 + carrot2_index)},
+          carrot2_payment,
+          lws::db::carrot_external,
+          std::uint32_t(carrot2_index),
+          carrot::raw_byte_convert<crypto::public_key>(
+            tx6.carrot.at(carrot2_index).enote.enote_ephemeral_pubkey
+          )
+        },
+        0,
+        0,
+        cryptonote::get_transaction_prefix_hash(tx6.tx),
+        tx6.carrot.at(carrot2_index).enote.onetime_address,
+        rct::sk2rct(tx6.carrot.at(carrot2_index).amount_blinding_factor),
+        {},
+        lws::db::pack(lws::db::extra::ringct_output, 8),
+        {crypto::hash8{{5}}},
+        612000000, // fee
+        lws::db::address_index{},
+        tx6.carrot.at(carrot2_index).enote.tx_first_key_image,
+        tx6.carrot.at(carrot2_index).enote.anchor_enc
+      };
+
+      bmessage.blocks.emplace_back();
+      bmessage.blocks.back().block.miner_tx = lws_test::make_miner_tx(lest_env, last_block.id, {}, true).tx;
+      bmessage.blocks.back().block.tx_hashes.push_back(cryptonote::get_transaction_hash(tx6.tx));
+      bmessage.blocks.back().transactions.push_back(tx6.tx);
+      bmessage.output_indices.emplace_back();
+      bmessage.output_indices.back().emplace_back();
+      bmessage.output_indices.back().back().push_back(400);
+      bmessage.output_indices.back().emplace_back();
+      bmessage.output_indices.back().back().push_back(401);
+      bmessage.output_indices.back().back().push_back(402);
+
+      bmessage.blocks.push_back(bmessage.blocks.back());
+      bmessage.output_indices.push_back(bmessage.output_indices.back());
+
+      EXPECT(cache.register_output(make_output_pair(carrot2_output)));
+      EXPECT_NO_THROW(
+        cache.sync_block(
+          bmessage.start_height + 4,
+          get_block_hash(bmessage.blocks.at(4).block),
+          get_block_hash(bmessage.blocks.at(3).block),
+          {{bmessage.start_height + 5, {{std::uint64_t(401 + carrot2_index), make_output_pair(tx6.tx, carrot2_index)}}}}
+        )
+      );
+      EXPECT_NO_THROW(
+        cache.sync_block(
+          bmessage.start_height + 5,
+          get_block_hash(bmessage.blocks.at(5).block),
+          get_block_hash(bmessage.blocks.at(4).block),
+          {}
+        )
+      );
+
+      // seventh block
+      lws_test::transaction tx7 = make_carrot_tx(
+        lest_env, keys, {to_carrot_dest(account3), to_carrot_dest(keys3, {0, 2})}, cache, *tree, {carrot2_output}
+      );
+
+      static constexpr const std::uint64_t carrot3_payment = carrot2_payment / 3;
+      const auto carrot3_block_id = add(carrot2_block_id, 2);
+      const bool is_carrot3_0_change = tx7.carrot.at(0).amount != carrot3_payment;
+      const bool is_carrot3_1_change = tx7.carrot.at(1).amount != carrot3_payment;
+      const bool is_carrot3_2_change = tx7.carrot.at(2).amount != carrot3_payment;
+      const std::uint8_t carrot3_index1 = is_carrot3_0_change;
+      const std::uint8_t carrot3_index2 = 1 + std::uint8_t(is_carrot3_0_change) + is_carrot3_1_change;
+      const std::uint8_t carrot3_change_index =
+        std::uint8_t(is_carrot3_1_change) + std::uint8_t(is_carrot3_2_change) * 2;
+      const std::uint64_t carrot3_change = tx7.carrot.at(carrot3_change_index).amount;
+
+      EXPECT(carrot3_index1 <= 1);
+      EXPECT(1 <= carrot3_index2);
+      EXPECT(carrot3_index2 <= 2);
+      EXPECT(carrot3_change_index <= 2);
+      EXPECT(carrot3_change_index != carrot3_index1);
+      EXPECT(carrot3_change_index != carrot3_index2);
+      EXPECT(carrot3_index1 != carrot3_index2);
+
+      const auto miner_tx2 = make_single_enote_carrot_coinbase_transaction_v1(
+        carrot::CarrotDestinationV1{account3.spend_public, account3.view_public, false, {}},
+        miner_reward,
+        std::uint64_t(carrot3_block_id),
+        {}
+      );
+ 
+      bmessage.blocks.emplace_back();
+      bmessage.blocks.back().block.miner_tx = miner_tx2;
+      bmessage.blocks.back().block.tx_hashes.push_back(cryptonote::get_transaction_hash(tx7.tx));
+      bmessage.blocks.back().transactions.push_back(tx7.tx);
+      bmessage.output_indices.emplace_back();
+      bmessage.output_indices.back().emplace_back();
+      bmessage.output_indices.back().back().push_back(500);
+      bmessage.output_indices.back().emplace_back();
+      bmessage.output_indices.back().back().push_back(501);
+      bmessage.output_indices.back().back().push_back(502);
+      bmessage.output_indices.back().back().push_back(503);
+
+      bmessage.blocks.push_back(bmessage.blocks.back());
+      bmessage.output_indices.push_back(bmessage.output_indices.back());
+ 
       std::vector<crypto::hash> hashes{
         last_block.hash,
-        cryptonote::get_block_hash(bmessage.blocks.back().block),
+        cryptonote::get_block_hash(bmessage.blocks.front().block),
       };
       {
         cryptonote::rpc::GetHashesFast::Response hmessage{};
@@ -389,13 +1002,48 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
         }
       }
 
+      hashes.push_back(cryptonote::get_block_hash(bmessage.blocks.at(1).block));
+      hashes.push_back(cryptonote::get_block_hash(bmessage.blocks.at(2).block));
+      hashes.push_back(cryptonote::get_block_hash(bmessage.blocks.at(3).block));
+      hashes.push_back(cryptonote::get_block_hash(bmessage.blocks.at(4).block));
+      hashes.push_back(cryptonote::get_block_hash(bmessage.blocks.at(5).block));
+      hashes.push_back(cryptonote::get_block_hash(bmessage.blocks.at(6).block));
+      hashes.push_back(cryptonote::get_block_hash(bmessage.blocks.at(7).block));
+
       EXPECT(db.add_account(account, keys.m_view_secret_key));
       EXPECT(db.add_account(account2, keys2.m_view_secret_key));
+      EXPECT(db.add_account(account3_pubs, keys3.m_view_secret_key, lws::db::view_balance_key));
+      {
+        const std::vector<lws::db::subaddress_dict> indexes{
+          lws::db::subaddress_dict{
+            lws::db::major_index::primary,
+            lws::db::index_ranges{
+              {lws::db::index_range{lws::db::minor_index(1), lws::db::minor_index(2)}}
+            }
+          }
+        };
+        for (std::uint32_t i = 1; i < 4; i += 2)
+        {
+          const auto result =
+            db.upsert_subaddresses(lws::db::account_id(i), std::nullopt, indexes, 2);
+          EXPECT(result);
+          EXPECT(result->size() == 1);
+          EXPECT(result->at(0).first == lws::db::major_index::primary);
+          EXPECT(result->at(0).second.get_container().size() == 1);
+          EXPECT(result->at(0).second.get_container().at(0).size() == 2);
+          EXPECT(result->at(0).second.get_container().at(0).at(0) == lws::db::minor_index(1));
+          EXPECT(result->at(0).second.get_container().at(0).at(1) == lws::db::minor_index(2));
+        }
+
+        EXPECT(!db.upsert_subaddresses(lws::db::account_id(4), std::nullopt, indexes, 2));
+      } 
 
       messages.clear();
       messages.push_back(daemon_response(bmessage));
       bmessage.start_height = bmessage.current_height;
+      bmessage.blocks.front() = bmessage.blocks.back();
       bmessage.blocks.resize(1);
+      bmessage.output_indices.front() = bmessage.output_indices.back();
       bmessage.output_indices.resize(1);
       messages.push_back(daemon_response(bmessage));
       {
@@ -405,152 +1053,28 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
         const join on_scope_exit{server_thread};
         scanner.run(std::move(rpc), pool, 1, {}, {}, opts);
       }
-
-      hashes.push_back(cryptonote::get_block_hash(bmessage.blocks.back().block));
       lws_test::test_chain(lest_env, MONERO_UNWRAP(db.start_read()), last_block.id, epee::to_span(hashes));
 
-      const lws::db::block_id new_last_block_id = lws::db::block_id(std::uint64_t(last_block.id) + 2);
-      EXPECT(get_account().scan_height == new_last_block_id);
-      {
-        const std::map<std::pair<lws::db::output_id, std::uint32_t>, lws::db::output> expected{
-          {
-            {lws::db::output_id{0, 100}, 35184372088830}, lws::db::output{
-              lws::db::transaction_link{new_last_block_id, cryptonote::get_transaction_hash(tx.tx)},
-              lws::db::output::spend_meta_{
-                lws::db::output_id{0, 100}, 35184372088830, 0, 0, tx.pub_keys.at(0)
-              },
-              0,
-              0,
-              cryptonote::get_transaction_prefix_hash(tx.tx),
-              tx.spend_publics.at(0),
-              rct::commit(35184372088830, rct::identity()),
-              {},
-              lws::db::pack(lws::db::extra(lws::db::extra::coinbase_output | lws::db::extra::ringct_output), 0),
-              {},
-              0, // fee
-              lws::db::address_index{}
-            },
-          },
-          {
-            {lws::db::output_id{0, 101}, 8000}, lws::db::output{
-              lws::db::transaction_link{new_last_block_id, cryptonote::get_transaction_hash(tx2.tx)},
-              lws::db::output::spend_meta_{
-                lws::db::output_id{0, 101}, 8000, 15, 0, tx2.pub_keys.at(0)
-              },
-              0,
-              0,
-              cryptonote::get_transaction_prefix_hash(tx2.tx),
-              tx2.spend_publics.at(0),
-              tx2.tx.rct_signatures.outPk.at(0).mask,
-              {},
-              lws::db::pack(lws::db::extra::ringct_output, 8),
-              {},
-              12000, // fee
-              lws::db::address_index{}
-            },
-          },
-	        {
-            {lws::db::output_id{0, 102}, 8000}, lws::db::output{
-              lws::db::transaction_link{new_last_block_id, cryptonote::get_transaction_hash(tx3.tx)},
-              lws::db::output::spend_meta_{
-                lws::db::output_id{0, 102}, 8000, 15, 0, tx3.pub_keys.at(0)
-              },
-              0,
-              0,
-              cryptonote::get_transaction_prefix_hash(tx3.tx),
-              tx3.spend_publics.at(0),
-              tx3.tx.rct_signatures.outPk.at(0).mask,
-              {},
-              lws::db::pack(lws::db::extra::ringct_output, 8),
-              {},
-              12000, // fee
-              lws::db::address_index{}
-            },
-          },
-          {
-            {lws::db::output_id{0, 200}, 8000}, lws::db::output{
-              lws::db::transaction_link{new_last_block_id, cryptonote::get_transaction_hash(tx4.tx)},
-              lws::db::output::spend_meta_{
-                lws::db::output_id{0, 200}, 8000, 15, 0, tx4.pub_keys.at(0)
-              },
-              0,
-              0,
-              cryptonote::get_transaction_prefix_hash(tx4.tx),
-              tx4.spend_publics.at(0),
-              tx4.tx.rct_signatures.outPk.at(0).mask,
-              {},
-              lws::db::pack(lws::db::extra::ringct_output, 8),
-              {},
-              10000, // fee
-              lws::db::address_index{}
-            }
-          },
-          {
-            {lws::db::output_id{0, 201}, 8000}, lws::db::output{
-              lws::db::transaction_link{new_last_block_id, cryptonote::get_transaction_hash(tx4.tx)},
-              lws::db::output::spend_meta_{
-                lws::db::output_id{0, 201}, 8000, 15, 1, tx4.pub_keys.at(0)
-              },
-              0,
-              0,
-              cryptonote::get_transaction_prefix_hash(tx4.tx),
-              tx4.spend_publics.at(1),
-              tx4.tx.rct_signatures.outPk.at(1).mask,
-              {},
-              lws::db::pack(lws::db::extra::ringct_output, 8),
-              {},
-              10000, // fee
-              lws::db::address_index{}
-            }
-          },
-          {
-            {lws::db::output_id{0, 200}, 2000}, lws::db::output{
-              lws::db::transaction_link{new_last_block_id, cryptonote::get_transaction_hash(tx4.tx)},
-              lws::db::output::spend_meta_{
-                lws::db::output_id{0, 200}, 2000, 15, 0, tx4.pub_keys.at(0)
-              },
-              0,
-              0,
-              cryptonote::get_transaction_prefix_hash(tx4.tx),
-              tx4.spend_publics.at(0),
-              tx4.tx.rct_signatures.outPk.at(0).mask,
-              {},
-              lws::db::pack(lws::db::extra::ringct_output, 8),
-              {},
-              10000, // fee
-              lws::db::address_index{lws::db::major_index::primary, lws::db::minor_index(1)}
-            }
-          },
-          {
-            {lws::db::output_id{0, 201}, 2000}, lws::db::output{
-              lws::db::transaction_link{new_last_block_id, cryptonote::get_transaction_hash(tx4.tx)},
-              lws::db::output::spend_meta_{
-                lws::db::output_id{0, 201}, 2000, 15, 1, tx4.pub_keys.at(0)
-              },
-              0,
-              0,
-              cryptonote::get_transaction_prefix_hash(tx4.tx),
-              tx4.spend_publics.at(1),
-              tx4.tx.rct_signatures.outPk.at(1).mask,
-              {},
-              lws::db::pack(lws::db::extra::ringct_output, 8),
-              {},
-              10000, // fee
-              lws::db::address_index{lws::db::major_index::primary, lws::db::minor_index(1)}
-            }
-          }
-        };
+      EXPECT(get_account().scan_height == add(carrot3_block_id, 1));
 
-        auto reader = MONERO_UNWRAP(db.start_read());
-        auto outputs = MONERO_UNWRAP(reader.get_outputs(lws::db::account_id(1)));
-        EXPECT(outputs.count() == 5);
+      using expected_map = std::map<std::tuple<lws::db::output_id, std::uint32_t, std::uint32_t>, lws::db::output>; 
+      auto reader = MONERO_UNWRAP(db.start_read());
+
+      const auto verify_outputs = [&lest_env, &reader] (const lws::db::account_id id, const std::size_t count, const expected_map& expected)
+      {
+        auto outputs = MONERO_UNWRAP(reader.get_outputs(id));
+        EXPECT(count <= expected.size());
+        EXPECT(outputs.count() == count);
+
+        std::set<lws::db::output_id> matched;
         auto output_it = outputs.make_iterator();
         for (auto output_it = outputs.make_iterator(); !output_it.is_end(); ++output_it)
         {
           auto real_output = *output_it;
           const auto expected_output =
-            expected.find(std::make_pair(real_output.spend_meta.id, real_output.spend_meta.amount));
+            expected.find(std::make_tuple(real_output.spend_meta.id, std::uint32_t(real_output.recipient.maj_i), std::uint32_t(real_output.recipient.min_i)));
           EXPECT(expected_output != expected.end());
+          EXPECT(matched.insert(real_output.spend_meta.id).second);
 
           EXPECT(real_output.link.height == expected_output->second.link.height);
           EXPECT(real_output.link.tx_hash == expected_output->second.link.tx_hash);
@@ -561,44 +1085,350 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
           EXPECT(real_output.tx_prefix_hash == expected_output->second.tx_prefix_hash);
           EXPECT(real_output.spend_meta.tx_public == expected_output->second.spend_meta.tx_public);
           EXPECT(real_output.pub == expected_output->second.pub);
-          EXPECT(rct::commit(real_output.spend_meta.amount, real_output.ringct_mask) == expected_output->second.ringct_mask);
+          EXPECT(real_output.ringct_mask == expected_output->second.ringct_mask);
           EXPECT(real_output.extra == expected_output->second.extra);
           if (unpack(expected_output->second.extra).second == 8)
             EXPECT(real_output.payment_id.short_ == expected_output->second.payment_id.short_);
           EXPECT(real_output.fee == expected_output->second.fee);
           EXPECT(real_output.recipient == expected_output->second.recipient);
+          EXPECT(real_output.first_image == expected_output->second.first_image);
+          EXPECT(real_output.anchor == expected_output->second.anchor);
         }
+      };
 
-        auto spends = MONERO_UNWRAP(reader.get_spends(lws::db::account_id(1)));
-        EXPECT(spends.count() == 2);
-        auto spend_it = spends.make_iterator();
-        EXPECT(!spend_it.is_end());
+      {
+        const expected_map expected_account1{
+          {
+            {lws::db::output_id{0, 100}, 0, 0}, legacy_output 
+          },
+          {
+            {lws::db::output_id{0, 101}, 0, 0}, lws::db::output{
+              lws::db::transaction_link{legacy_block_id, cryptonote::get_transaction_hash(tx2.tx)},
+              lws::db::output::spend_meta_{
+                lws::db::output_id{0, 101}, 8000, 15, 0, tx2.pub_keys.at(0)
+              },
+              0,
+              0,
+              cryptonote::get_transaction_prefix_hash(tx2.tx),
+              tx2.spend_publics.at(0),
+              tx2.ringct.at(0),
+              {},
+              lws::db::pack(lws::db::extra::ringct_output, 8),
+              {},
+              12000, // fee
+              lws::db::address_index{}
+            },
+          },
+	        {
+            {lws::db::output_id{0, 102}, 0, 0}, lws::db::output{
+              lws::db::transaction_link{legacy_block_id, cryptonote::get_transaction_hash(tx3.tx)},
+              lws::db::output::spend_meta_{
+                lws::db::output_id{0, 102}, 8000, 15, 0, tx3.pub_keys.at(0)
+              },
+              0,
+              0,
+              cryptonote::get_transaction_prefix_hash(tx3.tx),
+              tx3.spend_publics.at(0),
+              tx3.ringct.at(0),
+              {},
+              lws::db::pack(lws::db::extra::ringct_output, 8),
+              {},
+              12000, // fee
+              lws::db::address_index{}
+            },
+          },
+          {
+            {lws::db::output_id{0, 200}, 0, 0}, lws::db::output{
+              lws::db::transaction_link{legacy_block_id, cryptonote::get_transaction_hash(tx4.tx)},
+              lws::db::output::spend_meta_{
+                lws::db::output_id{0, 200}, 8000, 15, 0, tx4.pub_keys.at(0)
+              },
+              0,
+              0,
+              cryptonote::get_transaction_prefix_hash(tx4.tx),
+              tx4.spend_publics.at(0),
+              tx4.ringct.at(0),
+              {},
+              lws::db::pack(lws::db::extra::ringct_output, 8),
+              {},
+              10000, // fee
+              lws::db::address_index{}
+            }
+          },
+          {
+            {lws::db::output_id{0, 201}, 0, 0}, lws::db::output{
+              lws::db::transaction_link{legacy_block_id, cryptonote::get_transaction_hash(tx4.tx)},
+              lws::db::output::spend_meta_{
+                lws::db::output_id{0, 201}, 8000, 15, 1, tx4.pub_keys.at(0)
+              },
+              0,
+              0,
+              cryptonote::get_transaction_prefix_hash(tx4.tx),
+              tx4.spend_publics.at(1),
+              tx4.ringct.at(1),
+              {},
+              lws::db::pack(lws::db::extra::ringct_output, 8),
+              {},
+              10000, // fee
+              lws::db::address_index{}
+            }
+          },
+          {
+            {lws::db::output_id{0, 200}, 0, 1}, lws::db::output{
+              lws::db::transaction_link{legacy_block_id, cryptonote::get_transaction_hash(tx4.tx)},
+              lws::db::output::spend_meta_{
+                lws::db::output_id{0, 200}, 2000, 15, 0, tx4.pub_keys.at(0)
+              },
+              0,
+              0,
+              cryptonote::get_transaction_prefix_hash(tx4.tx),
+              tx4.spend_publics.at(0),
+              tx4.ringct.at(0),
+              {},
+              lws::db::pack(lws::db::extra::ringct_output, 8),
+              {},
+              10000, // fee
+              lws::db::address_index{lws::db::major_index::primary, lws::db::minor_index(1)}
+            }
+          },
+          {
+            {lws::db::output_id{0, 201}, 0, 1}, lws::db::output{
+              lws::db::transaction_link{legacy_block_id, cryptonote::get_transaction_hash(tx4.tx)},
+              lws::db::output::spend_meta_{
+                lws::db::output_id{0, 201}, 2000, 15, 1, tx4.pub_keys.at(0)
+              },
+              0,
+              0,
+              cryptonote::get_transaction_prefix_hash(tx4.tx),
+              tx4.spend_publics.at(1),
+              tx4.ringct.at(1),
+              {},
+              lws::db::pack(lws::db::extra::ringct_output, 8),
+              {},
+              10000, // fee
+              lws::db::address_index{lws::db::major_index::primary, lws::db::minor_index(1)}
+            }
+          },
+          {
+            {lws::db::output_id{0, std::uint64_t(301 + !carrot1_index)}, 0, 0}, lws::db::output{
+              lws::db::transaction_link{carrot1_block_id, cryptonote::get_transaction_hash(tx5.tx)},
+              lws::db::output::spend_meta_{
+                lws::db::output_id{0, std::uint64_t(301 + !carrot1_index)},
+                carrot1_change,
+                lws::db::carrot_external,
+                std::uint32_t(!carrot1_index),
+                carrot::raw_byte_convert<crypto::public_key>(
+                  tx5.carrot.at(!carrot1_index).enote.enote_ephemeral_pubkey
+                )
+              },
+              0,
+              0,
+              cryptonote::get_transaction_prefix_hash(tx5.tx),
+              tx5.carrot.at(!carrot1_index).enote.onetime_address,
+              rct::sk2rct(tx5.carrot.at(!carrot1_index).amount_blinding_factor),
+              {},
+              lws::db::pack(lws::db::extra::ringct_output, 8),
+              {},
+              612000000, // fee
+              lws::db::address_index{},
+              tx5.carrot.at(!carrot1_index).enote.tx_first_key_image,
+              tx5.carrot.at(!carrot1_index).enote.anchor_enc
+            }
+          },
+          {
+            {lws::db::output_id{0, std::uint64_t(401 + carrot2_index)}, 0, 0}, carrot2_output
+          },
+          {
+            {lws::db::output_id{0, std::uint64_t(501 + carrot3_change_index)}, 0, 0}, lws::db::output{
+              lws::db::transaction_link{carrot3_block_id, cryptonote::get_transaction_hash(tx7.tx)},
+              lws::db::output::spend_meta_{
+                lws::db::output_id{0, std::uint64_t(501 + carrot3_change_index)},
+                carrot3_change,
+                lws::db::carrot_external,
+                std::uint32_t(carrot3_change_index),
+                carrot::raw_byte_convert<crypto::public_key>(
+                  tx7.carrot.at(carrot3_change_index).enote.enote_ephemeral_pubkey
+                )
+              },
+              0,
+              0,
+              cryptonote::get_transaction_prefix_hash(tx7.tx),
+              tx7.carrot.at(carrot3_change_index).enote.onetime_address,
+              rct::sk2rct(tx7.carrot.at(carrot3_change_index).amount_blinding_factor),
+              {},
+              lws::db::pack(lws::db::extra::ringct_output, 8),
+              {},
+              629760000, // fee
+              lws::db::address_index{},
+              tx7.carrot.at(carrot3_change_index).enote.tx_first_key_image,
+              tx7.carrot.at(carrot3_change_index).enote.anchor_enc
+            }
+          }
+        };
 
-        auto real_spend = *spend_it;
-        EXPECT(real_spend.link.height == new_last_block_id);
-        EXPECT(real_spend.link.tx_hash == cryptonote::get_transaction_hash(tx3.tx));
-        lws::db::output_id expected_out{0, 100};
-        EXPECT(real_spend.source == expected_out);
-        EXPECT(real_spend.mixin_count == 15);
-        EXPECT(real_spend.length == 0);
-        EXPECT(real_spend.payment_id == crypto::hash{});
-        EXPECT(real_spend.sender == lws::db::address_index{});
-
-        ++spend_it;
-        EXPECT(!spend_it.is_end());
-
-        real_spend = *spend_it;
-        EXPECT(real_spend.link.height == new_last_block_id);
-        EXPECT(real_spend.link.tx_hash == cryptonote::get_transaction_hash(tx3.tx));
-        expected_out = lws::db::output_id{0, 101};
-        EXPECT(real_spend.source == expected_out);
-        EXPECT(real_spend.mixin_count == 15);
-        EXPECT(real_spend.length == 0);
-        EXPECT(real_spend.payment_id == crypto::hash{});
-        EXPECT(real_spend.sender == lws::db::address_index{});
-
-        EXPECT(MONERO_UNWRAP(reader.get_outputs(lws::db::account_id(2))).count() == 0);
-        EXPECT(MONERO_UNWRAP(reader.get_spends(lws::db::account_id(2))).count() == 0);
+        verify_outputs(lws::db::account_id(1), 8, expected_account1);
+      }
+      { 
+        const expected_map expected_account3{
+          {
+            {lws::db::output_id{0, std::uint64_t(301 + carrot1_index)}, 0, 0}, carrot1_output
+          },
+          {
+            {lws::db::output_id{0, std::uint64_t(401 + !carrot2_index)}, 0, 0}, lws::db::output{
+              lws::db::transaction_link{carrot2_block_id, cryptonote::get_transaction_hash(tx6.tx)},
+              lws::db::output::spend_meta_{
+                lws::db::output_id{0, std::uint64_t(401 + !carrot2_index)},
+                carrot2_change,
+                lws::db::carrot_internal,
+                std::uint32_t(!carrot2_index),
+                carrot::raw_byte_convert<crypto::public_key>(
+                  tx6.carrot.at(!carrot2_index).enote.enote_ephemeral_pubkey
+                )
+              },
+              0,
+              0,
+              cryptonote::get_transaction_prefix_hash(tx6.tx),
+              tx6.carrot.at(!carrot2_index).enote.onetime_address,
+              rct::sk2rct(tx6.carrot.at(!carrot2_index).amount_blinding_factor),
+              {},
+              lws::db::pack(lws::db::extra::ringct_output, 0),
+              {},
+              612000000, // fee
+              lws::db::address_index{},
+              tx6.carrot.at(!carrot2_index).enote.tx_first_key_image,
+              tx6.carrot.at(!carrot2_index).enote.anchor_enc
+            }
+          },
+          {
+            {lws::db::output_id{0, std::uint64_t(500)}, 0, 0}, lws::db::output{
+              lws::db::transaction_link{carrot3_block_id, cryptonote::get_transaction_hash(miner_tx2)},
+              lws::db::output::spend_meta_{
+                lws::db::output_id{0, std::uint64_t(500)},
+                miner_reward,
+                lws::db::carrot_external,
+                std::uint32_t(0),
+                get_tx_pub_key_from_extra(miner_tx2),
+              },
+              0,
+              0,
+              cryptonote::get_transaction_prefix_hash(miner_tx2),
+              boost::get<cryptonote::txout_to_carrot_v1>(miner_tx2.vout.at(0).target).key,
+              rct::identity(),
+              {},
+              lws::db::pack(lws::db::extra(lws::db::ringct_output | lws::db::coinbase_output), 0),
+              {},
+              0, // fee
+              lws::db::address_index{},
+              crypto::key_image{},
+              boost::get<cryptonote::txout_to_carrot_v1>(miner_tx2.vout.at(0).target).encrypted_janus_anchor
+            }
+          },
+          {
+            {lws::db::output_id{0, std::uint64_t(501 + carrot3_index1)}, 0, 0}, lws::db::output{
+              lws::db::transaction_link{carrot3_block_id, cryptonote::get_transaction_hash(tx7.tx)},
+              lws::db::output::spend_meta_{
+                lws::db::output_id{0, std::uint64_t(501 + carrot3_index1)},
+                carrot3_payment,
+                lws::db::carrot_external,
+                std::uint32_t(carrot3_index1),
+                carrot::raw_byte_convert<crypto::public_key>(
+                  tx7.carrot.at(carrot3_index1).enote.enote_ephemeral_pubkey
+                )
+              },
+              0,
+              0,
+              cryptonote::get_transaction_prefix_hash(tx7.tx),
+              tx7.carrot.at(carrot3_index1).enote.onetime_address,
+              rct::sk2rct(tx7.carrot.at(carrot3_index1).amount_blinding_factor),
+              {},
+              lws::db::pack(lws::db::extra::ringct_output, 8),
+              {},
+              629760000, // fee
+              lws::db::address_index{},
+              tx7.carrot.at(carrot3_index1).enote.tx_first_key_image,
+              tx7.carrot.at(carrot3_index1).enote.anchor_enc
+            }
+          },
+          {
+            {lws::db::output_id{0, std::uint64_t(501 + carrot3_index1)}, 0, 2}, lws::db::output{
+              lws::db::transaction_link{carrot3_block_id, cryptonote::get_transaction_hash(tx7.tx)},
+              lws::db::output::spend_meta_{
+                lws::db::output_id{0, std::uint64_t(501 + carrot3_index1)},
+                carrot3_payment,
+                lws::db::carrot_external,
+                std::uint32_t(carrot3_index1),
+                carrot::raw_byte_convert<crypto::public_key>(
+                  tx7.carrot.at(carrot3_index1).enote.enote_ephemeral_pubkey
+                )
+              },
+              0,
+              0,
+              cryptonote::get_transaction_prefix_hash(tx7.tx),
+              tx7.carrot.at(carrot3_index1).enote.onetime_address,
+              rct::sk2rct(tx7.carrot.at(carrot3_index1).amount_blinding_factor),
+              {},
+              lws::db::pack(lws::db::extra::ringct_output, 8),
+              {},
+              629760000, // fee
+              {lws::db::major_index(0), lws::db::minor_index(2)},
+              tx7.carrot.at(carrot3_index1).enote.tx_first_key_image,
+              tx7.carrot.at(carrot3_index1).enote.anchor_enc
+            }
+          },
+          {
+            {lws::db::output_id{0, std::uint64_t(501 + carrot3_index2)}, 0, 0}, lws::db::output{
+              lws::db::transaction_link{carrot3_block_id, cryptonote::get_transaction_hash(tx7.tx)},
+              lws::db::output::spend_meta_{
+                lws::db::output_id{0, std::uint64_t(501 + carrot3_index2)},
+                carrot3_payment,
+                lws::db::carrot_external,
+                std::uint32_t(carrot3_index2),
+                carrot::raw_byte_convert<crypto::public_key>(
+                  tx7.carrot.at(carrot3_index2).enote.enote_ephemeral_pubkey
+                )
+              },
+              0,
+              0,
+              cryptonote::get_transaction_prefix_hash(tx7.tx),
+              tx7.carrot.at(carrot3_index2).enote.onetime_address,
+              rct::sk2rct(tx7.carrot.at(carrot3_index2).amount_blinding_factor),
+              {},
+              lws::db::pack(lws::db::extra::ringct_output, 8),
+              {},
+              629760000, // fee
+              lws::db::address_index{},
+              tx7.carrot.at(carrot3_index2).enote.tx_first_key_image,
+              tx7.carrot.at(carrot3_index2).enote.anchor_enc
+            }
+          },
+          {
+            {lws::db::output_id{0, std::uint64_t(501 + carrot3_index2)}, 0, 2}, lws::db::output{
+              lws::db::transaction_link{carrot3_block_id, cryptonote::get_transaction_hash(tx7.tx)},
+              lws::db::output::spend_meta_{
+                lws::db::output_id{0, std::uint64_t(501 + carrot3_index2)},
+                carrot3_payment,
+                lws::db::carrot_external,
+                std::uint32_t(carrot3_index2),
+                carrot::raw_byte_convert<crypto::public_key>(
+                  tx7.carrot.at(carrot3_index2).enote.enote_ephemeral_pubkey
+                )
+              },
+              0,
+              0,
+              cryptonote::get_transaction_prefix_hash(tx7.tx),
+              tx7.carrot.at(carrot3_index2).enote.onetime_address,
+              rct::sk2rct(tx7.carrot.at(carrot3_index2).amount_blinding_factor),
+              {},
+              lws::db::pack(lws::db::extra::ringct_output, 8),
+              {},
+              629760000, // fee
+              {lws::db::major_index(0), lws::db::minor_index(2)},
+              tx7.carrot.at(carrot3_index2).enote.tx_first_key_image,
+              tx7.carrot.at(carrot3_index2).enote.anchor_enc
+            }
+          }
+        };
+        verify_outputs(lws::db::account_id(3), 5, expected_account3);
       }
     } //SECTION (lws::scanner::run (with upsert))
 
@@ -938,7 +1768,6 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
             }
           }
         };
-
         auto reader = MONERO_UNWRAP(db.start_read());
         auto outputs = MONERO_UNWRAP(reader.get_outputs(lws::db::account_id(1)));
         EXPECT(outputs.count() == 6);

--- a/tests/unit/util/transaction.test.cpp
+++ b/tests/unit/util/transaction.test.cpp
@@ -27,6 +27,7 @@
 
 #include "transaction.test.h"
 
+#include "carrot_core/payment_proposal.h"        // monero/src
 #include "crypto/crypto.h"                       // monero/src
 #include "cryptonote_basic/account.h"            // monero/src
 #include "cryptonote_core/cryptonote_tx_utils.h" // monero/src

--- a/tests/unit/util/transaction.test.h
+++ b/tests/unit/util/transaction.test.h
@@ -34,6 +34,7 @@
 #include "db/fwd.h"
 #include "lest.hpp"
 
+namespace carrot { struct RCTOutputEnoteProposal; }
 namespace cryptonote
 {
   class account_keys;
@@ -53,6 +54,7 @@ namespace lws_test
     std::vector<crypto::public_key> spend_publics;
     std::vector<crypto::key_image> images;
     std::vector<rct::key> ringct;
+    std::vector<carrot::RCTOutputEnoteProposal> carrot;
   };
 
   transaction make_miner_tx(lest::env& lest_env, lws::db::block_id height, const lws::db::account_address& miner_address, bool use_view_tags);


### PR DESCRIPTION
This is a draft for the carrot/fcmp++ changes that are upcoming. The CI should fail initially, as this only works with the [fcmp++ branch](https://github.com/seraphis-migration/monero/tree/fcmp%2B%2B-stage) of Monero. This PR will be in draft status until fcmp++ code is merged into the Monero repo, and then proper CI will run.

### Latest Status 2026/04/02

The unit tests indicate that legacy, view-incoming, and view-balance key scanning works with incoming carrot/fcmp++ XMR, which is useful for xmrchat et al which need real-time reporting. The same tests also verify that legacy and view-balance keys detect spends, making lws useful for displaying the balance of recovered wallets.  This branch now supports the newest changes to the key-image generation.

This PR also provides a new REST endpoint: `get_tree_paths`. That endpoint takes "legacy" output ids or new "unified" output ids, and returns everything needed to construct a fcmp++ tree needed for transaction construction. In other words, this PR is fully ready for fcmp++ receiving and spending.