### PR TITLE
fix: pass regtest flag to initial startup sync + regtest re-org aware [develop]

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -5,5 +5,6 @@ namespace lws
 namespace config
 {
   cryptonote::network_type network = cryptonote::MAINNET;
+  bool regtest = false;
 }
 }

--- a/src/config.h
+++ b/src/config.h
@@ -10,6 +10,9 @@ namespace config
 {
   extern cryptonote::network_type network;
 
+  //! True when running against a regtest/fakechain daemon (no checkpoints)
+  extern bool regtest;
+
   //! Default inactivity timeout for `/feed` websocket connections
   constexpr const std::chrono::minutes feed_timeout{4};
 

--- a/src/db/storage.cpp
+++ b/src/db/storage.cpp
@@ -3171,7 +3171,9 @@ namespace db
 
       // collect all .value() errors
       updated out{};
-      if (get_checkpoints().get_max_height() <= last_update)
+      // regtest hast no checkpoints, so a re-org can occur at any height (including below the
+      // mainnet checkpoint height that get_checkpoints() reports)
+      if (lws::config::regtest || get_checkpoints().get_max_height() <= last_update)
       {
         cursor::blocks blocks_cur;
         cursor::pow    pow_cur;

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -331,6 +331,8 @@ namespace
       command_line::get_arg(args, opts.balance_new_addresses)
     };
 
+    lws::config::regtest = prog.regtest;
+
     if (prog.regtest && lws::config::network != cryptonote::MAINNET)
       MONERO_THROW(lws::error::configuration, "Regtest cannot be used with testnet or stagenet");
 

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -382,7 +382,7 @@ namespace
       mempool = std::make_shared<lws::mempool>();
     }
 
-    auto client = scanner.sync(ctx.connect().value(), prog.untrusted_daemon).value();
+    auto client = scanner.sync(ctx.connect().value(), prog.untrusted_daemon, prog.regtest).value();
 
     lws::rest_server server{
       epee::to_span(prog.rest_servers),


### PR DESCRIPTION
a fresh sync rejects a regtest fakechain ('Attempting rollback past last checkpoint ... wrong --network?') even with --regtest