### PR TITLE
Add EXCLUDE_FROM_ALL for monero dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,7 @@ else () # NOT MONERO_BUILD_DIR
   endif ()
 
   include(FetchContent)
-  FetchContent_Declare(monero SOURCE_DIR "${MONERO_SOURCE_DIR}")
+  FetchContent_Declare(monero SOURCE_DIR "${MONERO_SOURCE_DIR}" EXCLUDE_FROM_ALL)
 
   if (NOT monero_POPULATED)
     FetchContent_MakeAvailable(monero)


### PR DESCRIPTION
This helps speed up builds that are **not** using `MONERO_BUILD_DIR`.