### PR TITLE
Changes needed to work with 0.18 branch (including C++14 target) [1.0 beta]

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -10,12 +10,12 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  APT_INSTALL_LINUX: 'apt -y install build-essential cmake git libboost-all-dev miniupnpc libunbound-dev libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev libprotobuf-dev protobuf-compiler'
+  APT_INSTALL_LINUX: 'apt -y install build-essential cmake git libboost-all-dev miniupnpc libunbound-dev libunwind8-dev pkg-config libssl-dev libzmq3-dev libsodium-dev libhidapi-dev libnorm-dev libusb-1.0-0-dev libpgm-dev'
   APT_SET_CONF: |
         echo "Acquire::Retries \"3\";"         | sudo tee -a /etc/apt/apt.conf.d/80-custom
         echo "Acquire::http::Timeout \"120\";" | sudo tee -a /etc/apt/apt.conf.d/80-custom
         echo "Acquire::ftp::Timeout \"120\";"  | sudo tee -a /etc/apt/apt.conf.d/80-custom
-  BREW_INSTALL_MAC: 'HOMEBREW_NO_AUTO_UPDATE=1 brew install boost hidapi openssl zmq libpgm miniupnpc expat libunwind-headers protobuf unbound'
+  BREW_INSTALL_MAC: 'HOMEBREW_NO_AUTO_UPDATE=1 brew install boost hidapi openssl zmq libpgm miniupnpc expat libunwind-headers unbound'
   CONFIGURE_BASIC: '-B "$GITHUB_WORKSPACE/lws/build" -DMONERO_SOURCE_DIR="$GITHUB_WORKSPACE/monero" -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -S "$GITHUB_WORKSPACE/lws"'
   BUILD: 'cmake --build "$GITHUB_WORKSPACE/lws/build" -j$(nproc)'
   RUN: 'ctest --test-dir "$GITHUB_WORKSPACE/lws/build" --output-on-failure'
@@ -42,7 +42,8 @@ jobs:
         with:
           repository: monero-project/monero
           path: ${{github.workspace}}/monero/
-          submodules: recursive 
+          submodules: recursive
+          ref: release-v0.18
       - name: Checkout LWS Source
         uses: actions/checkout@v6
         with:
@@ -85,6 +86,7 @@ jobs:
           repository: monero-project/monero
           path: ${{github.workspace}}/monero/
           submodules: recursive 
+          ref: release-v0.18
       - name: Checkout LWS Source
         uses: actions/checkout@v6
         with:
@@ -126,6 +128,7 @@ jobs:
         repository: monero-project/monero
         path: ${{github.workspace}}/monero/
         submodules: recursive
+        ref: release-v0.18
 
     - name: Configure Monero
       run: cmake -B ${{github.workspace}}/monero/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} ${{github.workspace}}/monero
@@ -178,6 +181,7 @@ jobs:
         repository: monero-project/monero
         path: ${{github.workspace}}/monero/
         submodules: recursive
+        ref: release-v0.18
 
     - name: Checkout LWS Source
       uses: actions/checkout@v6

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Build+Push Daemon/Admin Docker Image
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "release-v1.0_0.18" ]
     paths-ignore: [ "docs/**", "mkdocs.yml" ]
 
 jobs:
@@ -12,9 +12,12 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Build Docker image
-      run: docker build --no-cache --tag vtnerd/monero-lws:master .
+      run: docker build --no-cache --tag vtnerd/monero-lws:1.0 .
     - name: Add additional tags
-      run: docker image tag vtnerd/monero-lws:master ghcr.io/vtnerd/monero-lws:master
+      run: >
+        docker image tag vtnerd/monero-lws:1.0 vtnerd/monero-lws:1 &&
+        docker image tag vtnerd/monero-lws:1.0 ghcr.io/vtnerd/monero-lws:1.0 &&
+        docker image tag vtnerd/monero-lws:1.0 ghcr.io/vtnerd/monero-lws:1
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ cmake_minimum_required(VERSION 3.5.0)
 project(monero-lws)
 
 enable_language(CXX)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_definitions(-DBOOST_UUID_DISABLE_ALIGNMENT) # This restores UUID's std::has_unique_object_representations property
 
