### PR TITLE
Hopefully fix issue with db corruption (bad data size)

### DIFF
--- a/src/db/storage.cpp
+++ b/src/db/storage.cpp
@@ -2975,6 +2975,7 @@ namespace db
           auto old_dict = subaddress_ranges.get_value(value);
           if (!old_dict)
             return old_dict.error();
+          mdb_cursor_del(ranges_cur.get(), 0); // updated at end
 
           auto& old_range = old_dict->second.get_container();
           const auto& new_range = major_entry.second.get_container();
@@ -3043,7 +3044,9 @@ namespace db
 
             value = lmdb::to_val(new_value);
 
-            MONERO_LMDB_CHECK(mdb_cursor_put(indexes_cur.get(), &key, &value, 0));
+            const int err = mdb_cursor_put(indexes_cur.get(), &key, &value, MDB_NODUPDATA);
+            if (err && err != MDB_KEYEXIST)
+              return {lmdb::error(err)};
           }
         }
 
@@ -3052,7 +3055,7 @@ namespace db
         if (!value_bytes)
           return value_bytes.error();
         value = MDB_val{value_bytes->size(), const_cast<void*>(static_cast<const void*>(value_bytes->data()))};
-        MONERO_LMDB_CHECK(mdb_cursor_put(ranges_cur.get(), &key, &value, 0));
+        MONERO_LMDB_CHECK(mdb_cursor_put(ranges_cur.get(), &key, &value, MDB_NODUPDATA));
       }
 
       return {std::move(out)};


### PR DESCRIPTION
#196 showed up while I was working on subaddress lookahead. This time the corruption was slightly different. I noticed that the msgpack data was truncated once again, but this time it was definitely truncated to the size of the prior entry. After investigating LMDB code, I noticed that duplicate key+data entries are treated identically to `MDB_CURRENT`, which is to say that it seems (in certain situations) to assume the key+data entries are identical in size.

Admittedly I've had difficultly triggering this on command, so this patch might be a little dodgy. OTOH, my use of duplicate keys needed some upgrading, in that `MDB_NODUPDATA` needs to be present to ensure we don't end up with duplicate key+data entries.

The unit tests exercise this good fairly well, so there shouldn't introduce a new db bug as result of changes.