### PR TITLE
Fix msgpack small negative integer output

### DIFF
--- a/src/wire/msgpack/write.cpp
+++ b/src/wire/msgpack/write.cpp
@@ -112,8 +112,9 @@ namespace wire
   void msgpack_writer::do_integer(const std::intmax_t value)
   {
     assert(value < 0); // constraint checked in header
-    if (0xe0 < value) // 0xe0 needs to be type `int` to work
+    if (-32 <= value)
     {
+      static_assert(msgpack::ftag_signed::tag() == std::uint8_t(-32), "");
       bytes_.put(std::uint8_t(value));
       return;
     }

--- a/tests/unit/wire/msgpack/read.write.test.cpp
+++ b/tests/unit/wire/msgpack/read.write.test.cpp
@@ -42,18 +42,18 @@
 namespace
 {
   constexpr const char basic_string[] = u8"my_string_data";
-  //constexpr const char basic_[] =
-  //  u8"{\"utf8\":\"my_string_data\",\"vec\":[0,127],\"data\":\"00ff2211\",\"choice\":true}";
+  //  u8"{\"utf8\":\"my_string_data\",\"vec\":[0,127],\"data\":\"00ff2211\",\"integer\":-2,\"choice\":true}";
   constexpr const std::uint8_t basic_msgpack[] = {
-    0x84, 0xa4, 0x75, 0x74, 0x66, 0x38, 0xae, 0x6d, 0x79, 0x5f, 0x73, 0x74,
+    0x85, 0xa4, 0x75, 0x74, 0x66, 0x38, 0xae, 0x6d, 0x79, 0x5f, 0x73, 0x74,
     0x72, 0x69, 0x6e, 0x67, 0x5f, 0x64, 0x61, 0x74, 0x61, 0xa3, 0x76, 0x65,
     0x63, 0x92, 0x00, 0x7f, 0xa4, 0x64, 0x61, 0x74, 0x61, 0xc4, 0x04, 0x00,
-    0xff, 0x22, 0x11, 0xa6, 0x63, 0x68, 0x6f, 0x69, 0x63, 0x65, 0xc3
+    0xff, 0x22, 0x11, 0xa7, 0x69, 0x6e, 0x74, 0x65, 0x67, 0x65, 0x72, 0xfe,
+    0xa6, 0x63, 0x68, 0x6f, 0x69, 0x63, 0x65, 0xc3
   };
   constexpr const std::uint8_t advanced_msgpack[] = {
-    0x84, 0x00, 0xae, 0x6d, 0x79, 0x5f, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67,
+    0x85, 0x00, 0xae, 0x6d, 0x79, 0x5f, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67,
     0x5f, 0x64, 0x61, 0x74, 0x61, 0x01, 0x92, 0x00, 0x7f, 0x02, 0xc4, 0x04,
-    0x00, 0xff, 0x22, 0x11, 0xcc, 0xfe, 0xc3
+    0x00, 0xff, 0x22, 0x11, 0x03, 0xd0, 0xdf, 0xcc, 0xfe, 0xc3
   };
 
   template<typename T>
@@ -62,6 +62,7 @@ namespace
     std::string utf8;
     std::vector<T> vec;
     lws_test::small_blob data;
+    std::int32_t integer;
     bool choice;
   };
 
@@ -73,6 +74,7 @@ namespace
       WIRE_FIELD_ID(0, utf8),
       wire::field<1>("vec", wire::array<vec_max>(std::ref(self.vec))),
       WIRE_FIELD_ID(2, data),
+      WIRE_FIELD_ID(3, integer),
       WIRE_FIELD_ID(254, choice)
     );
   }
@@ -100,6 +102,7 @@ namespace
         EXPECT(result.vec == expected);
       }
       EXPECT(result.data == lws_test::blob_test1);
+      EXPECT(result.integer == -2);
       EXPECT(result.choice);
     }
   }
@@ -119,6 +122,7 @@ namespace
         EXPECT(result.vec == expected);
       }
       EXPECT(result.data == lws_test::blob_test1);
+      EXPECT(result.integer == -33);
       EXPECT(result.choice);
     }
   }
@@ -128,7 +132,7 @@ namespace
   {
     SETUP("Basic (string keys) with " + boost::core::demangle(typeid(T).name()) + " integers")
     {
-      const basic_object<T> val{basic_string, std::vector<T>{0, 127}, lws_test::blob_test1, true};
+      const basic_object<T> val{basic_string, std::vector<T>{0, 127}, lws_test::blob_test1, -2, true};
       epee::byte_slice result{};
       const std::error_code error = wire::msgpack::to_bytes(result, val);
       EXPECT(!error);
@@ -141,7 +145,7 @@ namespace
   {
     SETUP("Advanced (integer keys) with " + boost::core::demangle(typeid(T).name()) + " integers")
     {
-      const basic_object<T> val{basic_string, std::vector<T>{0, 127}, lws_test::blob_test1, true};
+      const basic_object<T> val{basic_string, std::vector<T>{0, 127}, lws_test::blob_test1, -33, true};
       epee::byte_slice result{};
       {
         wire::msgpack_slice_writer out{true};

--- a/tests/unit/wire/read.write.test.cpp
+++ b/tests/unit/wire/read.write.test.cpp
@@ -97,7 +97,7 @@ namespace
   void fill(complex& self)
   {
     self.objects = std::vector<inner>{inner{0, limit<std::uint32_t>::max()}, inner{100, 200}, inner{44444, 83434}};
-    self.ints = std::vector<std::int16_t>{limit<std::int16_t>::min(), limit<std::int16_t>::max(), -3, 31234};
+    self.ints = std::vector<std::int16_t>{limit<std::int16_t>::min(), limit<std::int16_t>::max(), -3, 31234, -32};
     self.uints = std::vector<std::uint64_t>{0, limit<std::uint64_t>::max(), 34234234, 33};
     self.blobs = {lws_test::blob_test1, lws_test::blob_test2, lws_test::blob_test3};
     self.strings = {"string1", "string2", "string3", "string4"};
@@ -114,11 +114,12 @@ namespace
     EXPECT(self.objects.at(2).left == 44444);
     EXPECT(self.objects.at(2).right == 83434);
 
-    EXPECT(self.ints.size() == 4);
+    EXPECT(self.ints.size() == 5);
     EXPECT(self.ints.at(0) == limit<std::int16_t>::min());
     EXPECT(self.ints.at(1) == limit<std::int16_t>::max());
     EXPECT(self.ints.at(2) == -3);
     EXPECT(self.ints.at(3) == 31234);
+    EXPECT(self.ints.at(4) == -32);
 
     EXPECT(self.uints.size() == 4);
     EXPECT(self.uints.at(0) == 0);


### PR DESCRIPTION
During `monero-project/monero` reviews, an error in the msgpack integer output was discovered. Small negative integers were never output as a single byte, instead taking 2 bytes at minimum. This fixes that issue. A tweak to the read may be needed in the future, but for now the tests indicate it is working.

EDIT: Clarification - the disruption should be minimal as the error simply used more bytes than necessary to encode a value. So most msgpack readers should handle it, but possibly output a warning.