### PR TITLE
Return pool transactions in get_address_txs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,7 +71,7 @@ set(monero-lws-common_headers config.h error.h fwd.h)
 add_library(monero-lws-common ${monero-lws-common_sources} ${monero-lws-common_headers})
 target_link_libraries(monero-lws-common monero::libraries)
 
-add_library(monero-lws-daemon-common rest_server.cpp scanner.cpp)
+add_library(monero-lws-daemon-common rest_server.cpp scanner.cpp mempool.cpp)
 target_include_directories(monero-lws-daemon-common PUBLIC ${ZMQ_INCLUDE_PATH})
 target_link_libraries(monero-lws-daemon-common
   PUBLIC

--- a/src/fwd.h
+++ b/src/fwd.h
@@ -30,6 +30,7 @@
 namespace lws
 {
   class account;
+  class mempool;
   class rest_server;
   class scanner;
 }

--- a/src/mempool.cpp
+++ b/src/mempool.cpp
@@ -1,0 +1,215 @@
+// Copyright (c) 2024, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "mempool.h"
+
+#include "common/error.h"
+#include "cryptonote_basic/cryptonote_format_utils.h"
+#include "error.h"
+#include "misc_log_ex.h"
+#include "rpc/daemon_messages.h" // external/monero/src
+#include "rpc/daemon_zmq.h"
+#include "rpc/json.h"
+#include "util/ownership_test.h"
+
+namespace lws
+{
+  const size_t max_cache_size = 1000;
+
+  std::shared_ptr<const mempool::pool_table> mempool::get_txs() const
+  {
+    const std::lock_guard<std::mutex> lock{mutex_};
+
+    // return the existing snapshot if we have one
+    if (snapshot_) return snapshot_;
+
+    // otherwise make a fresh snapshot
+    snapshot_ = std::make_shared<const pool_table>(state_);
+    return snapshot_;
+  }
+
+  void mempool::add_txs(epee::span<cryptonote::transaction> txs)
+  {
+    const std::lock_guard<std::mutex> lock{mutex_};
+    snapshot_.reset();
+
+    for (auto& tx: txs)
+    {
+      auto hash = get_transaction_hash(tx);
+      auto found = state_.find(hash);
+      if (found != state_.end()) continue;
+      state_.insert({
+        hash,
+        std::make_shared<const cryptonote::transaction>(std::move(tx))
+      });
+      // MDEBUG("Mempool added tx " << hash << " size: " << state_.size());
+    }
+  }
+
+  void mempool::reset_txs(pool_table&& txs)
+  {
+    const std::lock_guard<std::mutex> lock{mutex_};
+    snapshot_.reset();
+
+    MDEBUG("Mempool reset from size " << state_.size() << " to " << txs.size());
+    state_ = std::move(txs);
+  }
+
+  std::unordered_set<crypto::hash> mempool::address_cache::get(const std::string& address) const
+  {
+    auto it = map_.find(address);
+    if (it == map_.end())
+      return {};
+    return {it->second.txids.begin(), it->second.txids.end()};
+  }
+
+  void mempool::address_cache::set(const std::string& address, std::vector<crypto::hash>&& txids)
+  {
+    // find or create entry for this address
+    auto status = map_.emplace(address, entry{});
+    entry& e = status.first->second;
+    e.txids = std::move(txids);
+    if (status.second)
+    {
+      // add new address to order list
+      order_.push_front(address);
+      e.order = order_.begin();
+
+      // evict old address if needed
+      if (map_.size() >= max_cache_size)
+      {
+        auto& evict_address = order_.back();
+        map_.erase(evict_address);
+        order_.pop_back();
+      }
+    }
+    else
+      // move existing address to front of order list
+      order_.splice(order_.begin(), order_, e.order);
+  }
+
+  std::vector<found_pool_tx> mempool::scan_account(lws::account& user) const
+  {
+    std::shared_ptr<const pool_table> snapshot = get_txs();
+    std::unordered_set<crypto::hash> skip;
+    {
+      std::lock_guard<std::mutex> lock{mutex_};
+      skip = cache_.get(user.address());
+    }
+
+    std::vector<found_pool_tx> found{};
+    ownership_test scan_transaction{
+      [&found](account&, db::spend&& spend)
+      {
+        if (found.empty() || found.back().hash != spend.link.tx_hash)
+          found.push_back({spend.link.tx_hash});
+        found.back().spends.push_back(std::move(spend));
+      },
+      [&found](account&, db::output&& output)
+      {
+        if (found.empty() || found.back().hash != output.link.tx_hash)
+          found.push_back({output.link.tx_hash});
+        found.back().outputs.push_back(std::move(output));
+      }
+    };
+
+    // uint64::max is for txpool
+    static const std::vector<std::uint64_t> fake_outs(
+      256, std::numeric_limits<std::uint64_t>::max()
+    );
+
+    std::vector<crypto::hash> skipped;
+    for (auto &pair: *snapshot) {
+      if (!skip.count(pair.first))
+        scan_transaction(
+          epee::span<lws::account>(&user, 1),
+          db::block_id::txpool,
+          0,
+          pair.first,
+          *pair.second,
+          fake_outs
+        );
+      if (found.empty() || found.back().hash != pair.first)
+        skipped.push_back(pair.first);
+    }
+
+    {
+      std::lock_guard<std::mutex> lock{mutex_};
+      cache_.set(user.address(), std::move(skipped));
+    }
+
+    return found;
+  }
+
+  expect<void> pool_update_loop(std::shared_ptr<mempool> pool, rpc::client& client)
+  {
+    return client.event_loop(
+      [&pool](std::string&& json) -> expect<void>
+      {
+        const auto msg = rpc::parse_json_response<rpc::get_transaction_pool>(std::move(json));
+        if (!msg)
+        {
+          MERROR("Pool failed to parse block response" << msg.error());
+          return msg.error();
+        }
+
+        mempool::pool_table txs{};
+        txs.reserve(msg->transactions.size());
+        for (auto& tx: msg->transactions)
+        {
+          auto shared_tx = std::make_shared<const cryptonote::transaction>(std::move(tx.tx));
+          txs.insert({tx.tx_hash, std::move(shared_tx)});
+        }
+        pool->reset_txs(std::move(txs));
+        return {};
+      },
+
+      [&client](rpc::minimal_chain_pub&& msg) -> expect<void>
+      {
+        cryptonote::rpc::GetTransactionPool::Request req{};
+        const auto sent = client.send(
+          rpc::client::make_message("get_transaction_pool", req),
+          std::chrono::seconds(0));
+
+        // fine if the socket is busy, we just carry extra txs for a while
+        if (!sent && sent != lws::error::daemon_timeout && sent != net::zmq::make_error_code(EFSM))
+        {
+          MERROR("Pool failed to send block request" << sent.error());
+          return sent.error();
+        }
+        return {};
+      },
+
+      [&pool](rpc::full_txpool_pub&& msg) -> expect<void>
+      {
+        pool->add_txs(epee::to_mut_span(msg.txes));
+        return {};
+      }
+    );
+  }
+
+} // namespace lws

--- a/src/mempool.h
+++ b/src/mempool.h
@@ -1,0 +1,109 @@
+// Copyright (c) 2024, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <memory>
+#include <vector>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "common/expect.h"
+#include "cryptonote_basic/cryptonote_basic.h" // external/monero/src
+#include "db/fwd.h"
+#include "rpc/client.h"
+
+namespace lws
+{
+  struct found_pool_tx {
+    crypto::hash hash;
+    std::vector<db::spend> spends;
+    std::vector<db::output> outputs;
+  };
+
+  /*!
+    Thread-safe mempool cache, designed to perform well with a single writer
+    and multiple concurrent readers.
+
+    The primary mutable state is guarded with a mutex, while each reader
+    receives an immutable snapshot of the latest state. These snapshots
+    use structural sharing to avoid copying the heavyweight transactions.
+
+    The two update methods are `add_tx` and `filter_txs`.
+  */
+  class mempool
+  {
+  public:
+    using pool_table = std::unordered_map<
+      crypto::hash,
+      std::shared_ptr<const cryptonote::transaction>
+    >;
+
+    //! \return Snapshot of current mempool state. Thread-safe.
+    std::shared_ptr<const pool_table> get_txs() const;
+
+    //! Adds transactions to the pool, if they are not already present.
+    // Thread-safe.
+    void add_txs(epee::span<cryptonote::transaction>);
+
+    //! Replaces all transactions to the pool. Thread-safe.
+    void reset_txs(pool_table&&);
+
+    //! Scans the pool for transactions belonging to an address. Thread-safe.
+    std::vector<found_pool_tx> scan_account(lws::account& user) const;
+
+  private:
+    //! Remembers which txid's that do *not* belong to an address,
+    // since there is no need for the scanner to revisit these.
+    class address_cache
+    {
+    public:
+      std::unordered_set<crypto::hash> get(const std::string& address) const;
+      void set(const std::string& address, std::vector<crypto::hash>&& txids);
+
+    private:
+      struct entry
+      {
+        std::vector<crypto::hash> txids;
+        std::list<std::string>::iterator order;
+      };
+
+      std::unordered_map<std::string, entry> map_;
+      std::list<std::string> order_;
+    };
+
+    pool_table state_;
+    mutable address_cache cache_;
+    mutable std::shared_ptr<const pool_table> snapshot_;
+    mutable std::mutex mutex_;
+  };
+
+  //! Run this on a thread to keep the pool in sync.
+  // Loops until an error or shutdown signal occurs.
+  expect<void> pool_update_loop(std::shared_ptr<mempool> pool, rpc::client& client);
+
+} // namespace lws

--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -716,6 +716,9 @@ namespace lws
           }
         }
 
