### PR TITLE
Fix locked_funds computation

### DIFF
--- a/src/db/data.h
+++ b/src/db/data.h
@@ -75,6 +75,9 @@ namespace db
   };
   WIRE_AS_INTEGER(block_id);
 
+  inline constexpr std::uint64_t to_uint(const block_id src) noexcept
+  { return std::uint64_t(src); }
+
   //! References a global output number, as determined by the public chain
   struct output_id
   {


### PR DESCRIPTION
Reported by user in matrix/irc, `locked_funds` wasn't reporting recently received funds as locked.