### PR TITLE
Add /get_version, based on openmonero with a few extra additions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,35 @@
 
 include_directories(.)
 
+find_package(Git)
+
+set(MLWS_COMMIT_BRANCH "")
+set(MLWS_COMMIT_DATE "")
+set(MLWS_COMMIT_HASH "")
+if (GIT_FOUND)
+  execute_process(
+    COMMAND "${GIT_EXECUTABLE}" rev-parse HEAD
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    OUTPUT_VARIABLE MLWS_COMMIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  execute_process(
+    COMMAND "${GIT_EXECUTABLE}" rev-parse --abbrev-ref HEAD
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    OUTPUT_VARIABLE MLWS_COMMIT_BRANCH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  execute_process(
+    COMMAND "${GIT_EXECUTABLE}" log -1 "--date=format:\"%Y/%m/%d %T\"" "--format=\"%ad\""
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    OUTPUT_VARIABLE MLWS_COMMIT_DATE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+endif ()
+
+configure_file(lws_version.h.in "${CMAKE_BINARY_DIR}/generated_include/lws_version.h")
+include_directories("${CMAKE_BINARY_DIR}/generated_include")
+
 add_subdirectory(lmdb)
 add_subdirectory(wire)
 add_subdirectory(db)

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -61,6 +61,8 @@ namespace lws
         return "Invalid blockchain height";
       case error::bad_url:
         return "Invlaid URL";
+      case error::bad_verb:
+        return "Incorrect HTTP verb provided";
       case error::bad_webhook:
         return "Invalid webhook request";
       case error::blockchain_reorg:

--- a/src/error.h
+++ b/src/error.h
@@ -44,6 +44,7 @@ namespace lws
     bad_daemon_response,        //!< RPC Response from daemon was invalid
     bad_height,                 //!< Invalid blockchain height
     bad_url,                    //!< Invalid URL
+    bad_verb,                   //!< Bad HTTP verb for endpoint
     bad_webhook,                //!< Invalid webhook request
     blockchain_reorg,           //!< Blockchain reorg after fetching/scanning block(s)
     configuration,              //!< Process configuration invalid

--- a/src/lws_version.h.in
+++ b/src/lws_version.h.in
@@ -1,0 +1,47 @@
+// Copyright (c) 2025, The Monero Project
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are
+// permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of
+//    conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list
+//    of conditions and the following disclaimer in the documentation and/or other
+//    materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its contributors may be
+//    used to endorse or promote products derived from this software without specific
+//    prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+// THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+// STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+// THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#pragma once
+
+#include <cstdint>
+
+namespace lws { namespace version
+{
+  constexpr const char branch[] = "@MLWS_COMMIT_BRANCH@";
+  constexpr const char commit[] = "@MLWS_COMMIT_HASH@";
+  constexpr const char date[] = "@MLWS_COMMIT_DATE@";
+  constexpr const char id[] = "0.4-alpha";
+  constexpr const char name[] = "monero-lws";
+
+  // openmonero is currently on 1.6 and we have multiple additions since then
+  namespace api
+  {
+    constexpr const std::uint16_t major = 1;
+    constexpr const std::uint16_t minor = 7;
+    constexpr const std::uint32_t combined = std::uint32_t(major) << 16 | minor;
+  }
+}} // lws // version
+

--- a/src/rpc/light_wallet.cpp
+++ b/src/rpc/light_wallet.cpp
@@ -37,10 +37,12 @@
 #include "config.h"
 #include "db/string.h"
 #include "error.h"
+#include "lws_version.h"
 #include "time_helper.h"       // monero/contrib/epee/include
 #include "ringct/rctOps.h"     // monero/src
 #include "span.h"              // monero/contrib/epee/include
 #include "util/random_outputs.h"
+#include "version.h"           // monero/src
 #include "wire.h"
 #include "wire/adapted/crypto.h"
 #include "wire/error.h"
@@ -359,6 +361,36 @@ namespace lws
       WIRE_FIELD_COPY(amount),
       wire::optional_field("outputs", wire::array(boost::adaptors::transform(self.outputs, expand))),
       WIRE_FIELD(fees)
+    );
+  }
+
+  rpc::get_version_response::get_version_response(const db::block_id height, const std::uint32_t max_subaddresses)
+    : server_type(lws::version::name),
+      server_version(lws::version::id),
+      last_git_commit_hash(lws::version::commit),
+      last_git_commit_date(lws::version::date),
+      git_branch_name(lws::version::branch),
+      monero_version_full(MONERO_VERSION_FULL),
+      blockchain_height(height),
+      api(lws::version::api::combined),
+      max_subaddresses(max_subaddresses),
+      network(lws::rpc::network_type(lws::config::network)),
+      testnet(config::network == cryptonote::TESTNET) 
+  {}
+  void rpc::write_bytes(wire::json_writer& dest, const get_version_response& self)
+  {
+    wire::object(dest,
+      WIRE_FIELD(server_type),
+      WIRE_FIELD(server_version),
+      WIRE_FIELD(last_git_commit_hash),
+      WIRE_FIELD(last_git_commit_date),
+      WIRE_FIELD(git_branch_name),
+      WIRE_FIELD(monero_version_full),
+      WIRE_FIELD_COPY(blockchain_height),
+      WIRE_FIELD(api),
+      WIRE_FIELD_COPY(max_subaddresses),
+      wire::field("network_type", self.network),
+      WIRE_FIELD_COPY(testnet)
     );
   }
 

--- a/src/rpc/light_wallet.h
+++ b/src/rpc/light_wallet.h
@@ -224,6 +224,35 @@ namespace rpc
   void write_bytes(wire::json_writer&, const get_subaddrs_response&);
 
 
+  struct get_version_request
+  {
+    get_version_request() = delete;
+  };
+  inline void read_bytes(const wire::reader&, const get_version_request&)
+  {}
+
+  struct get_version_response
+  {
+    //! Defaults to current network in unavailable state
+    get_version_response(lws::db::block_id height, std::uint32_t max_subaddresses);
+
+   
+    const std::string server_type;
+    const std::string server_version;
+    const std::string last_git_commit_hash;
+    const std::string last_git_commit_date;
+    const std::string git_branch_name;
+    const std::string monero_version_full;
+
+    const db::block_id blockchain_height;
+    const std::uint32_t api;
+    const std::uint32_t max_subaddresses;
+    const network_type network;
+    const bool testnet; 
+  };
+  void write_bytes(wire::json_writer&, const get_version_response&);
+
+
   struct import_request
   {
     import_request() = delete;


### PR DESCRIPTION
@SamsungGalaxyPlayer

Implements the idea proposed in #188 . This helps with subaddress lookahead because the client (`lwsf`) can be informed of the `max_subaddresses` directly instead of having to arbitrarily probe for it.

I used `/get_version` because OpenMonero already had a REST endpoint for retrieving version information. The only addition is `max_subaddresses`, everything else is similar to what OpenMonero provides.

The fields are:
```c++
    const std::string server_type;
    const std::string server_version;
    const std::string last_git_commit_hash;
    const std::string last_git_commit_date;
    const std::string git_branch_name;
    const std::string monero_version_full;

    const db::block_id blockchain_height;
    const std::uint32_t api;
    const std::uint32_t max_subaddresses;
    const network_type network;
    const bool testnet; 
```


Additionally, `/daemon_status` and `/get_version` now properly work with `HTTP GET` or `HTTP POST`, with the other endpoints still restricted to just `HTTP POST`.