### PR TITLE
Fix 'real' output in msgpack [1.0]

### DIFF
--- a/src/wire/msgpack/read.cpp
+++ b/src/wire/msgpack/read.cpp
@@ -387,10 +387,16 @@ namespace wire
 
     const auto read_float = [this](auto value)
     {
-      if (remaining_.size() < sizeof(value))
-        WIRE_DLOG_THROW_(error::msgpack::not_enough_bytes);
-      std::memcpy(std::addressof(value), remaining_.data(), sizeof(value));
-      remaining_.remove_prefix(sizeof(value));
+      using real_type = decltype(value);
+      using buf_type =  typename std::conditional<
+        std::is_same<real_type, float>::value, std::uint32_t, std::uint64_t
+      >::type;
+      static_assert(std::is_same<real_type, float>() || std::is_same<real_type, double>(), "");
+      static_assert(std::numeric_limits<real_type>::is_iec559, "");
+      static_assert(sizeof(real_type) == sizeof(buf_type), "");
+
+      const auto buf = read_endian<buf_type>(remaining_);
+      std::memcpy(&value, &buf, sizeof(buf));
       return value;
     };
 

--- a/src/wire/msgpack/write.cpp
+++ b/src/wire/msgpack/write.cpp
@@ -52,8 +52,8 @@ namespace
     bytes.put(std::uint8_t(value));
   }
 
-  template<typename T, typename U, wire::msgpack::tag tag>
-  void write_endian(epee::byte_stream& bytes, const T value, const wire::msgpack::type<U, tag> type)
+  template<typename U, typename T>
+  void write_endian(epee::byte_stream& bytes, const T value)
   {
     static_assert(std::is_integral<T>::value, "input not integral");
     static_assert(std::is_integral<U>::value, "output not integral");
@@ -62,16 +62,22 @@ namespace
     using out_limits = std::numeric_limits<U>;
     static_assert(in_limits::is_signed == out_limits::is_signed, "signs must match");
 
-    assert(type.min() <= value);
-    assert(value <= type.max());
-
     static constexpr const std::size_t bits = 8 * sizeof(U);
     using buffer_type =
       boost::endian::endian_buffer<boost::endian::order::big, U, bits>;
 
-    buffer_type buffer(value);
-    write_tag(bytes, type.Tag());
+    const buffer_type buffer(value);
     bytes.write(buffer.data(), sizeof(buffer));
+  }
+
+  template<typename T, typename U, wire::msgpack::tag tag>
+  void write_endian(epee::byte_stream& bytes, const T value, const wire::msgpack::type<U, tag> type)
+  {
+    assert(type.min() <= value);
+    assert(value <= type.max());
+
+    write_tag(bytes, type.Tag());
+    write_endian<U>(bytes, value);
   }
 
   template<typename T>
@@ -161,8 +167,15 @@ namespace wire
 
   void msgpack_writer::real(const double source)
   {
+    static_assert(std::numeric_limits<double>::is_iec559, "");
+    static_assert(sizeof(double) == sizeof(std::uint64_t), "");
+
     write_tag(bytes_, msgpack::tag::float64);
-    bytes_.write(reinterpret_cast<const char*>(std::addressof(source)), sizeof(source));
+
+    std::uint64_t buf;
+    std::memcpy(&buf, &source, sizeof(buf));
+    write_endian<std::uint64_t>(bytes_, buf);
+
     --expected_;
   }
 

--- a/tests/unit/wire/msgpack/read.write.test.cpp
+++ b/tests/unit/wire/msgpack/read.write.test.cpp
@@ -38,22 +38,24 @@
 #include "wire/wrappers_impl.h"
 
 #include "wire/base.test.h"
-
+#include "hex.h"
 namespace
 {
   constexpr const char basic_string[] = u8"my_string_data";
-  //  u8"{\"utf8\":\"my_string_data\",\"vec\":[0,127],\"data\":\"00ff2211\",\"integer\":-2,\"choice\":true}";
+  //  u8"{\"utf8\":\"my_string_data\",\"vec\":[0,127],\"data\":\"00ff2211\",\"integer\":-2,\"real\":3.7559,\"choice\":true}";
   constexpr const std::uint8_t basic_msgpack[] = {
-    0x85, 0xa4, 0x75, 0x74, 0x66, 0x38, 0xae, 0x6d, 0x79, 0x5f, 0x73, 0x74,
+    0x86, 0xa4, 0x75, 0x74, 0x66, 0x38, 0xae, 0x6d, 0x79, 0x5f, 0x73, 0x74,
     0x72, 0x69, 0x6e, 0x67, 0x5f, 0x64, 0x61, 0x74, 0x61, 0xa3, 0x76, 0x65,
     0x63, 0x92, 0x00, 0x7f, 0xa4, 0x64, 0x61, 0x74, 0x61, 0xc4, 0x04, 0x00,
     0xff, 0x22, 0x11, 0xa7, 0x69, 0x6e, 0x74, 0x65, 0x67, 0x65, 0x72, 0xfe,
-    0xa6, 0x63, 0x68, 0x6f, 0x69, 0x63, 0x65, 0xc3
+    0xa4, 0x72, 0x65, 0x61, 0x6c, 0xcb, 0x40, 0x0e, 0x0c, 0x15, 0x4c, 0x98,
+    0x5f, 0x07, 0xa6, 0x63, 0x68, 0x6f, 0x69, 0x63, 0x65, 0xc3
   };
   constexpr const std::uint8_t advanced_msgpack[] = {
-    0x85, 0x00, 0xae, 0x6d, 0x79, 0x5f, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67,
+    0x86, 0x00, 0xae, 0x6d, 0x79, 0x5f, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67,
     0x5f, 0x64, 0x61, 0x74, 0x61, 0x01, 0x92, 0x00, 0x7f, 0x02, 0xc4, 0x04,
-    0x00, 0xff, 0x22, 0x11, 0x03, 0xd0, 0xdf, 0xcc, 0xfe, 0xc3
+    0x00, 0xff, 0x22, 0x11, 0x03, 0xd0, 0xdf, 0x04, 0xcb, 0x40, 0x0e, 0x0c,
+    0x15, 0x4c, 0x98, 0x5f, 0x07, 0xcc, 0xfe, 0xc3
   };
 
   template<typename T>
@@ -63,6 +65,7 @@ namespace
     std::vector<T> vec;
     lws_test::small_blob data;
     std::int32_t integer;
+    double real;
     bool choice;
   };
 
