### PR TITLE
Add from_height to /import_wallet_request

### DIFF
--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -1300,7 +1300,7 @@ namespace lws
 
     struct import_request
     {
-      using request = rpc::account_credentials;
+      using request = rpc::import_request;
       using response = rpc::import_response;
 
       static expect<response> handle(request req, connection_data& data, std::function<async_complete>&&)
@@ -1308,17 +1308,17 @@ namespace lws
         bool new_request = false;
         bool fulfilled = false;
         {
-          auto user = open_account(req, data.global->disk.clone());
+          auto user = open_account(req.creds, data.global->disk.clone());
           if (!user)
             return user.error();
 
           data.passed_login = true;
-          if (user->first.start_height == db::block_id(0))
+          if (user->first.start_height <= db::block_id(req.from_height))
             fulfilled = true;
           else
           {
             const expect<db::request_info> info =
-              user->second.get_request(db::request::import_scan, req.address);
+              user->second.get_request(db::request::import_scan, req.creds.address);
 
             if (!info)
             {
@@ -1331,7 +1331,7 @@ namespace lws
         } // close reader
 
         if (new_request)
-          MONERO_CHECK(data.global->disk.clone().import_request(req.address, db::block_id(0)));
+          MONERO_CHECK(data.global->disk.clone().import_request(req.creds.address, db::block_id(req.from_height)));
 
         const char* status = new_request ?
           "Accepted, waiting for approval" : (fulfilled ? "Approved" : "Waiting for Approval");

--- a/src/rpc/light_wallet.cpp
+++ b/src/rpc/light_wallet.cpp
@@ -48,6 +48,7 @@
 #include "wire/traits.h"
 #include "wire/vector.h"
 #include "wire/wrapper/array.h"
+#include "wire/wrapper/defaulted.h"
 #include "wire/wrappers_impl.h"
 
 namespace
@@ -359,6 +360,17 @@ namespace lws
       wire::optional_field("outputs", wire::array(boost::adaptors::transform(self.outputs, expand))),
       WIRE_FIELD(fees)
     );
+  }
+
+  void rpc::read_bytes(wire::json_reader& source, import_request& self)
+  {
+    std::string address;
+    wire::object(source,
+      wire::field("address", std::ref(address)),
+      wire::field("view_key", std::ref(unwrap(unwrap(self.creds.key)))),
+      WIRE_FIELD_DEFAULTED(from_height, unsigned(0))
+    );
+    convert_address(address, self.creds.address);
   }
 
   void rpc::write_bytes(wire::json_writer& dest, const import_response& self)

--- a/src/rpc/light_wallet.h
+++ b/src/rpc/light_wallet.h
@@ -224,6 +224,14 @@ namespace rpc
   void write_bytes(wire::json_writer&, const get_subaddrs_response&);
 
 
+  struct import_request
+  {
+    import_request() = delete;
+    account_credentials creds;
+    std::uint64_t from_height;
+  };
+  void read_bytes(wire::json_reader&, import_request&);
+
   struct import_response
   {
     import_response() = delete;


### PR DESCRIPTION
This is one half of the new proposal monero-project/meta#1228 for updating `/import_wallet_request`. This should make real-usage wallets much faster.