+        if (!data.global->mempool)
+          return resp;
+
         // Add mempool transactions. Order is not important, since
         // mempool txs cannot depend on each other.
         lws::account full_user{user->first, receives, {}};

--- a/src/rest_server.h
+++ b/src/rest_server.h
@@ -41,6 +41,7 @@
 
 namespace lws
 {
+  class mempool;
   struct rest_server_data;
   class rest_server
   {
@@ -69,7 +70,13 @@ namespace lws
       bool auto_accept_import;
     };
 
-    explicit rest_server(epee::span<const std::string> addresses, std::vector<std::string> admin, db::storage disk, rpc::client client, configuration config);
+    explicit rest_server(
+      epee::span<const std::string> addresses,
+      std::vector<std::string> admin,
+      db::storage disk,
+      rpc::client client,
+      std::shared_ptr<lws::mempool> mempool,
+      configuration config);
 
     rest_server(rest_server&&) = delete;
     rest_server(rest_server const&) = delete;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -738,13 +738,6 @@ namespace rpc
     return ctx->daemon_addr;
   }
 
-  std::string const& context::pub_address() const
-  {
-    if (ctx == nullptr)
-      MONERO_THROW(common_error::kInvalidArgument, "Invalid lws::rpc::context");
-    return ctx->sub_addr;
-  }
-
   std::chrono::minutes context::cache_interval() const
   {
     if (ctx == nullptr)

--- a/src/rpc/client.h
+++ b/src/rpc/client.h
@@ -29,6 +29,7 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/optional/optional.hpp>
 #include <chrono>
+#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
@@ -131,6 +132,17 @@ namespace rpc
     //! Wait for new block announce or internal timeout.
     expect<std::vector<std::pair<topic, std::string>>> wait_for_block();
 
+    using rpc_handler = std::function<expect<void>(std::string&&)>;
+    using block_pub_handler = std::function<expect<void>(minimal_chain_pub&&)>;
+    using txpool_pub_handler = std::function<expect<void>(full_txpool_pub&&)>;
+
+    //! Loops until an error or shutdown happens, emitting events.
+    expect<void> event_loop(
+      rpc_handler on_rpc,
+      block_pub_handler on_block,
+      txpool_pub_handler on_txpool
+    );
+
     //! \return A JSON message for RPC request `M`.
     template<typename M>
     static epee::byte_slice make_message(char const* const name, const M& message)
@@ -223,6 +235,9 @@ namespace rpc
 
     //! \return The full address of the monerod ZMQ daemon.
     std::string const& daemon_address() const;
+
+    //! \return The full address of the monerod PUB port.
+    std::string const& pub_address() const;
 
     //! \return Exchange rate checking interval
     std::chrono::minutes cache_interval() const; 

--- a/src/rpc/client.h
+++ b/src/rpc/client.h
@@ -236,9 +236,6 @@ namespace rpc
     //! \return The full address of the monerod ZMQ daemon.
     std::string const& daemon_address() const;
 
-    //! \return The full address of the monerod PUB port.
-    std::string const& pub_address() const;
-
     //! \return Exchange rate checking interval
     std::chrono::minutes cache_interval() const; 
 

--- a/src/rpc/light_wallet.cpp
+++ b/src/rpc/light_wallet.cpp
@@ -292,19 +292,22 @@ namespace lws
       }
 
       const bool is_coinbase = (extra.first & db::coinbase_output);