@@ -134,13 +134,13 @@ if (MONERO_BUILD_DIR)
     usb_LIBRARY
     HIDAPI_INCLUDE_DIR
     HIDAPI_LIBRARY
-    libzmq_INCLUDE_DIRS
     LMDB_INCLUDE
     monero_SOURCE_DIR
     OPENSSL_INCLUDE_DIR
     OPENSSL_CRYPTO_LIBRARY
     OPENSSL_SSL_LIBRARY
-    pkgcfg_lib_libzmq_zmq
+    ZMQ_INCLUDE_PATH
+    ZMQ_LIB
     sodium_LIBRARY_RELEASE
     SODIUM_LIBRARY
     UNBOUND_LIBRARIES
@@ -186,6 +186,7 @@ if (MONERO_BUILD_DIR)
 
   set(LMDB_INCLUDE "${monero_LMDB_INCLUDE}")
   set(LMDB_LIB_PATH "monero::lmdb")
+  set(ZMQ_LIB "${monero_ZMQ_LIB}")
 else () # NOT MONERO_BUILD_DIR
   if (NOT MONERO_SOURCE_DIR)
     set (MONERO_SOURCE_DIR "${monero-lws_SOURCE_DIR}/external/monero")
@@ -201,7 +202,7 @@ else () # NOT MONERO_BUILD_DIR
   set(MONERO_BUILD_DIR "${monero_BINARY_DIR}")
   set(IMPORTED_MONERO_LIBRARIES "${MONERO_LIBRARIES}")
   set(monero_Boost_THREAD_LIBRARY_RELEASE "${Boost_THREAD_LIBRARY_RELEASE}")
-  set(monero_pkgcfg_lib_libzmq_zmq "${pkgcfg_lib_libzmq_zmq}")
+  find_library(ZMQ_LIB zmq)
   if (SODIUM_LIBRARY)
     set(monero_SODIUM_LIBRARY "${SODIUM_LIBRARY}")
   else()
@@ -239,8 +240,6 @@ else()
   set(RMQ_LIBRARY "")
 endif()
 
-set(ZMQ_INCLUDE_PATH "${libzmq_INCLUDE_DIRS}")
-set(ZMQ_LIB "${monero_pkgcfg_lib_libzmq_zmq}")
 if (monero_SODIUM_LIBRARY)
   set(SODIUM_LIBRARY "${monero_SODIUM_LIBRARY}")
 else ()

--- a/src/client_main.cpp
+++ b/src/client_main.cpp
@@ -27,13 +27,13 @@
 
 #include <boost/asio/signal_set.hpp>
 #include <boost/filesystem/operations.hpp>
+#include <boost/optional/optional.hpp>
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/parsers.hpp>
 #include <boost/program_options/variables_map.hpp>
 #include <boost/thread/thread.hpp>
 #include <csignal>
 #include <iostream>
-#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -139,7 +139,7 @@ namespace
     out << description;
   }
 
-  std::optional<program> get_program(int argc, char** argv)
+  boost::optional<program> get_program(int argc, char** argv)
   {
     namespace po = boost::program_options;
 
@@ -170,7 +170,7 @@ namespace
     if (command_line::get_arg(args, command_line::arg_help))
     {
       print_help(std::cout);
-      return std::nullopt;
+      return boost::none;
     }
 
     opts.set_network(args); // do this first, sets global variable :/
@@ -257,7 +257,7 @@ namespace
           auto new_client = MONERO_UNWRAP(zclient.clone());
           MONERO_UNWRAP(new_client.watch_scan_signals());
           send_users send{client};
-          if (!lws::scanner::loop(self, std::move(send), std::nullopt, std::move(new_client), std::move(users), *queue, opts, false))
+          if (!lws::scanner::loop(self, std::move(send), boost::none, std::move(new_client), std::move(users), *queue, opts, false))
             return;
         }
       }
