### PR TITLE
Add regtest option

### DIFF
--- a/src/client_main.cpp
+++ b/src/client_main.cpp
@@ -246,7 +246,7 @@ namespace
 
         if (!users.empty())
         {
-          static constexpr const lws::scanner_options opts{false, false};
+          static constexpr const lws::scanner_options opts{false, false, false};
 
           auto new_client = MONERO_UNWRAP(zclient.clone());
           MONERO_UNWRAP(new_client.watch_scan_signals());

--- a/src/db/storage.cpp
+++ b/src/db/storage.cpp
@@ -1729,12 +1729,12 @@ namespace db
     });
   }
 
-  expect<void> storage::sync_chain(block_id height, epee::span<const crypto::hash> hashes)
+  expect<void> storage::sync_chain(block_id height, epee::span<const crypto::hash> hashes, bool regtest)
   {
     MONERO_PRECOND(!hashes.empty());
     MONERO_PRECOND(db != nullptr);
 
-    return db->try_write([this, height, hashes] (MDB_txn& txn) -> expect<void>
+    return db->try_write([this, height, hashes, regtest] (MDB_txn& txn) -> expect<void>
     {
       cursor::blocks blocks_cur;
       MONERO_CHECK(check_cursor(txn, this->db->tables.blocks, blocks_cur));
@@ -1767,7 +1767,7 @@ namespace db
 
         if (*hash != chain.front())
         {
-          if (current <= get_checkpoints().get_max_height())
+          if (!regtest && current <= get_checkpoints().get_max_height())
           {
             /* Either the daemon is performing an attack with a fake chain, or
               the daemon is still syncing. */

--- a/src/db/storage.h
+++ b/src/db/storage.h
@@ -235,7 +235,7 @@ namespace db
 
       \return True if the local blockchain is correctly synced.
     */
-    expect<void> sync_chain(block_id height, epee::span<const crypto::hash> hashes);
+    expect<void> sync_chain(block_id height, epee::span<const crypto::hash> hashes, bool regtest);
 
     expect<void> sync_pow(block_id height, epee::span<const crypto::hash> hashes, epee::span<const pow_sync> pow);
 

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -1100,7 +1100,7 @@ namespace lws
     }
 
     // does not validate blockchain hashes
-    expect<rpc::client> sync_quick(scanner_sync& self, db::storage disk, rpc::client client)
+    expect<rpc::client> sync_quick(scanner_sync& self, db::storage disk, rpc::client client, bool regtest)
     {
       MINFO("Starting blockchain sync with daemon");
 
@@ -1123,7 +1123,7 @@ namespace lws
         if (resp->hashes.size() <= 1 || resp->hashes.back() == req.known_hashes.front())
           return {std::move(client)};
 
-        MONERO_CHECK(disk.sync_chain(db::block_id(resp->start_height), epee::to_span(resp->hashes)));
+        MONERO_CHECK(disk.sync_chain(db::block_id(resp->start_height), epee::to_span(resp->hashes), regtest));
 
         req.known_hashes.erase(req.known_hashes.begin(), --(req.known_hashes.end()));
         for (std::size_t num = 0; num < 10; ++num)
@@ -1302,13 +1302,13 @@ namespace lws
     return store(io, disk_, client, webhook, chain, users, pow);
   } 
 
-  expect<rpc::client> scanner::sync(rpc::client client, const bool untrusted_daemon)
+  expect<rpc::client> scanner::sync(rpc::client client, const bool untrusted_daemon, const bool regtest)
   {
     if (has_shutdown())
       MONERO_THROW(common_error::kInvalidArgument, "this has shutdown");
     if (untrusted_daemon)
       return sync_full(sync_, disk_.clone(), std::move(client));
-    return sync_quick(sync_, disk_.clone(), std::move(client));
+    return sync_quick(sync_, disk_.clone(), std::move(client), regtest);
   }
 
   void scanner::run(rpc::context ctx, std::size_t thread_count, const std::string& lws_server_addr, std::string lws_server_pass, const scanner_options& opts)

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -47,6 +47,7 @@ namespace lws
   {
     bool enable_subaddresses;
     bool untrusted_daemon;
+    bool regtest;
   };
 
   //! Used in `scan_loop` by server
@@ -119,7 +120,7 @@ namespace lws
     static bool loop(scanner_sync& self, store_func store, std::optional<db::storage> disk, rpc::client client, std::vector<lws::account> users, rpc::scanner::queue& queue, const scanner_options& opts, bool leader_thread);
     
     //! Use `client` to sync blockchain data, and \return client if successful.
-    expect<rpc::client> sync(rpc::client client, const bool untrusted_daemon = false);
+    expect<rpc::client> sync(rpc::client client, const bool untrusted_daemon = false, const bool regtest = false);
 
     //! Poll daemon until `shutdown()` is called, using `thread_count` threads.
     void run(rpc::context ctx, std::size_t thread_count, const std::string& server_addr, std::string server_pass, const scanner_options&);

--- a/tests/unit/db/chain.test.cpp
+++ b/tests/unit/db/chain.test.cpp
@@ -89,9 +89,9 @@ LWS_CASE("db::storage::sync_chain")
     };
 
     EXPECT(db.add_account(account, view));
-    EXPECT(db.sync_chain(lws::db::block_id(0), chain) == lws::error::bad_blockchain);
-    EXPECT(db.sync_chain(last_block.id, {chain + 1, 4}) == lws::error::bad_blockchain);
-    EXPECT(db.sync_chain(last_block.id, chain));
+    EXPECT(db.sync_chain(lws::db::block_id(0), chain, false) == lws::error::bad_blockchain);
+    EXPECT(db.sync_chain(last_block.id, {chain + 1, 4}, false) == lws::error::bad_blockchain);
+    EXPECT(db.sync_chain(last_block.id, chain, false));
 
     {
       const lws::account accounts[1] = {lws::account{get_account(), {}, {}}};
@@ -125,7 +125,7 @@ LWS_CASE("db::storage::sync_chain")
         crypto::rand<crypto::hash>()
       };
 
-      EXPECT(db.sync_chain(last_block.id, fchain));
+      EXPECT(db.sync_chain(last_block.id, fchain, false));
       lws_test::test_chain(lest_env, MONERO_UNWRAP(db.start_read()), last_block.id, fchain);
       EXPECT(get_account().scan_height == fork_height);
 
@@ -147,7 +147,7 @@ LWS_CASE("db::storage::sync_chain")
         crypto::rand<crypto::hash>()
       };
 
-      const auto sync_result = db.sync_chain(lws::db::block_id(point->first), fchain);
+      const auto sync_result = db.sync_chain(lws::db::block_id(point->first), fchain, false);
       EXPECT(sync_result == lws::error::bad_blockchain);
       EXPECT(get_account().scan_height == scan_height);
 


### PR DESCRIPTION
This PR adds a new `regtest` option in order to disable checkpoints check at storage::sync_chain when running a `monerod` in regtest mode, useful in testing environments.