+      const auto height = self.value().info.link.height;
+      const bool mempool = height == db::block_id::txpool;
+      const iso_timestamp timestamp{self.value().info.timestamp};
 
       wire::object(dest,
         wire::field("id", std::uint64_t(self.index())),
         wire::field("hash", std::cref(self.value().info.link.tx_hash)),
-        wire::field("timestamp", iso_timestamp(self.value().info.timestamp)),
+        wire::optional_field("timestamp", mempool ? nullptr : &timestamp),
         wire::field("total_received", safe_uint64(self.value().info.spend_meta.amount)),
         wire::field("total_sent", safe_uint64(self.value().spent)),
         wire::field("fee", safe_uint64(self.value().info.fee)),
         wire::field("unlock_time", self.value().info.unlock_time),
-        wire::field("height", self.value().info.link.height),
+        wire::optional_field("height", mempool ? nullptr : &height),
         wire::optional_field("payment_id", payment_id),
         wire::field("coinbase", is_coinbase),
-        wire::field("mempool", false),
+        wire::field("mempool", mempool),
         wire::field("mixin", self.value().info.spend_meta.mixin_count),
         wire::field("recipient", self.value().info.recipient),
         wire::field("spent_outputs", std::cref(self.value().spends))

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -732,7 +732,7 @@ namespace lws
           threads.emplace_back(attrs, std::bind(&do_scan_loop, std::ref(self), std::move(data), i));
         }
 