@@ -363,7 +363,7 @@ int main(int argc, char** argv)
 
   try
   {
-    std::optional<program> prog;
+    boost::optional<program> prog;
 
     try
     {

--- a/src/db/storage.cpp
+++ b/src/db/storage.cpp
@@ -449,7 +449,7 @@ namespace db
           return {lmdb::error(MDB_CORRUPTED)};
 
         key_bytes.assign(reinterpret_cast<const char*>(key.mv_data), key.mv_size);
-        key.mv_data = reinterpret_cast<void*>(key_bytes.data());
+        key.mv_data = const_cast<void*>(reinterpret_cast<const void*>(key_bytes.data()));
 
         Y transition{};
         std::memcpy(std::addressof(transition), value.mv_data, value.mv_size);

--- a/src/lws_version.h.in
+++ b/src/lws_version.h.in
@@ -33,7 +33,7 @@ namespace lws { namespace version
   constexpr const char branch[] = "@MLWS_COMMIT_BRANCH@";
   constexpr const char commit[] = "@MLWS_COMMIT_HASH@";
   constexpr const char date[] = "@MLWS_COMMIT_DATE@";
-  constexpr const char id[] = "1.0-alpha";
+  constexpr const char id[] = "1.0-beta";
   constexpr const char name[] = "monero-lws";
 
   // openmonero is currently on 1.6 and we have multiple additions since then

--- a/src/mempool.cpp
+++ b/src/mempool.cpp
@@ -51,7 +51,7 @@ namespace lws
 
     for (auto& tx: txs)
     {
-      auto found = state_.try_emplace(get_transaction_hash(tx), nullptr);
+      auto found = state_.emplace(get_transaction_hash(tx), nullptr);
       if (!found.first->second)
         found.first->second = std::make_shared<pool_entry>(std::move(tx), now);
     }

--- a/src/rest_server.cpp
+++ b/src/rest_server.cpp
@@ -1489,8 +1489,9 @@ namespace lws
           if (std::numeric_limits<std::size_t>::max() - msg.size() < active->outstanding || config::submit_tx_max < msg.size() + active->outstanding)
             return {error::load};
 
-          active->outstanding += msg.size(); 
-          auto& elem = active->resumers.emplace_back();
+          active->outstanding += msg.size();
+          active->resumers.emplace_back();
+          auto& elem = active->resumers.back();
           std::get<0>(elem) = std::move(msg);
           std::get<1>(elem) = std::move(resume);
           if (!cryptonote::parse_and_validate_tx_from_blob(tx_blob, std::get<2>(elem)))
@@ -1630,7 +1631,8 @@ namespace lws
         cache.status = active;
 
         active->outstanding += msg.size();
-        auto& elem = active->resumers.emplace_back();
+        active->resumers.emplace_back();
+        auto& elem = active->resumers.back();
         std::get<0>(elem) = std::move(msg);
         std::get<1>(elem) = std::move(resume);
         if (!cryptonote::parse_and_validate_tx_from_blob(tx_blob, std::get<2>(elem)))
@@ -1830,7 +1832,7 @@ namespace lws
     constexpr const unsigned max_endpoint_size =
       std::max(max_standard_endpoint_size, max_admin_endpoint_size);
 
-    constexpr const endpoint* get_endpoint(const std::string_view name) noexcept
+    constexpr const endpoint* get_endpoint(const boost::beast::string_view name) noexcept
     {
       const endpoint* current = std::begin(endpoints);
       endpoint const* const end = std::end(endpoints);
@@ -2084,7 +2086,7 @@ namespace lws
       if (!handler)
         return self_->bad_request(boost::beast::http::status::not_found, std::forward<F>(resume));
 
-      static constexpr endpoint const* const feed = get_endpoint("/feed");
+      static endpoint const* const feed = get_endpoint("/feed");
       if (handler == feed)
       {
         rest_server_data* const from = self_->data_.global;
@@ -2241,7 +2243,7 @@ namespace lws
           else
           {
             MDEBUG("New connection to " << next_->sock().remote_endpoint(error) << " / " << next_.get());
-            boost::asio::dispatch(next_->strand_, handler_loop{next_});
+            boost::asio::dispatch(next_->strand_, handler_loop<Sock>{next_});
           }
         }
       }

--- a/src/rpc/CMakeLists.txt
+++ b/src/rpc/CMakeLists.txt
@@ -28,7 +28,7 @@
 
 add_subdirectory(scanner)
 
-set(monero-lws-rpc_sources admin.cpp client.cpp daemon_pub.cpp daemon_zmq.cpp feed_ssl.cpp feed_tcp.cpp light_wallet.cpp login.cpp lws_pub.cpp rates.cpp)
+set(monero-lws-rpc_sources admin.cpp client.cpp daemon_pub.cpp daemon_zmq.cpp feed_ssl.cpp feed_tcp.cpp json.cpp light_wallet.cpp login.cpp lws_pub.cpp rates.cpp)
 set(monero-lws-rpc_headers admin.h client.h daemon_pub.h daemon_zmq.h feed.h fwd.h json.h light_wallet.h login.h lws_pub.h rates.h)
 
 add_library(monero-lws-rpc ${monero-lws-rpc_sources} ${monero-lws-rpc_headers})

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -30,7 +30,6 @@
 #include <array>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/thread/mutex.hpp>
-#include <boost/utility/string_ref.hpp>
 #include <cassert>
 #include <system_error>
 
@@ -338,12 +337,12 @@ namespace rpc
     return {lws::error::bad_daemon_response};
   }
 
-  expect<std::uint32_t> account_sub::watch(const std::string_view address) const
+  expect<std::uint32_t> account_sub::watch(const boost::string_ref address) const
   {
     MONERO_PRECOND(ctx);
     MONERO_PRECOND(sub.zsock);
 
-    const std::string_view warning = feed_warning::prefix();
+    const boost::string_ref warning = feed_warning::prefix();
     const std::uint32_t count = ctx->warning_count;
     MONERO_ZMQ_CHECK(zmq_setsockopt(sub.zsock.get(), ZMQ_SUBSCRIBE, warning.data(), warning.size()));
     MONERO_ZMQ_CHECK(zmq_setsockopt(sub.zsock.get(), ZMQ_SUBSCRIBE, address.data(), address.size()));
@@ -710,10 +709,10 @@ namespace rpc
   namespace
   {
     template<typename T>
-    expect<void> prep_message(epee::byte_stream& sink, const std::string_view prefix, const T& message)
+    expect<void> prep_message(epee::byte_stream& sink, const boost::string_ref prefix, const T& message)
     {  
       sink.write({prefix.data(), prefix.size()});
-      if (prefix.empty() || prefix.back() != u8':')
+      if (prefix.empty() || prefix.back() != ':')
         sink.push_back(':');
 
       wire::msgpack_slice_writer dest{std::move(sink), true /* integer keys */};
@@ -731,7 +730,7 @@ namespace rpc
     }
 
     template<typename T>
-    expect<epee::byte_slice> prep_message(const std::string_view prefix, const T& message)
+    expect<epee::byte_slice> prep_message(const boost::string_ref prefix, const T& message)
     {  
       epee::byte_stream sink;
       MONERO_CHECK(prep_message(sink, prefix, message));

--- a/src/rpc/client.h
+++ b/src/rpc/client.h
@@ -28,6 +28,7 @@
 
 #include <boost/asio/io_context.hpp>
 #include <boost/optional/optional.hpp>
+#include <boost/utility/string_ref.hpp>
 #include <chrono>
 #include <functional>
 #include <memory>
@@ -86,7 +87,7 @@ namespace rpc
     net::zmq::async_client& get() noexcept { return sub; }
 
     //! Subscribe to events from `address` and "warning:"
-    expect<std::uint32_t> watch(const std::string_view address) const;
+    expect<std::uint32_t> watch(const boost::string_ref address) const;
 
     //! Initiate complete shutdown on this sub
     void shutdown(boost::system::error_code& ec)

--- a/src/rpc/feed.inl
+++ b/src/rpc/feed.inl
@@ -49,6 +49,7 @@
 #include <boost/beast/http/write.hpp>
 #include <boost/beast/version.hpp>
 #include <boost/beast/websocket/stream.hpp>
+#include <boost/utility/string_ref.hpp>
 #include <chrono>
 #include <type_traits>
 #include <utility>
@@ -169,7 +170,7 @@ namespace lws { namespace rpc { namespace feed
   };
  
   // defined in `feed_tcp.cpp`
-  std::string_view get_prefix(const boost::beast::net::const_buffer buf);
+  boost::string_ref get_prefix(const boost::beast::net::const_buffer buf);
   expect<epee::byte_slice> prep_error(std::error_code error, protocol proto);
   expect<epee::byte_slice> prep_login(const db::storage& disk, const mempool* pool, account_sub* sub, connection_sync* sync, boost::beast::flat_buffer& buffer, protocol proto);
   expect<epee::byte_slice> prep_update(const db::storage& disk, std::string&& source, connection_sync* sync, protocol proto);

--- a/src/rpc/feed_tcp.cpp
+++ b/src/rpc/feed_tcp.cpp
@@ -27,6 +27,7 @@
 
 #include "feed.inl"
 
+#include <boost/utility/string_view.hpp>
 #include <cstring>
 
 #include "db/account.h"
@@ -165,9 +166,17 @@ namespace lws { namespace rpc { namespace feed
 
   namespace
   {
+    constexpr boost::beast::string_view constexpr_ref(const char* str) noexcept
+    {
+      char const* const start = str;
+      while (*str)
+        ++str;
+      return {start, std::size_t(str - start)};
+    }
+
     constexpr std::pair<boost::beast::string_view, protocol> get_map(const protocol proto) noexcept
     {
-      return {get_string(proto), proto};
+      return {constexpr_ref(get_string(proto)), proto};
     }
 
     std::string get_string(const boost::beast::net::const_buffer buf)
@@ -185,7 +194,7 @@ namespace lws { namespace rpc { namespace feed
     {
       epee::byte_stream sink{};
 
-      const std::string_view prefix = T::prefix();
+      const boost::string_ref prefix = T::prefix();
       sink.write({prefix.data(), prefix.size()});
 
       const std::error_code error = proto == protocol::v0_msgpack ?
@@ -217,10 +226,10 @@ namespace lws { namespace rpc { namespace feed
   }
 
 
-  std::string_view get_prefix(const boost::beast::net::const_buffer buf)
+  boost::string_ref get_prefix(const boost::beast::net::const_buffer buf)
   {
     char const* const begin = reinterpret_cast<const char*>(buf.data());
-    void const* const match = std::memchr(begin, u8':', buf.size());
+    void const* const match = std::memchr(begin, ':', buf.size());
     if (match)
       return {begin, std::size_t(reinterpret_cast<const char*>(match) - begin + 1)};
     return {};
@@ -234,7 +243,7 @@ namespace lws { namespace rpc { namespace feed
   expect<epee::byte_slice> prep_login(const db::storage& disk, mempool const* const pool, account_sub* const sub, connection_sync* const sync, boost::beast::flat_buffer& buffer, const protocol proto)
   {
     LWS_VERIFY(sub && sync);
-    const std::string_view prefix = get_prefix(buffer.cdata());
+    const boost::string_ref prefix = get_prefix(buffer.cdata());
     if (prefix != feed_login::prefix())
       return {error::protocol};
 
@@ -285,7 +294,7 @@ namespace lws { namespace rpc { namespace feed
     LWS_VERIFY(sync);
 
     epee::byte_slice slice{std::move(source)};
-    const std::string_view prefix = get_prefix({slice.data(), slice.size()});
+    const boost::string_ref prefix = get_prefix({slice.data(), slice.size()});
     const bool warning = prefix == feed_warning::prefix();
     slice.remove_prefix(prefix.size());
     if (warning)

--- a/src/rpc/json.cpp
+++ b/src/rpc/json.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020, The Monero Project
+// Copyright (c) 2026, The Monero Project
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are
@@ -25,37 +25,14 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#include "transactions.h"
+#include "rpc/json.h"
 
-#include "cryptonote_config.h"
-#include "crypto/crypto.h"
-#include "crypto/hash.h"
-#include "ringct/rctOps.h"
-
-void lws::decrypt_payment_id(crypto::hash8& out, const crypto::key_derivation& key)
+namespace lws { namespace rpc
 {
-  crypto::hash hash;
-  char data[33]; /* A hash, and an extra byte */
+  constexpr const char json_request_base::jsonrpc[];
 
-  memcpy(data, &key, 32);
-  data[32] = config::HASH_KEY_ENCRYPTED_PAYMENT_ID;
-  cn_fast_hash(data, 33, hash);
-
-  for (size_t b = 0; b < 8; ++b)
-    out.data[b] ^= hash.data[b];
-}
-
-boost::optional<std::pair<std::uint64_t, rct::key>> lws::decode_amount(const rct::key& commitment, const rct::ecdhTuple& info, const crypto::key_derivation& sk, std::size_t index, const bool bulletproof2)
-{
-  crypto::secret_key scalar{};
-  crypto::derivation_to_scalar(sk, index, scalar);
-
-  rct::ecdhTuple copy{info};
-  rct::ecdhDecode(copy, rct::sk2rct(scalar), bulletproof2);
-
-  rct::key Ctmp;
-  rct::addKeys2(Ctmp, copy.mask, copy.amount, rct::H);
-  if (rct::equalKeys(commitment, Ctmp))
-    return {{rct::h2d(copy.amount), copy.mask}};
-  return boost::none;
-}
+  void read_bytes(wire::json_reader& source, json_error& self)
+  {
+    wire::object(source, WIRE_FIELD(code), WIRE_FIELD(message));
+  }
+}}

--- a/src/rpc/json.h
+++ b/src/rpc/json.h
@@ -25,6 +25,9 @@
 // STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
 // THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#pragma once
+
+#include "error.h"
 #include "wire/json.h"
 #include "wire/wrapper/variant.h"
 
@@ -44,7 +47,6 @@ namespace rpc
     unsigned id;
     const char* method; //!< Must be in static memory
   };
-  constexpr const char json_request_base::jsonrpc[];
 
   //! \tparam W implements the WRITE concept \tparam M implements the METHOD concept
   template<typename W, typename M>
@@ -76,10 +78,7 @@ namespace rpc
     std::string message;
   };
 
-  inline void read_bytes(wire::json_reader& source, json_error& self)
-  {
-    wire::object(source, WIRE_FIELD(code), WIRE_FIELD(message));
-  }
+  void read_bytes(wire::json_reader& source, json_error& self);
 
   //! \tparam R implements the READ concept
   template<typename R>

--- a/src/rpc/light_wallet.cpp
+++ b/src/rpc/light_wallet.cpp
@@ -510,7 +510,7 @@ namespace lws
       const bool is_coinbase = (extra.first & db::coinbase_output);
       const auto height = self.value().info.link.height;
       const bool mempool = height == db::block_id::txpool;
-      const iso_timestamp timestamp{self.value().info.timestamp};
+      const iso_timestamp timestamp = iso_timestamp(self.value().info.timestamp);
 
       wire::object(dest,
         wire::field("id", std::uint64_t(self.index())),
@@ -709,7 +709,8 @@ namespace lws
           if (txes_processed.count(row.hash))
             continue;
 
-          rpc::get_transaction& tx = out.emplace_back();
+          out.emplace_back();
+          rpc::get_transaction& tx = out.back();
 
           // Ingore spends that use unknown outputs
           // (perhaps the scanner thread is behind, and hasn't seen them yet).

--- a/src/rpc/scanner/queue.cpp
+++ b/src/rpc/scanner/queue.cpp
@@ -38,7 +38,7 @@ namespace lws { namespace rpc { namespace scanner
     status out{
      std::move(replace_), std::move(push_), user_count_
     };
-    replace_ = std::nullopt;
+    replace_ = boost::none;
     push_.clear();
     push_.shrink_to_fit();
     return out; 

--- a/src/rpc/scanner/queue.h
+++ b/src/rpc/scanner/queue.h
@@ -27,11 +27,11 @@
 #pragma once
 
 #include <algorithm>
+#include <boost/optional/optional.hpp>
 #include <boost/thread/condition_variable.hpp>
 #include <boost/thread/lock_guard.hpp>
 #include <boost/thread/mutex.hpp>
 #include <cstddef>
-#include <optional>
 #include <vector>
 
 #include "db/fwd.h"
@@ -46,13 +46,13 @@ namespace lws { namespace rpc { namespace scanner
     //! Status of upstream scan requests.
     struct status
     {
-      std::optional<std::vector<lws::account>> replace; //!< Empty optional means replace **not** requested.
+      boost::optional<std::vector<lws::account>> replace; //!< Empty optional means replace **not** requested.
       std::vector<lws::account> push;
       std::size_t user_count;
     };
 
   private:
-    std::optional<std::vector<lws::account>> replace_;
+    boost::optional<std::vector<lws::account>> replace_;
     std::vector<lws::account> push_;
     std::size_t user_count_;
     db::block_id current_min_height_;  //!< Minimum scan height of accounts on this thread

--- a/src/rpc/scanner/read_commands.h
+++ b/src/rpc/scanner/read_commands.h
@@ -148,7 +148,7 @@ namespace lws { namespace rpc { namespace scanner
   {
     if (!self)
       return false;
-    boost::asio::dispatch(self->strand_, do_read_commands{self});
+    boost::asio::dispatch(self->strand_, do_read_commands<T>{self});
     return true;
   }
 }}} // lws // rpc // scanner

--- a/src/rpc/scanner/write_commands.h
+++ b/src/rpc/scanner/write_commands.h
@@ -210,7 +210,7 @@ namespace lws { namespace rpc { namespace scanner
         self_->write_bufs_.push_back(std::move(msg_));
 
         if (queue)
-          write_buffers{self_}();
+          write_buffers<T>{self_}();
         else if (max_write_buffers <= self_->write_bufs_.size())
         {
           MERROR("Exceeded max buffer size for connection: " << self_->remote_endpoint());

--- a/src/scanner.cpp
+++ b/src/scanner.cpp
@@ -100,7 +100,7 @@ namespace lws
       scanner_options opts;
     };
  
-    bool is_new_block(std::string&& chain_msg, std::optional<db::storage>& disk, const account& user)
+    bool is_new_block(std::string&& chain_msg, boost::optional<db::storage>& disk, const account& user)
     {
       const auto chain = rpc::minimal_chain_pub::from_json(std::move(chain_msg));
       if (!chain)
@@ -359,7 +359,7 @@ namespace lws
   scanner::~scanner()
   {}
 
-    bool scanner::loop(scanner_sync& self, store_func store, std::optional<db::storage> disk, rpc::client client, std::vector<lws::account> users, rpc::scanner::queue& queue, const scanner_options& opts, const size_t thread_n)
+    bool scanner::loop(scanner_sync& self, store_func store, boost::optional<db::storage> disk, rpc::client client, std::vector<lws::account> users, rpc::scanner::queue& queue, const scanner_options& opts, const size_t thread_n)
     {
       const bool leader_thread = thread_n == 0;
 

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -125,7 +125,7 @@ namespace lws
       \throw std::exception on hard errors (shutdown) conditions
       \return True iff `queue` indicates thread now has zero accounts. False
         indicates a soft, typically recoverable error. */
-    static bool loop(scanner_sync& self, store_func store, std::optional<db::storage> disk, rpc::client client, std::vector<lws::account> users, rpc::scanner::queue& queue, const scanner_options& opts, const size_t thread_n);
+    static bool loop(scanner_sync& self, store_func store, boost::optional<db::storage> disk, rpc::client client, std::vector<lws::account> users, rpc::scanner::queue& queue, const scanner_options& opts, const size_t thread_n);
     
     //! Use `client` to sync blockchain data, and \return client if successful.
     expect<rpc::client> sync(rpc::client client, const bool untrusted_daemon = false, const bool regtest = false);

--- a/tests/unit/net/http/client.test.cpp
+++ b/tests/unit/net/http/client.test.cpp
@@ -82,7 +82,7 @@ LWS_CASE("net::http::client")
 
     SECTION("GET 200 OK")
     {
-      std::atomic<bool> done = false;
+      std::atomic<bool> done{false};
       const auto handler = [&done, &lest_env] (boost::system::error_code error, std::string body)
       {
         EXPECT(!error);
@@ -102,7 +102,7 @@ LWS_CASE("net::http::client")
 
     SECTION("GET 200 OK Twice")
     {
-      std::atomic<unsigned> done = 0;
+      std::atomic<unsigned> done{0};
       const auto handler = [&done, &lest_env] (boost::system::error_code error, std::string body)
       {
         EXPECT(!error);
@@ -125,7 +125,7 @@ LWS_CASE("net::http::client")
 
     SECTION("GET 404 NOT FOUND")
     {
-      std::atomic<bool> done = false;
+      std::atomic<bool> done{false};
       const auto handler = [&done, &lest_env] (boost::system::error_code error, std::string body)
       {
         EXPECT(error == boost::asio::error::operation_not_supported);
@@ -145,7 +145,7 @@ LWS_CASE("net::http::client")
 
     SECTION("GET (Invalid server address)")
     {
-      std::atomic<bool> done = false;
+      std::atomic<bool> done{false};
       const auto handler = [&done, &lest_env] (boost::system::error_code error, std::string body)
       {
         EXPECT(error == boost::asio::error::connection_refused);

--- a/tests/unit/rest.test.cpp
+++ b/tests/unit/rest.test.cpp
@@ -29,8 +29,8 @@
 
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/beast/websocket/error.hpp>
+#include <boost/optional/optional.hpp>
 #include <memory>
-#include <optional>
 #include <time.h>
 
 #include "cryptonote_basic/account.h"            // monero/src
@@ -155,7 +155,7 @@ namespace
 
   std::string get_prefix(const std::string& raw)
   {
-    char const* const sep = std::strchr(raw.c_str(), u8':');
+    char const* const sep = std::strchr(raw.c_str(), ':');
     if (!sep)
       return {};
     return {raw.data(), std::size_t(sep - raw.data() + 1)};
@@ -176,7 +176,7 @@ LWS_CASE("rest_server")
 
   SETUP("Database and login")
   {
-    std::optional<lws::rest_server> server;
+    boost::optional<lws::rest_server> server;
     lws::db::test::cleanup_db on_scope_exit{};
     lws::db::storage db = lws::db::test::get_fresh_db();
     auto context =

--- a/tests/unit/scanner.test.cpp
+++ b/tests/unit/scanner.test.cpp
@@ -50,6 +50,9 @@ namespace
 {
   constexpr const std::chrono::seconds message_timeout{3};
 
+  unsigned char* to_bytes(crypto::ec_scalar &scalar) { return &reinterpret_cast<unsigned char&>(scalar); }
+  const unsigned char* to_bytes(const crypto::ec_scalar &scalar) { return &reinterpret_cast<const unsigned char&>(scalar); }
+
   template<typename T>
   struct json_rpc_response
   {

--- a/tests/unit/wire/read.test.cpp
+++ b/tests/unit/wire/read.test.cpp
@@ -47,7 +47,7 @@ namespace
     {
       EXPECT(Target(0) == wire::integer::cast_unsigned<Target>(std::uintmax_t(0)));
       EXPECT(limit::max() == wire::integer::cast_unsigned<Target>(std::uintmax_t(limit::max())));
-      if constexpr (limit::max() < max)
+      if (limit::max() < max)
       {
         EXPECT_THROWS_AS(wire::integer::cast_unsigned<Target>(std::uintmax_t(limit::max()) + 1), wire::exception);
         EXPECT_THROWS_AS(wire::integer::cast_unsigned<Target>(max), wire::exception);
@@ -68,7 +68,7 @@ namespace
 
     SETUP("intmax_t to " + boost::core::demangle(typeid(Target).name()))
     {
-      if constexpr (min < limit::min())
+      if (min < limit::min())
       {
         EXPECT_THROWS_AS(wire::integer::cast_signed<Target>(std::intmax_t(limit::min()) - 1), wire::exception);
         EXPECT_THROWS_AS(wire::integer::cast_signed<Target>(min), wire::exception);
@@ -76,7 +76,7 @@ namespace
       EXPECT(limit::min() == wire::integer::cast_signed<Target>(std::intmax_t(limit::min())));
       EXPECT(Target(0) == wire::integer::cast_signed<Target>(std::intmax_t(0)));
       EXPECT(limit::max() == wire::integer::cast_signed<Target>(std::intmax_t(limit::max())));
-      if constexpr (limit::max() < max)
+      if (limit::max() < max)
       {
         EXPECT_THROWS_AS(wire::integer::cast_signed<Target>(std::intmax_t(limit::max()) + 1), wire::exception);
         EXPECT_THROWS_AS(wire::integer::cast_signed<Target>(max), wire::exception);


### PR DESCRIPTION
This contains the necessary changes to make the LWS `v1.0_0.18` branch compatible with `v0.18` branch of `monero`. This also downgrades to C++14 to follow the 0.18 branch (the goal being reducing incompatibilities in C++ version being used).

The C++ version downgrade probably isn't necessary (it seems to work with mixed C++14/17), but it seemed just as easy to be on the safe side. There's only one real concession where a `constexpr` was downgraded to a runtime `static` initialization.

None of this will be ported to the `master` branch as its better to keep that C++17 ready, for the inevitable bump to monero 0.19 tree.