### PR TITLE
Fix ZMQ async receives (upstream read size limit)

### DIFF
--- a/src/net/zmq_async.cpp
+++ b/src/net/zmq_async.cpp
@@ -27,6 +27,7 @@
 
 #include "zmq_async.h"
 
+#include "rpc/client.h"
 #include <stdexcept>
 
 namespace net { namespace zmq
@@ -86,6 +87,13 @@ namespace net { namespace zmq
     }
   }
 
+  expect<std::string> read_msg_op::read()
+  {
+    // net::zmq::read has a small limit designed for RPC server usage
+    MONERO_PRECOND(sock_);
+    return lws::rpc::read_msg(sock_->zsock.get(), ZMQ_DONTWAIT, sock_->msg_limit);
+  }
+
   expect<async_client> async_client::make(boost::asio::io_context& io, socket zsock)
   {
     MONERO_PRECOND(zsock != nullptr);
@@ -95,7 +103,7 @@ namespace net { namespace zmq
     if (zmq_getsockopt(zsock.get(), ZMQ_FD, &fd, &length) != 0)
       return net::zmq::get_error_code();
 
-    async_client out{std::move(zsock), nullptr, false};
+    async_client out{std::move(zsock), nullptr, std::numeric_limits<std::uint32_t>::max(), false};
     out.asock.reset(new adescriptor{io, fd});
     return out;
   }

--- a/src/net/zmq_async.h
+++ b/src/net/zmq_async.h
@@ -32,6 +32,7 @@
 #include <boost/asio/posix/stream_descriptor.hpp>
 #include <boost/system/error_code.hpp>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <zmq.h>
@@ -61,6 +62,7 @@ namespace net { namespace zmq
     async_client() = delete;
     socket zsock;
     asocket asock;
+    std::uint32_t msg_limit;
     bool close;
 
     static expect<async_client> make(boost::asio::io_context& io, socket zsock);
@@ -70,6 +72,8 @@ namespace net { namespace zmq
   {
     async_client* sock_;
     std::string* msg_;
+
+    expect<std::string> read();
 
   public:
     read_msg_op(async_client& sock, std::string& msg)
@@ -87,7 +91,7 @@ namespace net { namespace zmq
         return self.complete(boost::asio::error::operation_aborted, 0);
 
       assert(sock_->zsock && sock_->asock);
-      expect<std::string> msg = receive(sock_->zsock.get(), ZMQ_DONTWAIT);
+      expect<std::string> msg = read();
       if (!msg)
       {
         if (msg != make_error_code(EAGAIN))

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -29,6 +29,7 @@
 
 #include <array>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/numeric/conversion/cast.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/utility/string_ref.hpp>
 #include <cassert>
@@ -339,13 +340,6 @@ namespace rpc
         return unsigned(max_out) < added ? max_out : int(added);
       }
     };
-
-    expect<std::string> read_msg(void* const socket, const int flags, const std::uint64_t max_message_size)
-    {
-      std::string payload{};
-      MONERO_CHECK(net::zmq::retry_op(do_receive{}, payload, socket, flags, max_message_size));
-      return {std::move(payload)};
-    }
   } // anonymous
 
   namespace detail
@@ -398,6 +392,13 @@ namespace rpc
       std::atomic_flag rates_running;
     };
   } // detail
+
+  expect<std::string> read_msg(void* const socket, const int flags, const std::uint64_t max_message_size)
+  {
+    std::string payload{};
+    MONERO_CHECK(net::zmq::retry_op(do_receive{}, payload, socket, flags, max_message_size));
+    return {std::move(payload)};
+  }
 
   expect<void> parse_response(cryptonote::rpc::Message& parser, std::string msg, source_location loc)
   {
@@ -720,7 +721,14 @@ namespace rpc
     expect<net::zmq::socket> daemon = make_daemon(ctx);
     if (!daemon)
       return daemon.error();
-    return net::zmq::async_client::make(io, std::move(*daemon));
+    auto out = net::zmq::async_client::make(io, std::move(*daemon));
+    if (out && ctx->untrusted_daemon)
+    {
+      const std::uint64_t limit{ctx->get_msg_max(max_msg_req)};
+      out->msg_limit = boost::numeric_cast<std::uint32_t>(limit);
+      MONERO_CHECK(do_set_option(out->zsock.get(), ZMQ_MAXMSGSIZE, limit));
+    }
+    return out;
   }
 
   expect<void> client::send(epee::byte_slice message, std::chrono::seconds timeout) noexcept

--- a/src/rpc/client.h
+++ b/src/rpc/client.h
@@ -64,6 +64,7 @@ namespace rpc
     std::string routing;
   };
 
+  expect<std::string> read_msg(void* const socket, const int flags, std::uint64_t msg_max);
   expect<void> parse_response(cryptonote::rpc::Message& parser, std::string msg, source_location loc = {});
 
   class account_sub


### PR DESCRIPTION
Some REST endpoints are currently not working when built with latest upstream `monero-project/monero` changes. This fixes the read size limit for those situations.

The other read calls for block fetching has already been fixed, its just the "async" zmq code that needs updating.