-        if (pool && !ctx.pub_address().empty()) {
+        if (pool) {
           auto client = std::make_shared<rpc::client>(MONERO_UNWRAP(ctx.connect()));
           threads.emplace_back(attrs, [pool, client, &self] ()
           {

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -734,17 +734,19 @@ namespace lws
 
         if (pool) {
           auto client = std::make_shared<rpc::client>(MONERO_UNWRAP(ctx.connect()));
+          MONERO_UNWRAP(client->watch_scan_signals());
           threads.emplace_back(attrs, [pool, client, &self] ()
           {
+            MINFO("Pool updater thread started");
             while (self.is_running())
             {
               try
               {
-                  auto result = pool_update_loop(pool, *client);
-                  if (!result
-                    && result.error() != make_error_code(lws::error::signal_abort_process)
-                    && result.error() != make_error_code(lws::error::signal_abort_scan))
-                    MERROR("Pool update loop failed " << result.error());
+                auto result = pool_update_loop(pool, *client);
+                if (!result
+                  && result.error() != make_error_code(lws::error::signal_abort_process)
+                  && result.error() != make_error_code(lws::error::signal_abort_scan))
+                  MERROR("Pool update loop failed " << result.error());
               }
               catch (std::exception const& e)
               {
@@ -755,6 +757,7 @@ namespace lws
                 MERROR("Pool update threw unknown exception");
               }
             }
+            MINFO("Pool updater thread stopped");
           });
         }
 

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -43,6 +43,8 @@
 
 namespace lws
 {
+  class mempool;
+
   struct scanner_options
   {
     std::uint32_t max_subaddresses;
@@ -123,7 +125,13 @@ namespace lws
     expect<rpc::client> sync(rpc::client client, const bool untrusted_daemon = false, const bool regtest = false);
 
     //! Poll daemon until `shutdown()` is called, using `thread_count` threads.
-    void run(rpc::context ctx, std::size_t thread_count, const std::string& server_addr, std::string server_pass, const scanner_options&);
+    void run(
+      rpc::context ctx,
+      std::shared_ptr<mempool> pool,
+      std::size_t thread_count,
+      const std::string& server_addr,
+      std::string server_pass,
+      const scanner_options&);
 
     //! \return True iff `stop()` and `shutdown()` has never been called
     bool is_running() const noexcept { return sync_.is_running(); }

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -331,11 +331,13 @@ namespace
     //! SIGINT handle registered by `scanner` constructor
     lws::scanner scanner{disk.clone(), prog.rest_config.webhook_verify};
 
+    std::shared_ptr<lws::mempool> mempool;
     MINFO("Using monerod ZMQ RPC at " << ctx.daemon_address());
     if (!sub_address.empty())
+    {
       MINFO("Using monerod ZMQ sub at " << sub_address);
-
-    auto mempool = std::make_shared<lws::mempool>();
+      mempool = std::make_shared<lws::mempool>();
+    }
 
     auto client = scanner.sync(ctx.connect().value(), prog.untrusted_daemon).value();
 

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -26,8 +26,8 @@
 # STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 # THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set(monero-lws-util_sources blocks.cpp gamma_picker.cpp random_outputs.cpp source_location.cpp transactions.cpp)
-set(monero-lws-util_headers blocks.h fwd.h gamma_picker.h random_outputs.h source_location.h transactions.h)
+set(monero-lws-util_sources blocks.cpp gamma_picker.cpp ownership_test.cpp random_outputs.cpp source_location.cpp transactions.cpp)
+set(monero-lws-util_headers blocks.h fwd.h gamma_picker.h ownership_test.h random_outputs.h source_location.h transactions.h)
 
 add_library(monero-lws-util ${monero-lws-util_sources} ${monero-lws-util_headers})
 target_link_libraries(monero-lws-util monero::libraries monero-lws-db)

--- a/src/util/ownership_test.cpp
+++ b/src/util/ownership_test.cpp
@@ -1,0 +1,325 @@
+// Copyright (c) 2018-2025, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "ownership_test.h"
+
+#include <boost/optional/optional.hpp>
+#include <boost/range/combine.hpp>
+
+#include "common/error.h"
+#include "crypto/wallet/crypto.h"
+#include "cryptonote_basic/cryptonote_format_utils.h"
+#include "cryptonote_basic/tx_extra.h"
+#include "db/account.h"
+#include "db/data.h"
+#include "db/storage.h"
+#include "error.h"
+#include "misc_log_ex.h"
+#include "rpc/daemon_messages.h"
+#include "util/transactions.h"
+
+namespace lws
+{
+  ownership_test::ownership_test(spend_action on_spend, output_action on_output)
+    : on_spend(on_spend)
+    , on_output(on_output)
+  {}
+
+  void ownership_test::enable_subaddresses(const db::storage& disk, const std::uint32_t max_subaddresses)
+  {
+    subaddress.emplace(subaddress_reader{disk, max_subaddresses});
+  }
+
+  void ownership_test::disable_subaddresses()
+  {
+    subaddress.reset();
+  }
+
+  void ownership_test::operator()(
+    epee::span<account> users,
+    db::block_id height,
+    std::uint64_t timestamp,
+    const crypto::hash& tx_hash,
+    const cryptonote::transaction& tx,
+    const std::vector<std::uint64_t>& out_ids)
+  {
+    if (2 < tx.version)
+      throw std::runtime_error{"Unsupported tx version"};
+
+    cryptonote::tx_extra_pub_key key;
+    boost::optional<crypto::hash> prefix_hash;
+    boost::optional<cryptonote::tx_extra_nonce> extra_nonce;
+    std::pair<std::uint8_t, db::output::payment_id_> payment_id;
+    cryptonote::tx_extra_additional_pub_keys additional_tx_pub_keys;
+    std::vector<crypto::key_derivation> additional_derivations;
+
+    {
+      std::vector<cryptonote::tx_extra_field> extra;
+      cryptonote::parse_tx_extra(tx.extra, extra);
+      if (!cryptonote::find_tx_extra_field_by_type(extra, key))
+        return;
+
+      extra_nonce.emplace();
+      if (cryptonote::find_tx_extra_field_by_type(extra, *extra_nonce))
+      {
+        if (cryptonote::get_payment_id_from_tx_extra_nonce(extra_nonce->nonce, payment_id.second.long_))
+          payment_id.first = sizeof(crypto::hash);
+      }
+      else
+        extra_nonce = boost::none;
+
+      if (subaddress)
+        cryptonote::find_tx_extra_field_by_type(extra, additional_tx_pub_keys);
+    }
+
+    for (account& user : users)
+    {
+      if (height <= user.scan_height())
+        continue;
+
+      crypto::key_derivation derived;
+      if (!crypto::wallet::generate_key_derivation(key.pub_key, user.view_key(), derived))
+        continue;
+
+      if (subaddress && additional_tx_pub_keys.data.size() == tx.vout.size())
+      {
+        additional_derivations.resize(tx.vout.size());
+        for (std::size_t index = 0; index < tx.vout.size(); ++index)
+        {
+          if (!crypto::wallet::generate_key_derivation(additional_tx_pub_keys.data[index], user.view_key(), additional_derivations[index]))
+          {
+            additional_derivations.clear();
+            break;
+          }
+        }
+      }
+
+      db::extra ext{};
+      std::uint32_t mixin = 0;
+      for (auto const& in : tx.vin)
+      {
+        if (const auto in_data = boost::get<cryptonote::txin_to_key>(std::addressof(in)))
+        {
+          mixin = boost::numeric_cast<std::uint32_t>(std::max<std::size_t>(1, in_data->key_offsets.size()) - 1);
+
+          std::uint64_t goffset = 0;
+          for (std::uint64_t offset : in_data->key_offsets)
+          {
+            goffset += offset;
+            const auto address_index = user.get_spendable(db::output_id{in_data->amount, goffset});
+            if (!address_index)
+              continue;
+
+            on_spend(
+              user,
+              db::spend{
+                db::transaction_link{height, tx_hash},
+                in_data->k_image,
+                db::output_id{in_data->amount, goffset},
+                timestamp,
+                tx.unlock_time,
+                mixin,
+                {0, 0, 0},
+                payment_id.first,
+                payment_id.second.long_,
+                *address_index
+              }
+            );
+          }
+        }
+        else if (boost::get<cryptonote::txin_gen>(std::addressof(in)))
+          ext = db::extra(ext | db::coinbase_output);
+      }
+
+      for (std::size_t index = 0; index < tx.vout.size(); ++index)
+      {
+        crypto::public_key out_pub_key;
+        if (!cryptonote::get_output_public_key(tx.vout[index], out_pub_key))
+          continue;
+
+        const auto view_tag = cryptonote::get_output_view_tag(tx.vout[index]);
+        const bool matched =
+          (!additional_derivations.empty() && cryptonote::out_can_be_to_acc(view_tag, additional_derivations.at(index), index)) ||
+          cryptonote::out_can_be_to_acc(view_tag, derived, index);
+
+        if (!matched)
+          continue;
+
+        bool found_pub = false;
+        db::address_index account_index{db::major_index::primary, db::minor_index::primary};
+        crypto::key_derivation active_derivation{};
+        crypto::public_key active_pub{};
+
+        for (std::size_t attempt = 0; attempt < 2; ++attempt)
+        {
+          if (attempt == 0)
+          {
+            active_derivation = derived;
+            active_pub = key.pub_key;
+          }
+          else if (!additional_derivations.empty())
+          {
+            active_derivation = additional_derivations.at(index);
+            active_pub = additional_tx_pub_keys.data.at(index);
+          }
+          else
+            break;
+
+          crypto::public_key derived_pub;
+          if (!crypto::wallet::derive_subaddress_public_key(out_pub_key, active_derivation, index, derived_pub))
+            continue;
+
+          if (user.spend_public() != derived_pub)
+          {
+            if (!subaddress)
+              continue;
+
+            const expect<db::address_index> match = subaddress->find_subaddress(user, derived_pub);
+            if (!match)
+            {
+              if (match != lmdb::error(MDB_NOTFOUND))
+                MERROR("Failure when doing subaddress search: " << match.error().message());
+              continue;
+            }
+
+            auto result = subaddress->update_lookahead(user, *match, height);
+            if (!result)
+              MWARNING("Failed to update lookahead for " << user.address() << ": " << result.error());
+            found_pub = true;
+            account_index = *match;
+            break;
+          }
+          else
+          {
+            found_pub = true;
+            break;
+          }
+        }
+
+        if (!found_pub)
+          continue;
+
+        if (!prefix_hash)
+        {
+          prefix_hash.emplace();
+          cryptonote::get_transaction_prefix_hash(tx, *prefix_hash);
+        }
+
+        std::uint64_t amount = tx.vout[index].amount;
+        rct::key mask = rct::identity();
+        if (!amount && !(ext & db::coinbase_output) && 1 < tx.version)
+        {
+          const bool bulletproof2 = (rct::RCTTypeBulletproof2 <= tx.rct_signatures.type);
+          const auto decrypted = lws::decode_amount(
+            tx.rct_signatures.outPk.at(index).mask,
+            tx.rct_signatures.ecdhInfo.at(index),
+            active_derivation,
+            index,
+            bulletproof2
+          );
+          if (!decrypted)
+          {
+            MWARNING(user.address() << " failed to decrypt amount for tx " << tx_hash << ", skipping output");
+            continue;
+          }
+          amount = decrypted->first;
+          mask = decrypted->second;
+          ext = db::extra(ext | db::ringct_output);
+        }
+        else if (1 < tx.version)
+          ext = db::extra(ext | db::ringct_output);
+
+        if (extra_nonce && !payment_id.first && cryptonote::get_encrypted_payment_id_from_tx_extra_nonce(extra_nonce->nonce, payment_id.second.short_))
+        {
+          payment_id.first = sizeof(crypto::hash8);
+          lws::decrypt_payment_id(payment_id.second.short_, active_derivation);
+        }
+
+        on_output(
+          user,
+          db::output{
+            db::transaction_link{height, tx_hash},
+            db::output::spend_meta_{
+              db::output_id{tx.version < 2 ? tx.vout[index].amount : 0, out_ids.at(index)},
+              amount,
+              mixin,
+              boost::numeric_cast<std::uint32_t>(index),
+              active_pub
+            },
+            timestamp,
+            tx.unlock_time,
+            *prefix_hash,
+            out_pub_key,
+            mask,
+            {0, 0, 0, 0, 0, 0, 0},
+            db::pack(ext, payment_id.first),
+            payment_id.second,
+            cryptonote::get_tx_fee(tx),
+            account_index
+          }
+        );
+      }
+    }
+  }
+
+  subaddress_reader::subaddress_reader(db::storage const& disk_in, const std::uint32_t max_subaddresses)
+    : reader(common_error::kInvalidArgument), disk(), cur(nullptr), max_subaddresses(max_subaddresses)
+  {
+    disk = disk_in.clone();
+    update_reader();
+  }
+
+  void subaddress_reader::update_reader()
+  {
+    reader = disk->start_read();
+    if (!reader)
+      MERROR("Subadress lookup failure: " << reader.error().message());
+  }
+  
+  expect<db::address_index> subaddress_reader::find_subaddress(const account& user, crypto::public_key const& pubkey)
+  {
+    if (!reader)
+      return {lmdb::error(MDB_NOTFOUND)};
+    return reader->find_subaddress(user.id(), pubkey, cur);
+  }
+
+  expect<void> subaddress_reader::update_lookahead(const account& user, const db::address_index& match, const db::block_id height)
+  {
+    if (match.is_zero())
+      return {}; // keep subaddress disabled servers quick
+
+    auto upserted = disk->update_lookahead(user.db_address(), height, match, max_subaddresses);
+    if (!upserted)
+      return upserted.error();
+    if (0 < *upserted)
+      update_reader(); // update reader after upsert added new addresses
+    else if (*upserted < 0)
+      upserted = {error::max_subaddresses};
+    return {};
+  }
+
+} // namespace lws

--- a/src/util/ownership_test.h
+++ b/src/util/ownership_test.h
@@ -1,0 +1,95 @@
+// Copyright (c) 2018-2025, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <boost/optional/optional.hpp>
+#include <functional>
+
+#include "cryptonote_basic/cryptonote_basic.h"
+#include "db/account.h"
+#include "db/storage.h"
+#include "span.h"
+
+namespace lws
+{
+  class subaddress_reader
+  {
+  public:
+    subaddress_reader(db::storage const& disk_in, const std::uint32_t max_subaddresses);
+
+    expect<db::address_index> find_subaddress(const account& user, crypto::public_key const& pubkey);
+    expect<void> update_lookahead(const account& user, const db::address_index& match, const db::block_id height);
+
+  private:
+    expect<db::storage_reader> reader;
+    std::optional<db::storage> disk;
+    db::cursor::subaddress_indexes cur;
+    const std::uint32_t max_subaddresses;
+
+    void update_reader();
+  };
+
+  class ownership_test {
+  public:
+    using spend_action = std::function<void(account&, db::spend&&)>;
+    using output_action = std::function<void(account&, db::output&&)>;
+
+    ownership_test(spend_action, output_action);
+
+    ownership_test(const ownership_test&) = delete;
+    ownership_test(ownership_test&&) = default;
+
+    ownership_test& operator=(const ownership_test&) = delete;
+    ownership_test& operator=(ownership_test&&) = default;
+
+    /*! Tests the transaction against out accounts,
+      and invokes callbacks for matching inputs or outputs.
+      @param height mined height
+      @param timestamp mined block timestamp
+      @param out_ids maps vout indices to global utxo indexes
+    */
+    void operator()(
+      epee::span<account> users,
+      db::block_id height,
+      std::uint64_t timestamp,
+      const crypto::hash& tx_hash,
+      const cryptonote::transaction& tx,
+      const std::vector<std::uint64_t>& out_ids
+    );
+
+    void enable_subaddresses(const db::storage& disk, const std::uint32_t max_subaddresses);
+    void disable_subaddresses();
+
+  private:
+    spend_action on_spend;
+    output_action on_output;
+
+    boost::optional<subaddress_reader> subaddress;
+  };
+
+} // namespace lws

--- a/tests/unit/rest.test.cpp
+++ b/tests/unit/rest.test.cpp
@@ -34,7 +34,6 @@
 #include "db/string.h"
 #include "error.h"
 #include "hex.h" // monero/epee/contrib/include
-#include "mempool.h"
 #include "net/http_client.h"
 #include "rest_server.h"
 #include "scanner.test.h"
@@ -135,7 +134,7 @@ LWS_CASE("rest_server")
         std::vector<std::string>{admin_server},
         db.clone(),
         MONERO_UNWRAP(rpc.clone()),
-        std::make_shared<lws::mempool>(),
+        std::shared_ptr<lws::mempool>{},
         config
       );
     }

--- a/tests/unit/rest.test.cpp
+++ b/tests/unit/rest.test.cpp
@@ -34,6 +34,7 @@
 #include "db/string.h"
 #include "error.h"
 #include "hex.h" // monero/epee/contrib/include
+#include "mempool.h"
 #include "net/http_client.h"
 #include "rest_server.h"
 #include "scanner.test.h"
@@ -134,6 +135,7 @@ LWS_CASE("rest_server")
         std::vector<std::string>{admin_server},
         db.clone(),
         MONERO_UNWRAP(rpc.clone()),
+        std::make_shared<lws::mempool>(),
         config
       );
     }

--- a/tests/unit/scanner.test.cpp
+++ b/tests/unit/scanner.test.cpp
@@ -42,7 +42,6 @@
 #include "net/zmq.h"                 // monero/src
 #include "rpc/client.h"
 #include "rpc/daemon_messages.h"     // monero/src
-#include "mempool.h"
 #include "scanner.h"
 #include "wire/error.h"
 #include "wire/json/write.h"
@@ -332,7 +331,7 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
 
   SETUP("lws::rpc::context, ZMQ_REP Server, and lws::db::storage")
   {
-    auto pool = std::make_shared<lws::mempool>();
+    std::shared_ptr<lws::mempool> pool{};
     auto rpc = 
       lws::rpc::context::make(lws_test::rpc_rendevous, {}, {}, {}, std::chrono::minutes{0}, false);
 

--- a/tests/unit/scanner.test.cpp
+++ b/tests/unit/scanner.test.cpp
@@ -42,6 +42,7 @@
 #include "net/zmq.h"                 // monero/src
 #include "rpc/client.h"
 #include "rpc/daemon_messages.h"     // monero/src
+#include "mempool.h"
 #include "scanner.h"
 #include "wire/error.h"
 #include "wire/json/write.h"
@@ -331,6 +332,7 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
 
   SETUP("lws::rpc::context, ZMQ_REP Server, and lws::db::storage")
   {
+    auto pool = std::make_shared<lws::mempool>();
     auto rpc = 
       lws::rpc::context::make(lws_test::rpc_rendevous, {}, {}, {}, std::chrono::minutes{0}, false);
 
@@ -542,7 +544,7 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
         lws::scanner scanner{db.clone(), epee::net_utils::ssl_verification_t::none};
         boost::thread server_thread(&scanner_thread, std::ref(scanner), rpc.zmq_context(), std::cref(messages));
         const join on_scope_exit{server_thread};
-        scanner.run(std::move(rpc), 1, {}, {}, opts);
+        scanner.run(std::move(rpc), pool, 1, {}, {}, opts);
       }
 
       hashes.push_back(cryptonote::get_block_hash(bmessage.blocks.back().block));
@@ -868,7 +870,7 @@ LWS_CASE("lws::scanner::sync and lws::scanner::run")
         lws::scanner scanner{db.clone(), epee::net_utils::ssl_verification_t::none};
         boost::thread server_thread(&scanner_thread, std::ref(scanner), rpc.zmq_context(), std::cref(messages));
         const join on_scope_exit{server_thread};
-        scanner.run(std::move(rpc), 1, {}, {}, opts);
+        scanner.run(std::move(rpc), pool, 1, {}, {}, opts);
       }
 
       hashes.push_back(cryptonote::get_block_hash(bmessage.blocks.back().block));


### PR DESCRIPTION
The basic design is to keep pool transactions in RAM, and then re-scan them on each REST request. The pool is generally pretty small and dynamic, so this strategy is usually cheaper than trying to index everything in the database. Odds are, pool transactions don't belong to any of our addresses, and so they will never even be queried. Thus, any indexing work we do ahead of time is likely to be useless.

I'm submitting this draft PR to show the basic direction this work is heading. There are a number of remaining flaws that need more work:

- I want to add a small cache to the mempool class, which maps from recent addresses to scan results. Repeated wallets requests will hit the cache instead of re-scanning the same transactions over and over.
- While the pool sync mostly works, the tx pool updater will break if the connection drops. I still need to replicate the scanner's restart-on-error logic, and possibly move the update logic into the scanner itself.
- Actually, mempool is the wrong term - maybe I should rename the class to txpool instead.