@@ -75,6 +78,7 @@ namespace
       wire::field<1>("vec", wire::array<vec_max>(std::ref(self.vec))),
       WIRE_FIELD_ID(2, data),
       WIRE_FIELD_ID(3, integer),
+      WIRE_FIELD_ID(4, real),
       WIRE_FIELD_ID(254, choice)
     );
   }
@@ -103,6 +107,7 @@ namespace
       }
       EXPECT(result.data == lws_test::blob_test1);
       EXPECT(result.integer == -2);
+      EXPECT(result.real == 3.7559);
       EXPECT(result.choice);
     }
   }
@@ -123,6 +128,7 @@ namespace
       }
       EXPECT(result.data == lws_test::blob_test1);
       EXPECT(result.integer == -33);
+      EXPECT(result.real == 3.7559);
       EXPECT(result.choice);
     }
   }
@@ -132,7 +138,7 @@ namespace
   {
     SETUP("Basic (string keys) with " + boost::core::demangle(typeid(T).name()) + " integers")
     {
-      const basic_object<T> val{basic_string, std::vector<T>{0, 127}, lws_test::blob_test1, -2, true};
+      const basic_object<T> val{basic_string, std::vector<T>{0, 127}, lws_test::blob_test1, -2, 3.7559, true};
       epee::byte_slice result{};
       const std::error_code error = wire::msgpack::to_bytes(result, val);
       EXPECT(!error);
@@ -145,7 +151,7 @@ namespace
   {
     SETUP("Advanced (integer keys) with " + boost::core::demangle(typeid(T).name()) + " integers")
     {
-      const basic_object<T> val{basic_string, std::vector<T>{0, 127}, lws_test::blob_test1, -33, true};
+      const basic_object<T> val{basic_string, std::vector<T>{0, 127}, lws_test::blob_test1, -33, 3.7559, true};
       epee::byte_slice result{};
       {
         wire::msgpack_slice_writer out{true};

--- a/tests/unit/wire/read.write.test.cpp
+++ b/tests/unit/wire/read.write.test.cpp
@@ -66,6 +66,7 @@ namespace
     std::vector<std::uint64_t> uints;
     std::vector<lws_test::small_blob> blobs;
     std::vector<std::string> strings;
+    double real;
     bool choice;
   };
 
@@ -79,6 +80,7 @@ namespace
       WIRE_FIELD_ARRAY(uints, max_vec),
       WIRE_FIELD(blobs),
       WIRE_FIELD_ARRAY(strings, max_vec),
+      WIRE_FIELD(real),
       WIRE_FIELD(choice)
     );
   }
@@ -101,6 +103,7 @@ namespace
     self.uints = std::vector<std::uint64_t>{0, limit<std::uint64_t>::max(), 34234234, 33};
     self.blobs = {lws_test::blob_test1, lws_test::blob_test2, lws_test::blob_test3};
     self.strings = {"string1", "string2", "string3", "string4"};
+    self.real = 3.7559;
     self.choice = true;
   }
 
@@ -137,6 +140,8 @@ namespace
     EXPECT(self.strings.at(1) == "string2");
     EXPECT(self.strings.at(2) == "string3");
     EXPECT(self.strings.at(3) == "string4");
+
+    EXPECT(self.real == 3.7559);
 
     EXPECT(self.choice == true);
   }


### PR DESCRIPTION
Real (float/double) msgpack output is not used in the 1.0 LWS branch. However, the `::wire` interface includes it because JSON uses it for reading exchange rates (when enabled).

I therefore decided to "fix" the float/double msgpack output/input in the 1.0 branch just in case some feature gets imported which uses it.

This patch will eventually be included in the `master` branch, but more work is needed to get that branch up-to-date with monero mainline.